### PR TITLE
Consolidate feeder config under a dedicated airplanes-namespaced dir

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -111,7 +111,8 @@ if [[ $(hostname) == "radarcape" ]] || pgrep rcd &>/dev/null; then
     INPUT_TYPE="radarcape_gps"
 fi
 
-tee /etc/default/airplanes >/dev/null <<EOF
+mkdir -p /etc/airplanes
+tee /etc/airplanes/feed.env >/dev/null <<EOF
 INPUT="$INPUT"
 REDUCE_INTERVAL="0.5"
 

--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -4,7 +4,7 @@ if grep -qs -e 'LATITUDE' /boot/adsb-config.txt &>/dev/null && [[ -f /boot/airpl
     source /boot/adsb-config.txt
     source /boot/airplanes-env
 else
-    source /etc/default/airplanes
+    source /etc/airplanes/feed.env
 fi
 
 if ! [[ -d /run/airplanes-feed/ ]]; then

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -4,7 +4,7 @@ if grep -qs -e 'LATITUDE' /boot/adsb-config.txt &>/dev/null && [[ -f /boot/airpl
     source /boot/adsb-config.txt
     source /boot/airplanes-env
 else
-    source /etc/default/airplanes
+    source /etc/airplanes/feed.env
 fi
 
 if [[ "$LATITUDE" == 0 ]] || [[ "$LONGITUDE" == 0 ]] || [[ "$USER" == 0 ]] || [[ "$USER" == "disable" ]]; then

--- a/scripts/second-mlat.sh
+++ b/scripts/second-mlat.sh
@@ -15,7 +15,7 @@ After=network.target
 
 [Service]
 User=airplanes
-EnvironmentFile=/etc/default/airplanes
+EnvironmentFile=/etc/airplanes/feed.env
 ExecStart=/usr/local/share/airplanes/venv/bin/mlat-client \
     --input-type $INPUT_TYPE --no-udp \
     --input-connect $INPUT \

--- a/update.sh
+++ b/update.sh
@@ -127,12 +127,19 @@ if diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; then
     exit $?
 fi
 
+# Migrate the env file from /etc/default/airplanes to /etc/airplanes/feed.env.
+# Idempotent: only fires when a regular file still exists at the legacy path.
+mkdir -p /etc/airplanes
+if [[ -f /etc/default/airplanes && ! -L /etc/default/airplanes ]]; then
+    cp -fp /etc/default/airplanes /etc/airplanes/feed.env
+fi
+
 if [ -f /boot/airplanes-env ]; then
     source /boot/airplanes-env
 else
-    source /etc/default/airplanes
-    if ! grep -qs -e UAT_INPUT /etc/default/airplanes; then
-        cat >> /etc/default/airplanes <<"EOF"
+    source /etc/airplanes/feed.env
+    if ! grep -qs -e UAT_INPUT /etc/airplanes/feed.env; then
+        cat >> /etc/airplanes/feed.env <<"EOF"
 
 # this is the source for 978 data, use port 30978 from dump978 --raw-port
 # if you're not receiving 978, don't worry about it, not doing any harm!
@@ -378,9 +385,17 @@ if grep -qs 'SERVER_HOSTPORT.*feed.airplanes.live' /etc/default/mlat-client &>/d
     systemctl disable --now mlat-client >> $LOGFILE 2>&1 || true
 fi
 
-if [[ -f /etc/default/airplanes ]]; then
-    sed -i -e 's/feed.airplanes.live,30004,beast_reduce_out,feed.airplanes.live,64004/feed.airplanes.live,30004,beast_reduce_out,feed.airplanes.live,64004/' /etc/default/airplanes || true
+if [[ -f /etc/airplanes/feed.env ]]; then
+    sed -i -e 's/feed.airplanes.live,30004,beast_reduce_out,feed.airplanes.live,64004/feed.airplanes.live,30004,beast_reduce_out,feed.airplanes.live,64004/' /etc/airplanes/feed.env || true
 fi
+
+# Replace the legacy regular file with a compat symlink, only after the
+# services have been restarted using the new path (above). Idempotent —
+# ln -sfn updates an existing symlink in place.
+if [[ -f /etc/default/airplanes && ! -L /etc/default/airplanes ]]; then
+    rm -f /etc/default/airplanes
+fi
+ln -sfn /etc/airplanes/feed.env /etc/default/airplanes
 
 
 echo 100


### PR DESCRIPTION
Stacked on top of #6. Pulls the existing env file into the same airplanes-namespaced config dir as the new claim-secret file so config doesn't end up split across two locations. After both PRs merge, all rotatable per-host airplanes.live config lives in one place.