### PR TITLE
Add claim_secret_register.sh helper

### DIFF
--- a/scripts/claim_secret_register.sh
+++ b/scripts/claim_secret_register.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# claim_secret_register.sh — Register this feeder's claim secret with
+# airplanes.live.
+#
+# Reads the existing UUID at /usr/local/share/airplanes/airplanes-uuid (or
+# /boot/airplanes-uuid on the official image), generates a 16-char canonical
+# claim secret if none is persisted yet, and POSTs it to the website's
+# /api/feeders/secret endpoint. The secret is written to disk BEFORE the
+# POST so that a crash mid-flight can be resumed without server-side state
+# diverging from what's on disk.
+#
+# On success the secret is persisted to /etc/airplanes/claim-secret (mode
+# 0600). Subsequent runs reuse it.
+#
+# Exit codes:
+#   0  registration succeeded (HTTP 200 NOOP_REPLAY or 201 Created)
+#   1  configuration error or fatal protocol error
+#   2  network unreachable
+#   3  retry budget exhausted (--max-retry-time)
+#   4  feeder predates the claim-secret rollout (use the website's reinstall flow)
+
+set -euo pipefail
+
+ROOT='/'
+TARGET_URL=''
+DRY_RUN=0
+MAX_RETRY_TIME=60
+
+usage() {
+    cat <<'USAGE'
+Usage: claim_secret_register.sh --target-url URL [--root PATH] [--dry-run]
+
+Options:
+  --target-url URL    Website base URL (e.g. https://airplanes.live). Required.
+  --root PATH         Filesystem root prefix (for testing in temp dirs).
+                      Default: /
+  --dry-run           Read UUID + generate secret, print, but don't POST.
+  --max-retry-time N  Seconds; cap retry on 429 / 423 reset / 5xx. Default: 60.
+  -h, --help          Show this message.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root) ROOT="$2"; shift 2 ;;
+        --target-url) TARGET_URL="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --max-retry-time) MAX_RETRY_TIME="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$TARGET_URL" ]]; then
+    echo "ERROR: --target-url is required" >&2
+    exit 1
+fi
+
+# Read UUID from the existing on-disk path; don't migrate, since
+# scripts/airplanes-feed.sh still reads from these locations.
+UUID_PATH="${ROOT%/}/usr/local/share/airplanes/airplanes-uuid"
+if [[ ! -f "$UUID_PATH" ]]; then
+    UUID_PATH="${ROOT%/}/boot/airplanes-uuid"
+fi
+if [[ ! -f "$UUID_PATH" ]]; then
+    echo "ERROR: no UUID file at ${ROOT%/}/usr/local/share/airplanes/airplanes-uuid or ${ROOT%/}/boot/airplanes-uuid" >&2
+    exit 1
+fi
+UUID="$(tr -d '\n' < "$UUID_PATH")"
+
+# Validate UUID format up front — the server rejects malformed UUIDs with
+# 400 anyway, but failing loud here gives a clearer error message. Pattern
+# matches create-uuid.sh: canonical lowercase 8-4-4-4-12.
+if [[ ! "$UUID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    echo "ERROR: invalid UUID format at ${UUID_PATH}: ${UUID}" >&2
+    exit 1
+fi
+echo "UUID: $UUID"
+
+ALPHABET='ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
+# tr | head triggers SIGPIPE on the tr side once head closes after 16 bytes.
+# Under `set -euo pipefail` that propagates a non-zero exit and kills the
+# script. Wrap in a subshell with pipefail disabled — `( )` scopes the
+# `set +o pipefail` so it doesn't leak.
+generate_secret() (
+    set +o pipefail
+    LC_ALL=C tr -dc "$ALPHABET" </dev/urandom | head -c 16
+)
+
+# Persist the secret BEFORE the first POST so a crash between "row created
+# server-side" and "secret written to disk" doesn't leave the next run
+# generating a different secret and hitting 409 rotation_rejected.
+#
+# Read precedence:
+#   1. existing /etc/airplanes/claim-secret         → reuse (expect NOOP_REPLAY)
+#   2. existing /etc/airplanes/claim-secret.pending → reuse (mid-POST resume)
+#   3. otherwise → generate fresh + write to .pending
+#
+# On 200/201 the pending file is atomically promoted to claim-secret.
+
+SECRET_DIR="${ROOT%/}/etc/airplanes"
+FINAL_PATH="$SECRET_DIR/claim-secret"
+PENDING_PATH="$SECRET_DIR/claim-secret.pending"
+
+if [[ -f "$FINAL_PATH" ]]; then
+    read -r SECRET < "$FINAL_PATH" || SECRET=''
+elif [[ -f "$PENDING_PATH" ]]; then
+    read -r SECRET < "$PENDING_PATH" || SECRET=''
+else
+    SECRET="$(generate_secret)"
+    if (( ! DRY_RUN )); then
+        mkdir -p "$SECRET_DIR"
+        printf '%s\n' "$SECRET" > "$PENDING_PATH"
+        chmod 600 "$PENDING_PATH"
+    fi
+fi
+
+if [[ -z "$SECRET" ]]; then
+    echo "ERROR: read empty secret from filesystem at $FINAL_PATH or $PENDING_PATH" >&2
+    exit 1
+fi
+echo "SECRET: $SECRET"
+
+if (( DRY_RUN )); then
+    echo "(dry-run; would POST to $TARGET_URL/api/feeders/secret)"
+    exit 0
+fi
+
+# Response body for the most recent POST goes to a per-run temp file so
+# concurrent or stale runs don't collide.
+RESP_BODY="$(mktemp)"
+trap 'rm -f "$RESP_BODY"' EXIT
+
+# do_post writes the response body to $RESP_BODY and prints the HTTP status
+# code on stdout (or empty string on curl failure; curl_rc holds the exit).
+do_post() {
+    local body
+    body=$(printf '{"uuid":"%s","current_secret":null,"new_secret":"%s"}' \
+        "$UUID" "$SECRET")
+    curl --silent --show-error \
+        --connect-timeout 10 --max-time 30 \
+        --request POST \
+        --header 'Content-Type: application/json' \
+        --data "$body" \
+        --output "$RESP_BODY" \
+        --write-out '%{http_code}' \
+        "$TARGET_URL/api/feeders/secret"
+}
+
+# Parse a JSON top-level field; empty string if missing.
+parse_field() {
+    jq -r "$1 // empty" < "$RESP_BODY" 2>/dev/null || true
+}
+
+# Seconds until a given ISO 8601 timestamp; 0 if past or unparseable. Used
+# by the 423 reset_locked retry path.
+seconds_until_iso() {
+    local iso="$1"
+    local target_epoch now
+    target_epoch=$(date -d "$iso" -u +%s 2>/dev/null || echo "")
+    if [[ -z "$target_epoch" ]]; then
+        echo 0
+        return
+    fi
+    now=$(date -u +%s)
+    local delta=$(( target_epoch - now ))
+    if (( delta < 0 )); then
+        echo 0
+    else
+        echo "$delta"
+    fi
+}
+
+deadline=$(( $(date +%s) + MAX_RETRY_TIME ))
+backoff=1
+
+while true; do
+    set +e
+    status=$(do_post)
+    curl_rc=$?
+    set -e
+
+    case "$curl_rc" in
+        0) ;;  # HTTP ok (status code in $status); fall through.
+        6|7|28)
+            echo "ERROR: curl rc=$curl_rc (DNS/connect/timeout) — network unreachable" >&2
+            exit 2
+            ;;
+        *)
+            echo "ERROR: curl rc=$curl_rc — $TARGET_URL/api/feeders/secret unreachable" >&2
+            exit 2
+            ;;
+    esac
+
+    error=$(parse_field '.error')
+    body_preview=$(head -c 200 "$RESP_BODY" || true)
+
+    case "$status" in
+        200|201)
+            version=$(parse_field '.version')
+            : "${version:=1}"
+            # Atomic promotion: pending → final on success. If the secret
+            # came from an existing final (NOOP_REPLAY scenario), there's
+            # no pending to promote — the file is already in place.
+            if [[ -f "$PENDING_PATH" ]]; then
+                mkdir -p "$SECRET_DIR"
+                mv "$PENDING_PATH" "$FINAL_PATH"
+                chmod 600 "$FINAL_PATH"
+            fi
+            echo "SUCCESS ($status, version $version)"
+            echo "Secret persisted to $FINAL_PATH"
+            exit 0
+            ;;
+        400)
+            echo "ERROR: 400 bad request — $body_preview" >&2
+            exit 1
+            ;;
+        409)
+            case "$error" in
+                legacy_unclaimed)
+                    echo "ERROR: 409 legacy_unclaimed — pre-secret-era row needs the website's reinstall flow ($body_preview)" >&2
+                    exit 4
+                    ;;
+                rotation_rejected)
+                    echo "ERROR: 409 rotation_rejected — server hash mismatched current_secret; local state has diverged" >&2
+                    exit 1
+                    ;;
+                *)
+                    echo "ERROR: 409 with unknown error=${error:-<missing>} — $body_preview" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        423)
+            case "$error" in
+                feeder_blocked)
+                    echo "ERROR: 423 feeder_blocked — admin block, no retry ($body_preview)" >&2
+                    exit 1
+                    ;;
+                reset_locked)
+                    reset_until=$(parse_field '.reset_until')
+                    if [[ -z "$reset_until" ]]; then
+                        echo "ERROR: 423 reset_locked without reset_until field" >&2
+                        exit 1
+                    fi
+                    sleep_for=$(seconds_until_iso "$reset_until")
+                    echo "INFO: 423 reset_locked until $reset_until; sleeping ${sleep_for}s" >&2
+                    ;;
+                *)
+                    echo "ERROR: 423 with unknown error=${error:-<missing>} — $body_preview" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        429)
+            sleep_for=$(parse_field '.retry_after')
+            : "${sleep_for:=5}"
+            echo "INFO: 429 rate-limited; sleeping ${sleep_for}s (server retry_after)" >&2
+            ;;
+        404)
+            ct=$(curl --silent --head --connect-timeout 5 --max-time 10 \
+                "$TARGET_URL/api/feeders/secret" 2>/dev/null \
+                | grep -i '^content-type' || true)
+            if [[ "$ct" != *application/json* ]]; then
+                echo "ERROR: 404 non-JSON response — endpoint disabled or wrong URL ($TARGET_URL)" >&2
+                exit 1
+            fi
+            echo "ERROR: 404 from API — $body_preview" >&2
+            exit 1
+            ;;
+        5*)
+            sleep_for="$backoff"
+            backoff=$(( backoff * 2 ))
+            (( backoff > 60 )) && backoff=60
+            echo "INFO: $status server error; backing off ${sleep_for}s" >&2
+            ;;
+        *)
+            echo "ERROR: unexpected status $status — $body_preview" >&2
+            exit 1
+            ;;
+    esac
+
+    now=$(date +%s)
+    if (( now + sleep_for > deadline )); then
+        echo "ERROR: exceeded --max-retry-time=${MAX_RETRY_TIME}s on status $status" >&2
+        exit 3
+    fi
+    sleep "$sleep_for"
+done

