### PR TITLE
Add CI workflow + cleanup pass to enable shellcheck/bash/bats gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: shellcheck + bash -n
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run shellcheck (warning severity)
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 shellcheck -S warning
+
+      - name: Run bash syntax check
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 -n1 bash -n
+
+  test:
+    name: bats
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install bats, jq, curl, python3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats jq curl python3
+
+      - name: Run bats suite
+        run: bats test/

--- a/configure.sh
+++ b/configure.sh
@@ -31,8 +31,6 @@ set -e
 trap 'echo "[ERROR] Error in line $LINENO when executing: $BASH_COMMAND"' ERR
 renice 10 $$ &>/dev/null
 
-IPATH=/usr/local/share/airplanes
-
 function abort() {
     echo ------------
     echo "Setup canceled (probably using Esc button)!"

--- a/scripts/lib/systemd-helpers.sh
+++ b/scripts/lib/systemd-helpers.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Helpers for inspecting systemd unit state. Sourced by update.sh; the
+# function bodies are kept small so they can be unit-tested against a
+# stubbed `systemctl` (see test/test_systemd_helpers.bats).
+
+# is_unit_masked UNIT_NAME — return 0 if the unit is currently masked
+# (i.e. systemctl is-enabled prints "masked"), non-zero otherwise.
+is_unit_masked() {
+    [[ "$(systemctl is-enabled "$1" 2>/dev/null)" == "masked" ]]
+}

--- a/test/test_systemd_helpers.bats
+++ b/test/test_systemd_helpers.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# Tests for is_unit_masked, defined in scripts/lib/systemd-helpers.sh.
+# Stubs `systemctl` via PATH manipulation so the function is exercised
+# against deterministic synthetic output rather than the host's real
+# systemd state.
+
+setup() {
+    STUB_DIR="$(mktemp -d)"
+    STUB_OUTPUT_FILE="$(mktemp)"
+    STUB_ARGS_FILE="$(mktemp)"
+
+    # Tiny systemctl shim. Records its argv to $STUB_ARGS_FILE so a test
+    # can assert how the helper invoked it. Emits the contents of
+    # $STUB_OUTPUT_FILE on stdout (empty file → no output, mirroring the
+    # "unit not found" case where real systemctl errors with empty stdout).
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/bin/bash
+echo "$@" >> "${STUB_ARGS_FILE:-/dev/null}"
+[[ -n "${STUB_OUTPUT_FILE:-}" && -s "${STUB_OUTPUT_FILE}" ]] && cat "${STUB_OUTPUT_FILE}"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH STUB_OUTPUT_FILE STUB_ARGS_FILE
+
+    # shellcheck source=../scripts/lib/systemd-helpers.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/systemd-helpers.sh"
+}
+
+teardown() {
+    rm -rf "$STUB_DIR"
+    rm -f "$STUB_OUTPUT_FILE" "$STUB_ARGS_FILE"
+}
+
+@test "is_unit_masked returns 0 when systemctl reports masked" {
+    echo masked > "$STUB_OUTPUT_FILE"
+    run is_unit_masked airplanes-mlat.service
+    [ "$status" -eq 0 ]
+}
+
+@test "is_unit_masked returns non-zero when systemctl reports enabled" {
+    echo enabled > "$STUB_OUTPUT_FILE"
+    run is_unit_masked airplanes-mlat.service
+    [ "$status" -ne 0 ]
+}
+
+@test "is_unit_masked returns non-zero when systemctl reports disabled" {
+    echo disabled > "$STUB_OUTPUT_FILE"
+    run is_unit_masked airplanes-mlat.service
+    [ "$status" -ne 0 ]
+}
+
+@test "is_unit_masked returns non-zero when systemctl produces no output" {
+    # Mirrors the case where the unit doesn't exist and real systemctl
+    # exits non-zero with empty stdout — the function compares "" against
+    # "masked" and returns false.
+    : > "$STUB_OUTPUT_FILE"
+    run is_unit_masked nonexistent.service
+    [ "$status" -ne 0 ]
+}
+
+@test "is_unit_masked invokes systemctl is-enabled with the unit name" {
+    echo masked > "$STUB_OUTPUT_FILE"
+    run is_unit_masked airplanes-feed.service
+    [ "$status" -eq 0 ]
+    [ "$(cat "$STUB_ARGS_FILE")" = "is-enabled airplanes-feed.service" ]
+}

--- a/update.sh
+++ b/update.sh
@@ -127,6 +127,9 @@ if diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; then
     exit $?
 fi
 
+# shellcheck source=scripts/lib/systemd-helpers.sh
+source "$GIT/scripts/lib/systemd-helpers.sh"
+
 # Migrate the env file from /etc/default/airplanes to /etc/airplanes/feed.env.
 # Idempotent: only fires when a regular file still exists at the legacy path.
 mkdir -p /etc/airplanes
@@ -175,17 +178,6 @@ echo 4
 sleep 0.25
 
 # BUILD AND CONFIGURE THE MLAT-CLIENT PACKAGE
-
-progress=4
-echo "Checking and installing prerequesites ..."
-
-# Check that the prerequisite packages needed to build and install mlat-client are installed.
-
-# only install chrony if chrony and ntp aren't running
-if ! systemctl status chrony &>/dev/null && ! systemctl status ntp &>/dev/null; then
-    required_packages="chrony "
-fi
-
 
 echo
 bash "$IPATH/git/create-uuid.sh"
@@ -257,7 +249,7 @@ cp "$GIT"/scripts/airplanes-mlat.service /lib/systemd/system
 
 echo 60
 
-if ls -l /etc/systemd/system/airplanes-mlat.service 2>&1 | grep '/dev/null' &>/dev/null; then
+if is_unit_masked airplanes-mlat.service; then
     echo "--------------------"
     echo "CAUTION, airplanes-mlat is masked and won't run!"
     echo "If this is unexpected for you, please report this issue."
@@ -329,7 +321,7 @@ cp "$GIT"/scripts/airplanes-feed.service /lib/systemd/system
 
 echo 82
 
-if ! ls -l /etc/systemd/system/airplanes-feed.service 2>&1 | grep '/dev/null' &>/dev/null; then
+if ! is_unit_masked airplanes-feed.service; then
     # Enable airplanes-feed service
     systemctl enable airplanes-feed >> $LOGFILE || true
     echo 92


### PR DESCRIPTION
First CI gate for `airplanes-live/feed`. Adds automated PR verification so a bash typo, an obviously-broken script, or a regression in the claim-secret helper can't ship without someone noticing.
