### PR TITLE
Tolerate missing hostname/adduser on minimal install hosts

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -104,7 +104,9 @@ RECEIVERALTITUDE="$ALT"
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
 
-if [[ $(hostname) == "radarcape" ]] || pgrep rcd &>/dev/null; then
+# `hostname` and `pgrep` (procps) are absent on some minimal images — guard both.
+HOSTNAME_VAL="$(hostname 2>/dev/null || uname -n 2>/dev/null || cat /etc/hostname 2>/dev/null || true)"
+if [[ "$HOSTNAME_VAL" == "radarcape" ]] || { command -v pgrep &>/dev/null && pgrep rcd &>/dev/null; }; then
     INPUT="127.0.0.1:10003"
     INPUT_TYPE="radarcape_gps"
 fi

--- a/update.sh
+++ b/update.sh
@@ -170,8 +170,12 @@ cp "$GIT"/scripts/*.sh "$IPATH"
 UNAME=airplanes
 if ! id -u "${UNAME}" &>/dev/null
 then
-    # 2nd syntax is for fedora / centos
-    adduser --system --home "$IPATH" --no-create-home --quiet "$UNAME" || adduser --system --home-dir "$IPATH" --no-create-home "$UNAME"
+    # Try Debian-style adduser, then Fedora-style adduser, then useradd.
+    # `||` chains are set -e safe; the trailing block makes the all-failed case explicit.
+    adduser --system --home "$IPATH" --no-create-home --quiet "$UNAME" \
+        || adduser --system --home-dir "$IPATH" --no-create-home "$UNAME" \
+        || useradd --system --home-dir "$IPATH" --no-create-home "$UNAME" \
+        || { echo "ERROR: failed to create user '$UNAME' (no working adduser/useradd)." >&2; exit 1; }
 fi
 
 echo 4


### PR DESCRIPTION
## Summary

Addresses #2.

The install path aborts on minimal Debian/Ubuntu derivatives that ship without `hostname` (configure.sh) or `adduser` (update.sh) in their base image. This PR makes both call sites defensive so the install proceeds on those hosts.

### `configure.sh` — radarcape detection

- Read the hostname through a fallback chain: `hostname` → `uname -n` → `/etc/hostname` → empty.
- Guard `pgrep rcd` with `command -v pgrep` (the `procps` package is the same class of "missing on minimal images" bug).

Both binaries' absence now leaves `INPUT_TYPE=dump1090` (the default) and produces no stderr leak.

### `update.sh` — user creation

- Replace the two-`adduser` chain with a flat sequential `||` chain: Debian-style `adduser`, then Fedora-style `adduser`, then `useradd`, then an explicit `exit 1` if all fail.
- `||` chains are `set -e`-safe, so a failing `adduser` falls through to `useradd` instead of tripping the `ERR` trap.
- Drop `--shell` from `useradd` — `/usr/sbin/nologin` vs `/sbin/nologin` vs `/bin/false` is not portable; the system default is fine.

### Why "Addresses #2" not "Fixes #2"

End users install via `install.sh` and `update.sh`, both of which hard-code `BRANCH="main"`. Merging this PR to `dev` does not ship the fix to feeders — that happens on the eventual `dev → main` merge. Whoever performs that merge can close #2 then.

## Verification

CI (`.github/workflows/ci.yml` from PR #8) is now green on this branch — `shellcheck -S warning + bash -n` and the `bats` suite both pass.

Behavioral repro in `debian:13-slim` with `hostname`, `inetutils-hostname`, and `adduser` purged (script: 14 assertions, all pass):

| # | Scenario | PRE-fix | POST-fix |
|---|---|---|---|
| 1 | configure.sh, no `hostname` | exits 0 but leaks `bash: line 2: hostname: command not found` to stderr (matches issue report) | clean stderr, selects `dump1090` |
| 2 | configure.sh, no `hostname` AND no `pgrep` | — | clean stderr, selects `dump1090` |
| 3 | update.sh user creation, no `adduser`, `useradd` present | exit 127, user not created (matches issue report) | exit 0, user `airplanes` created (uid 999) via `useradd` |
| 4 | update.sh user creation, idempotent re-run | — | exit 0, no-op |

`adduser: command not found` still appears on stderr in the post-fix run because the `||` chain has to actually attempt each candidate before falling through. That's expected and visible in the user's install log, but no longer fatal.

## Test plan

- [x] CI lints + bats — green
- [ ] Maintainer review for the `useradd` flag set (no `--shell`, no `--system` on Fedora's variant — drop or keep?)
- [ ] Eventually: `dev → main` merge to actually ship the fix to feeders, then close #2