--- a/test/Dockerfile.claim-helper-test
+++ b/test/Dockerfile.claim-helper-test
@@ -1,0 +1,17 @@
+FROM debian:13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash curl jq ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/claim_secret_register.sh /usr/local/bin/claim_secret_register.sh
+RUN chmod +x /usr/local/bin/claim_secret_register.sh
+
+# UUID is generated at container start (entrypoint.sh), not baked into the
+# image, so each `docker run` produces a fresh registration.
+RUN mkdir -p /usr/local/share/airplanes /etc/airplanes
+
+COPY test/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Test-container entrypoint for claim_secret_register.sh. Generates a fresh
+# UUID for the container if none exists yet, so each `docker run` produces
+# an independent registration rather than replaying the same UUID.
+set -euo pipefail
+
+UUID_PATH=/usr/local/share/airplanes/airplanes-uuid
+if [[ ! -s "$UUID_PATH" ]]; then
+    install -D -m 0644 /dev/null "$UUID_PATH"
+    cat /proc/sys/kernel/random/uuid > "$UUID_PATH"
+fi
+
+exec /usr/local/bin/claim_secret_register.sh "$@"

--- a/test/test_claim_secret_register.bats
+++ b/test/test_claim_secret_register.bats
@@ -1,0 +1,269 @@
+#!/usr/bin/env bats
+# Tests for claim_secret_register.sh. Each test starts an inline Python
+# HTTP server bound on 127.0.0.1:0 (kernel-assigned port) so parallel or
+# stale runs don't collide.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/claim_secret_register.sh"
+    ROOT_DIR="$(mktemp -d)"
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    echo "11111111-2222-3333-4444-555555555555" > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    MOCK_RESP_FILE="$(mktemp)"
+    MOCK_PORT_FILE="$(mktemp)"
+    MOCK_PID_FILE="$(mktemp)"
+}
+
+teardown() {
+    stop_mock_server || true
+    rm -rf "$ROOT_DIR"
+    rm -f "$MOCK_RESP_FILE" "$MOCK_PORT_FILE" "$MOCK_PID_FILE"
+}
+
+# Inline mock HTTP server. Reads its (status, body) response from
+# $MOCK_RESP_FILE on each request, so a test can sequence responses by
+# rewriting the file between polls. For one-shot tests we just write once
+# before starting the server.
+start_mock_server() {
+    local port_file="$MOCK_PORT_FILE"
+    local resp_file="$MOCK_RESP_FILE"
+    local pid_file="$MOCK_PID_FILE"
+    python3 - "$port_file" "$resp_file" <<'PY' &
+import http.server, json, sys
+port_file, resp_file = sys.argv[1], sys.argv[2]
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        with open(resp_file) as f:
+            spec = json.load(f)
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        self.send_response(spec["status"])
+        ct = spec.get("content_type", "application/json")
+        self.send_header("Content-Type", ct)
+        self.end_headers()
+        body = spec.get("body", {})
+        out = body if isinstance(body, str) else json.dumps(body)
+        self.wfile.write(out.encode())
+    def log_message(self, *a, **kw): pass
+
+s = http.server.HTTPServer(("127.0.0.1", 0), H)
+with open(port_file, "w") as f:
+    f.write(str(s.server_address[1]))
+s.serve_forever()
+PY
+    echo $! > "$pid_file"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [[ -s "$port_file" ]] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+stop_mock_server() {
+    [[ -f "$MOCK_PID_FILE" ]] || return 0
+    local pid
+    pid="$(cat "$MOCK_PID_FILE" 2>/dev/null || true)"
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+}
+
+write_response() {
+    # write_response STATUS BODY_JSON [CONTENT_TYPE]
+    local status="$1"
+    local body="$2"
+    local ct="${3:-application/json}"
+    python3 -c "import json,sys; print(json.dumps({'status': int(sys.argv[1]), 'body': sys.argv[2], 'content_type': sys.argv[3]}))" \
+        "$status" "$body" "$ct" > "$MOCK_RESP_FILE"
+}
+
+mock_url() {
+    echo "http://127.0.0.1:$(cat "$MOCK_PORT_FILE")"
+}
+
+@test "shows usage on --help" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage:" ]]
+}
+
+@test "fails fast when --target-url missing" {
+    run "$SCRIPT" --root "$ROOT_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "target-url" ]]
+}
+
+@test "reads existing UUID from --root in --dry-run" {
+    run timeout 2 "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://127.0.0.1:1" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "11111111-2222-3333-4444-555555555555" ]]
+}
+
+@test "fails when no UUID file exists at --root" {
+    rm "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "http://127.0.0.1:1" --dry-run
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "UUID" || "$output" =~ "uuid" ]]
+}
+
+@test "rejects malformed UUID" {
+    echo "not-a-uuid" > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "http://127.0.0.1:1" --dry-run
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "UUID" || "$output" =~ "format" ]]
+}
+
+@test "reads UUID from /boot/airplanes-uuid as fallback" {
+    rm "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    mkdir -p "$ROOT_DIR/boot"
+    echo "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" > "$ROOT_DIR/boot/airplanes-uuid"
+    run timeout 2 "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://127.0.0.1:1" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" ]]
+}
+
+
+# --- Secret generation ----------------------------------------------------
+
+@test "secret is 16 chars, A-Z + 0-9 only" {
+    run timeout 2 "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://127.0.0.1:1" --dry-run
+    [ "$status" -eq 0 ]
+    secret=$(echo "$output" | grep -E '^SECRET: ' | awk '{print $2}')
+    [ -n "$secret" ]
+    [ "${#secret}" -eq 16 ]
+    [[ "$secret" =~ ^[A-Z0-9]{16}$ ]]
+}
+
+@test "two consecutive generations produce different secrets" {
+    s1=$(timeout 2 "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://127.0.0.1:1" --dry-run \
+        | grep -E '^SECRET: ' | awk '{print $2}')
+    s2=$(timeout 2 "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://127.0.0.1:1" --dry-run \
+        | grep -E '^SECRET: ' | awk '{print $2}')
+    [ -n "$s1" ]
+    [ -n "$s2" ]
+    [ "$s1" != "$s2" ]
+}
+
+
+# --- POST + JSON-body response dispatch -----------------------------------
+
+@test "201 success exits 0 and prints SUCCESS" {
+    write_response 201 '{"version": 1}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SUCCESS" ]]
+}
+
+@test "200 NOOP_REPLAY exits 0 (treated as success)" {
+    write_response 200 '{"version": 1}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SUCCESS" ]]
+}
+
+@test "409 legacy_unclaimed exits 4 (reinstall flow)" {
+    write_response 409 '{"error": "legacy_unclaimed"}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 4 ]
+}
+
+@test "409 rotation_rejected exits 1" {
+    write_response 409 '{"error": "rotation_rejected"}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+}
+
+@test "423 feeder_blocked exits 1 (terminal — no retry, fast)" {
+    write_response 423 '{"error": "feeder_blocked", "reason": "spam"}'
+    start_mock_server
+    local start_ts; start_ts=$(date +%s)
+    run timeout 5 "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    local elapsed=$(( $(date +%s) - start_ts ))
+    [ "$status" -eq 1 ]
+    [ "$elapsed" -lt 3 ]
+}
+
+@test "400 bad request exits 1" {
+    write_response 400 '{"error": "bad_request"}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+}
+
+@test "non-JSON 404 exits 1 (endpoint disabled / wrong URL)" {
+    write_response 404 '<html>Not Found</html>' 'text/html'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+}
+
+@test "network unreachable (RFC 2606 .invalid) exits 2" {
+    run "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://nonexistent-host-deliberately-broken.invalid" \
+        --max-retry-time 5
+    [ "$status" -eq 2 ]
+}
+
+
+# --- Atomic persistence + idempotent reuse --------------------------------
+
+@test "201 success persists secret atomically (mode 0600, .pending cleaned)" {
+    write_response 201 '{"version": 1}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    local final="$ROOT_DIR/etc/airplanes/claim-secret"
+    [ -f "$final" ]
+    [ ! -f "$ROOT_DIR/etc/airplanes/claim-secret.pending" ]
+    local persisted; persisted="$(cat "$final")"
+    [ "${#persisted}" -eq 16 ]
+    [[ "$persisted" =~ ^[A-Z0-9]{16}$ ]]
+    local mode; mode="$(stat -c '%a' "$final")"
+    [ "$mode" = "600" ]
+}
+
+@test "writes pending file before first POST so crash mid-POST recovers" {
+    # Use a non-routable address so the POST hangs/fails, but pending was
+    # written first and survives.
+    run timeout 4 "$SCRIPT" --root "$ROOT_DIR" \
+        --target-url "http://127.0.0.1:1" \
+        --max-retry-time 1
+    # Either curl-rc network-error (exit 2) or rate-limit-cap (exit 3).
+    [ "$status" -eq 2 ] || [ "$status" -eq 3 ]
+    # The pending file must exist because we wrote it pre-POST.
+    [ -f "$ROOT_DIR/etc/airplanes/claim-secret.pending" ]
+    # Final must NOT exist (POST didn't succeed).
+    [ ! -f "$ROOT_DIR/etc/airplanes/claim-secret" ]
+}
+
+@test "existing claim-secret is reused (NOOP_REPLAY scenario)" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    echo "PRESERVEDSECRET12" > "$ROOT_DIR/etc/airplanes/claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/claim-secret"
+    write_response 200 '{"version": 1}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SECRET: PRESERVEDSECRET12" ]]
+    # Final still has the original secret unchanged.
+    [ "$(cat "$ROOT_DIR/etc/airplanes/claim-secret")" = "PRESERVEDSECRET12" ]
+}
+
+@test "existing pending file is reused (mid-POST resume scenario)" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    echo "RESUMEDFROMPENDIN" > "$ROOT_DIR/etc/airplanes/claim-secret.pending"
+    write_response 201 '{"version": 1}'
+    start_mock_server
+    run "$SCRIPT" --root "$ROOT_DIR" --target-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SECRET: RESUMEDFROMPENDIN" ]]
+    # Pending was promoted to final on success.
+    [ -f "$ROOT_DIR/etc/airplanes/claim-secret" ]
+    [ ! -f "$ROOT_DIR/etc/airplanes/claim-secret.pending" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/claim-secret")" = "RESUMEDFROMPENDIN" ]
+}


