### PR TITLE
Install with pip & install wheel using pip

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-REPO="https://github.com/airplanes-live/feed.git"
+REPO="https://github.com/adsb-related-code/feed.git"
 BRANCH="main"
 IPATH=/usr/local/share/airplanes
 mkdir -p $IPATH

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-REPO="https://github.com/adsb-related-code/feed.git"
+REPO="https://github.com/airplanes-live/feed.git"
 BRANCH="main"
 IPATH=/usr/local/share/airplanes
 mkdir -p $IPATH

--- a/update.sh
+++ b/update.sh
@@ -221,11 +221,11 @@ else
         && echo 36 \
         && source $VENV/bin/activate >> $LOGFILE \
         && echo 37 \
-        && python3 -c "import setuptools" || python3 -m pip install setuptools
+        && python3 -c "import setuptools" || python3 -m pip install setuptools \
         && echo 39 \
-        && python3 -c "import asyncore" || python3 -m pip install pyasyncore
+        && python3 -c "import asyncore" || python3 -m pip install pyasyncore \
         && echo 40 \
-        && pip install .   
+        && pip install . \
         && echo 46 \
         && revision > $IPATH/mlat_version || rm -f $IPATH/mlat_version \
         && echo 48 \

--- a/update.sh
+++ b/update.sh
@@ -224,6 +224,7 @@ else
         && python3 -c "import setuptools" || python3 -m pip install setuptools \
         && echo 39 \
         && python3 -c "import asyncore" || python3 -m pip install pyasyncore \
+        && python3 -m pip install wheel \
         && echo 40 \
         && pip install . \
         && echo 46 \

--- a/update.sh
+++ b/update.sh
@@ -221,13 +221,11 @@ else
         && echo 36 \
         && source $VENV/bin/activate >> $LOGFILE \
         && echo 37 \
-        && python3 -c "import setuptools" || python3 -m pip install setuptools >> $LOGFILE \
-        && echo 38 \
-        && python3 -c "import asyncore" || python3 -m pip install pyasyncore >> $LOGFILE \
+        && python3 -c "import setuptools" || python3 -m pip install setuptools
         && echo 39 \
-        && python3 setup.py build >> $LOGFILE \
+        && python3 -c "import asyncore" || python3 -m pip install pyasyncore
         && echo 40 \
-        && python3 setup.py install >> $LOGFILE \
+        && pip install .   
         && echo 46 \
         && revision > $IPATH/mlat_version || rm -f $IPATH/mlat_version \
         && echo 48 \


### PR DESCRIPTION
Warnings removed:

install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
easy_install.py:158: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.

Removes:

Using legacy 'setup.py install' for MlatClient, since package 'wheel' is not installed.