### PR DESCRIPTION
Standalone bash helper for registering a feeder's claim secret against the airplanes.live website. Mirrors the protocol contract of the internal Python mock-feeder used for end-to-end testing.

## What this adds

`scripts/claim_secret_register.sh` — runnable on its own. Reads the existing UUID file at the conventional location, generates a 16-char canonical secret if none is persisted yet, persists it before the POST (resumable on crash), and atomically promotes pending-to-final on success.

`test/` — bats harness with 20 tests against an inline mock HTTP server, plus a small Dockerfile + entrypoint that mints a fresh UUID at container start for integration runs.

## File-system footprint

The helper places the new claim-secret file under a dedicated `etc/airplanes` config directory (mode 0600), namespaced to airplanes.live. The existing UUID file location stays unchanged. No other on-disk state is created.

## Exit codes

| code | meaning |
|---|---|
| 0 | registration succeeded (200 NOOP_REPLAY or 201 Created) |
| 1 | configuration / fatal protocol error |
| 2 | network unreachable |
| 3 | retry budget exhausted (`--max-retry-time`) |
| 4 | feeder predates the claim-secret rollout (use the website's reinstall flow) |

## Test plan

- [x] `bats test/test_claim_secret_register.bats` — 20/20 pass against the rewritten helper
- [ ] Manual integration run against a live website dev environment
- [ ] Reviewer confirms file headers and inline comments are end-user-appropriate (no internal phase/plan references)