### PR TITLE
Add install/update test harness; fix bugs surfaced by it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,9 @@ jobs:
         run: bats test/
 
   installer-smoke:
-    name: installer smoke (${{ matrix.image }})
+    name: installer smoke (${{ matrix.image }}, ${{ matrix.path }})
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -62,33 +63,31 @@ jobs:
         image:
           - debian:13-slim
           - ubuntu:24.04
+        path:
+          - bundled
+          - standalone
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - name: Resolve feed ref
-        id: feed-ref
+      - name: Pin local branch ref to HEAD
         env:
-          PR_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
-          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-          PUSH_REPO: https://github.com/${{ github.repository }}.git
-          PUSH_BRANCH: ${{ github.ref_name }}
+          BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
         run: |
-          if [ -n "$PR_REPO" ]; then
-            echo "repo=$PR_REPO" >> "$GITHUB_OUTPUT"
-            echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
-          else
-            echo "repo=$PUSH_REPO" >> "$GITHUB_OUTPUT"
-            echo "branch=$PUSH_BRANCH" >> "$GITHUB_OUTPUT"
-          fi
+          git -C "$PWD" branch -f "$BRANCH" HEAD
 
       - name: Run installer smoke
+        env:
+          FEED_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          IMAGE: ${{ matrix.image }}
+          TEST_PATH: ${{ matrix.path }}
         run: |
           docker run --rm \
-            -e AIRPLANES_FEED_REPO="${{ steps.feed-ref.outputs.repo }}" \
-            -e AIRPLANES_FEED_BRANCH="${{ steps.feed-ref.outputs.branch }}" \
+            -e AIRPLANES_FEED_REPO=file:///workspace \
+            -e AIRPLANES_FEED_BRANCH="$FEED_BRANCH" \
+            -e AIRPLANES_TEST_PATH="$TEST_PATH" \
             -v "$PWD:/workspace:ro" \
-            "${{ matrix.image }}" \
+            "$IMAGE" \
             bash /workspace/test/installer-smoke.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,44 @@ jobs:
 
       - name: Run bats suite
         run: bats test/
+
+  installer-smoke:
+    name: installer smoke (${{ matrix.image }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:13-slim
+          - ubuntu:24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve feed ref
+        id: feed-ref
+        env:
+          PR_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PUSH_REPO: https://github.com/${{ github.repository }}.git
+          PUSH_BRANCH: ${{ github.ref_name }}
+        run: |
+          if [ -n "$PR_REPO" ]; then
+            echo "repo=$PR_REPO" >> "$GITHUB_OUTPUT"
+            echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "repo=$PUSH_REPO" >> "$GITHUB_OUTPUT"
+            echo "branch=$PUSH_BRANCH" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run installer smoke
+        run: |
+          docker run --rm \
+            -e AIRPLANES_FEED_REPO="${{ steps.feed-ref.outputs.repo }}" \
+            -e AIRPLANES_FEED_BRANCH="${{ steps.feed-ref.outputs.branch }}" \
+            -v "$PWD:/workspace:ro" \
+            "${{ matrix.image }}" \
+            bash /workspace/test/installer-smoke.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC1090,SC2034

--- a/configure.sh
+++ b/configure.sh
@@ -29,7 +29,12 @@
 
 set -e
 trap 'echo "[ERROR] Error in line $LINENO when executing: $BASH_COMMAND"' ERR
-renice 10 $$ &>/dev/null
+renice 10 $$ &>/dev/null || true
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/install-update-common.sh
+source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+airplanes_init_paths
 
 function abort() {
     echo ------------
@@ -62,21 +67,31 @@ fi
 
 #((-90 <= RECEIVERLATITUDE <= 90))
 LAT_OK=0
-until [ $LAT_OK -eq 1 ]; do
+until [ "$LAT_OK" -eq 1 ]; do
     RECEIVERLATITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Latitude ${RECEIVERLATITUDE}" --nocancel --inputbox "\nEnter the latitude of your antenna in degrees with 5 decimal places.\n(Example: 32.36291)" 12 78 3>&1 1>&2 2>&3) || abort
-    LAT_OK=`awk -v LAT="$RECEIVERLATITUDE" 'BEGIN {printf (LAT<90 && LAT>-90 ? "1" : "0")}'`
+    if [[ "$RECEIVERLATITUDE" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+        LAT_OK=`awk -v LAT="$RECEIVERLATITUDE" 'BEGIN {printf (LAT<90 && LAT>-90 ? "1" : "0")}'`
+    else
+        LAT_OK=0
+        whiptail --backtitle "$BACKTITLETEXT" --title "Invalid latitude" --msgbox "Latitude must be a decimal number." 10 60 || abort
+    fi
 done
 
 
 #((-180<= RECEIVERLONGITUDE <= 180))
 LON_OK=0
-until [ $LON_OK -eq 1 ]; do
+until [ "$LON_OK" -eq 1 ]; do
     RECEIVERLONGITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Longitude ${RECEIVERLONGITUDE}" --nocancel --inputbox "\nEnter the longitude of your antenna in degrees with 5 decimal places.\n(Example: -64.71492)" 12 78 3>&1 1>&2 2>&3) || abort
-    LON_OK=`awk -v LON="$RECEIVERLONGITUDE" 'BEGIN {printf (LON<180 && LON>-180 ? "1" : "0")}'`
+    if [[ "$RECEIVERLONGITUDE" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+        LON_OK=`awk -v LON="$RECEIVERLONGITUDE" 'BEGIN {printf (LON<180 && LON>-180 ? "1" : "0")}'`
+    else
+        LON_OK=0
+        whiptail --backtitle "$BACKTITLETEXT" --title "Invalid longitude" --msgbox "Longitude must be a decimal number." 10 60 || abort
+    fi
 done
 
 ALT=0
-until [[ "$NOSPACENAME" == 0 ]] || [[ $ALT =~ ^(-?[0-9]*)ft$ ]] || [[ $ALT =~ ^(-?[0-9]*)m$ ]]; do
+until [[ "$NOSPACENAME" == 0 ]] || [[ $ALT =~ ^-?[0-9]+ft$ ]] || [[ $ALT =~ ^-?[0-9]+m$ ]]; do
     ALT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Altitude above sea level (at the antenna):" \
         --nocancel --inputbox \
 "\nEnter the altitude of your antenna, above sea level, including the unit with no spaces:\n\n\
@@ -85,12 +100,12 @@ or in meters like this:               78m\n" \
         12 78 3>&1 1>&2 2>&3) || abort
 done
 
-if [[ $ALT =~ ^-(.*)ft$ ]]; then
+if [[ $ALT =~ ^-([0-9]+)ft$ ]]; then
         NUM=${BASH_REMATCH[1]}
         NEW_ALT=`echo "$NUM" "3.28" | awk '{printf "-%0.2f", $1 / $2 }'`
         ALT=$NEW_ALT
 fi
-if [[ $ALT =~ ^-(.*)m$ ]]; then
+if [[ $ALT =~ ^-([0-9]+)m$ ]]; then
         NEW_ALT="-${BASH_REMATCH[1]}"
         ALT=$NEW_ALT
 fi
@@ -111,8 +126,8 @@ if [[ "$HOSTNAME_VAL" == "radarcape" ]] || { command -v pgrep &>/dev/null && pgr
     INPUT_TYPE="radarcape_gps"
 fi
 
-mkdir -p /etc/airplanes
-tee /etc/airplanes/feed.env >/dev/null <<EOF
+mkdir -p "$ETC_AIRPLANES"
+tee "$FEED_ENV" >/dev/null <<EOF
 INPUT="$INPUT"
 REDUCE_INTERVAL="0.5"
 
@@ -140,7 +155,6 @@ INPUT_TYPE="$INPUT_TYPE"
 
 MLATSERVER="feed.airplanes.live:31090"
 TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed.airplanes.live,64004"
-NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --write-json-every 1 --uuid-file /usr/local/share/airplanes/airplanes-uuid"
+NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --write-json-every 1 --uuid-file $(airplanes_path /usr/local/share/airplanes/airplanes-uuid)"
 JSON_OPTIONS="--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"
 EOF
-

--- a/configure.sh
+++ b/configure.sh
@@ -69,7 +69,7 @@ fi
 LAT_OK=0
 until [ "$LAT_OK" -eq 1 ]; do
     RECEIVERLATITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Latitude ${RECEIVERLATITUDE}" --nocancel --inputbox "\nEnter the latitude of your antenna in degrees with 5 decimal places.\n(Example: 32.36291)" 12 78 3>&1 1>&2 2>&3) || abort
-    if [[ "$RECEIVERLATITUDE" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+    if [[ "$RECEIVERLATITUDE" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
         LAT_OK=`awk -v LAT="$RECEIVERLATITUDE" 'BEGIN {printf (LAT<90 && LAT>-90 ? "1" : "0")}'`
     else
         LAT_OK=0
@@ -82,7 +82,7 @@ done
 LON_OK=0
 until [ "$LON_OK" -eq 1 ]; do
     RECEIVERLONGITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Longitude ${RECEIVERLONGITUDE}" --nocancel --inputbox "\nEnter the longitude of your antenna in degrees with 5 decimal places.\n(Example: -64.71492)" 12 78 3>&1 1>&2 2>&3) || abort
-    if [[ "$RECEIVERLONGITUDE" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+    if [[ "$RECEIVERLONGITUDE" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
         LON_OK=`awk -v LON="$RECEIVERLONGITUDE" 'BEGIN {printf (LON<180 && LON>-180 ? "1" : "0")}'`
     else
         LON_OK=0
@@ -155,6 +155,6 @@ INPUT_TYPE="$INPUT_TYPE"
 
 MLATSERVER="feed.airplanes.live:31090"
 TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed.airplanes.live,64004"
-NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --write-json-every 1 --uuid-file $(airplanes_path /usr/local/share/airplanes/airplanes-uuid)"
+NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --write-json-every 1 --uuid-file /usr/local/share/airplanes/airplanes-uuid"
 JSON_OPTIONS="--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"
 EOF

--- a/create-uuid.sh
+++ b/create-uuid.sh
@@ -1,27 +1,35 @@
 #!/bin/bash
 
-if [ -f /boot/airplanes-config.txt ]; then
-    UUID_FILE="/boot/airplanes-uuid"
+set -e
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/install-update-common.sh
+source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+airplanes_init_paths
+
+if [ -f "$BOOT_CONFIG" ]; then
+    UUID_FILE="$(airplanes_path /boot/airplanes-uuid)"
 else
-    mkdir -p /usr/local/share/airplanes
-    UUID_FILE="/usr/local/share/airplanes/airplanes-uuid"
+    mkdir -p "$IPATH"
+    UUID_FILE="$IPATH/airplanes-uuid"
     # move old file position
-    if [ -f /boot/airplanes-uuid ]; then
-        mv -f /boot/airplanes-uuid $UUID_FILE
+    BOOT_UUID="$(airplanes_path /boot/airplanes-uuid)"
+    if [ -f "$BOOT_UUID" ]; then
+        mv -f "$BOOT_UUID" "$UUID_FILE"
     fi
 fi
 
 function generateUUID() {
-    rm -f $UUID_FILE
+    rm -f "$UUID_FILE"
     sleep 0.$RANDOM; sleep 0.$RANDOM
     UUID=$(cat /proc/sys/kernel/random/uuid)
     echo New UUID: $UUID
-    echo $UUID > $UUID_FILE
+    echo "$UUID" > "$UUID_FILE"
 }
 
 # Check for a (valid) UUID...
-if [ -f $UUID_FILE ]; then
-    UUID=$(cat $UUID_FILE)
+if [ -f "$UUID_FILE" ]; then
+    UUID=$(cat "$UUID_FILE")
     if ! [[ $UUID =~ ^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$ ]]; then
         # Data in UUID file is invalid.  Regenerate it!
         echo "WARNING: Data in UUID file was invalid.  Regenerating UUID."

--- a/install.sh
+++ b/install.sh
@@ -1,35 +1,92 @@
 #!/bin/bash
 set -e
 
-REPO="https://github.com/airplanes-live/feed.git"
-BRANCH="main"
-IPATH=/usr/local/share/airplanes
-mkdir -p $IPATH
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-if [ "$(id -u)" != "0" ]; then
-    echo -e "\033[33m"
-    echo "This script must be ran using sudo or as root."
-    echo -e "\033[37m"
-    exit 1
+if [[ -f "$SCRIPT_DIR/scripts/lib/install-update-common.sh" ]]; then
+    # shellcheck source=scripts/lib/install-update-common.sh
+    source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+else
+    AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
+    AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
+    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
+
+    airplanes_path() {
+        local path="$1"
+        if [[ "$AIRPLANES_ROOT" == "/" ]]; then
+            printf '%s' "$path"
+        else
+            printf '%s%s' "${AIRPLANES_ROOT%/}" "$path"
+        fi
+    }
+
+    airplanes_init_paths() {
+        IPATH="$(airplanes_path /usr/local/share/airplanes)"
+        GIT="$IPATH/git"
+    }
+
+    airplanes_require_root() {
+        if [[ "${AIRPLANES_SKIP_ROOT_CHECK:-0}" == "1" ]]; then
+            return 0
+        fi
+        if [[ "$(id -u)" != "0" ]]; then
+            echo -e "\033[33m"
+            echo "This script must be ran using sudo or as root."
+            echo -e "\033[37m"
+            exit 1
+        fi
+    }
+
+    airplanes_install_bootstrap_deps() {
+        if ! command -v git &>/dev/null || ! command -v wget &>/dev/null || ! command -v unzip &>/dev/null || ! command -v whiptail &>/dev/null || ! command -v awk &>/dev/null; then
+            apt-get update || true
+            apt-get install -y --no-install-recommends --no-install-suggests git wget unzip whiptail mawk || true
+        fi
+    }
+
+    getGIT() {
+        local repo branch target tmp previous_dir
+        if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+            echo "getGIT wrong usage, check your script or tell the author!" 1>&2
+            return 1
+        fi
+        repo="$1"
+        branch="$2"
+        target="$3"
+        previous_dir="$(pwd)"
+        tmp="/tmp/getGIT-tmp.$RANDOM.$RANDOM"
+
+        if cd "$target" &>/dev/null && [[ "$(git remote get-url origin)" == "$repo" ]] && git fetch --depth 1 origin "$branch" && git reset --hard FETCH_HEAD; then
+            cd "$previous_dir" || return 1
+            return 0
+        fi
+
+        cd "$previous_dir" || return 1
+        if ! cd /tmp || ! rm -rf "$target"; then
+            return 1
+        fi
+        if git clone --depth 1 --single-branch --branch "$branch" "$repo" "$target"; then
+            cd "$previous_dir" || return 1
+            return 0
+        fi
+        if wget -O "$tmp" "${repo%".git"}/archive/$branch.zip" && unzip "$tmp" -d "$tmp.folder"; then
+            if mv -fT "$tmp.folder/$(ls "$tmp.folder")" "$target"; then
+                rm -rf "$tmp" "$tmp.folder"
+                cd "$previous_dir" || return 1
+                return 0
+            fi
+        fi
+        rm -rf "$tmp" "$tmp.folder"
+        cd "$previous_dir" || return 1
+        return 1
+    }
 fi
 
-if ! command -v git &>/dev/null || ! command -v wget &>/dev/null || ! command -v unzip &>/dev/null || ! command -v whiptail &>/dev/null; then
-    apt-get update || true; apt-get install -y --no-install-recommends --no-install-suggests git wget unzip whiptail || true
-fi
-function getGIT() {
-    # getGIT $REPO $BRANCH $TARGET (directory)
-    if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then echo "getGIT wrong usage, check your script or tell the author!" 1>&2; return 1; fi
-    REPO="$1"; BRANCH="$2"; TARGET="$3"; pushd .; tmp=/tmp/getGIT-tmp.$RANDOM.$RANDOM
-    if cd "$TARGET" &>/dev/null && [[ $(git remote get-url origin) == "$REPO" ]] && git fetch --depth 1 origin "$BRANCH" && git reset --hard FETCH_HEAD; then popd && return 0; fi
-    popd; if ! cd /tmp || ! rm -rf "$TARGET"; then return 1; fi
-    if git clone --depth 1 --single-branch --branch "$2" "$1" "$3"; then return 0; fi
-    if wget -O "$tmp" "${REPO%".git"}/archive/$BRANCH.zip" && unzip "$tmp" -d "$tmp.folder"; then
-        if mv -fT "$tmp.folder/$(ls $tmp.folder)" "$TARGET"; then rm -rf "$tmp" "$tmp.folder"; return 0; fi
-    fi
-    rm -rf "$tmp" "$tmp.folder"; return 1
-}
+airplanes_init_paths
+airplanes_require_root
+mkdir -p "$IPATH"
+airplanes_install_bootstrap_deps
+getGIT "$AIRPLANES_FEED_REPO" "$AIRPLANES_FEED_BRANCH" "$GIT"
 
-getGIT "$REPO" "$BRANCH" "$IPATH/git"
-
-cd "$IPATH/git"
-bash "$IPATH/git/setup.sh"
+cd "$GIT"
+bash "$GIT/setup.sh"

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,9 @@ else
             return 0
         fi
         if wget -O "$tmp" "${repo%".git"}/archive/$branch.zip" && unzip "$tmp" -d "$tmp.folder"; then
-            if mv -fT "$tmp.folder/$(ls "$tmp.folder")" "$target"; then
+            local entries
+            mapfile -t entries < <(find "$tmp.folder" -mindepth 1 -maxdepth 1 -print)
+            if [[ "${#entries[@]}" -eq 1 ]] && mv -fT "${entries[0]}" "$target"; then
                 rm -rf "$tmp" "$tmp.folder"
                 cd "$previous_dir" || return 1
                 return 0

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -41,17 +41,9 @@ airplanes_require_root() {
     fi
 }
 
-airplanes_refuse_image_install() {
-    [[ -f "$BOOT_CONFIG" ]] || return 0
-    echo --------
-    echo "You are using the airplanes.live image, the feed setup script does not need to be installed."
-    echo --------
-    exit 1
-}
-
 airplanes_apt_install() {
     if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
-        apt-get update
+        apt-get update || true
         if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
             apt-get clean || true
             apt-get -f install -y || true
@@ -73,7 +65,7 @@ airplanes_install_bootstrap_deps() {
 
 airplanes_update_packages() {
     local packages
-    packages="git wget unzip curl jq build-essential pkg-config python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
+    packages="git wget unzip curl jq build-essential pkg-config python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g whiptail mawk"
     if ! airplanes_is_legacy_os; then
         packages+=" libzstd-dev libzstd1"
     fi
@@ -91,10 +83,10 @@ airplanes_install_update_deps() {
         if ! command -v nc &>/dev/null; then
             airplanes_apt_install netcat-openbsd || true
         fi
-    elif [[ "$package_manager" == "yum" ]] || { [[ "$package_manager" == "auto" ]] && command -v yum &>/dev/null; }; then
-        yum install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconfig ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
     elif [[ "$package_manager" == "dnf" ]] || { [[ "$package_manager" == "auto" ]] && command -v dnf &>/dev/null; }; then
-        dnf install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconf-pkg-config ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
+        dnf install -y git wget unzip curl jq socat python3-virtualenv python3-devel gcc make pkgconf-pkg-config ncurses-devel newt gawk nc uuid zlib-devel zlib libzstd-devel libzstd
+    elif [[ "$package_manager" == "yum" ]] || { [[ "$package_manager" == "auto" ]] && command -v yum &>/dev/null; }; then
+        yum install -y git wget unzip curl jq socat python3-virtualenv python3-devel gcc make pkgconfig ncurses-devel newt gawk nc uuid zlib-devel zlib libzstd-devel libzstd
     elif [[ "$package_manager" != "none" ]]; then
         echo "No supported package manager found; continuing with existing system packages." >&2
     fi
@@ -131,7 +123,9 @@ getGIT() {
         return 0
     fi
     if wget -O "$tmp" "${repo%".git"}/archive/$branch.zip" && unzip "$tmp" -d "$tmp.folder"; then
-        if mv -fT "$tmp.folder/$(ls "$tmp.folder")" "$target"; then
+        local entries
+        mapfile -t entries < <(find "$tmp.folder" -mindepth 1 -maxdepth 1 -print)
+        if [[ "${#entries[@]}" -eq 1 ]] && mv -fT "${entries[0]}" "$target"; then
             rm -rf "$tmp" "$tmp.folder"
             cd "$previous_dir" || return 1
             return 0

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Shared helpers for the installer and updater. The scripts are still usable
+# when downloaded standalone; install.sh and update.sh keep a small fallback for
+# that bootstrap case.
+
+AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
+AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
+AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
+
+airplanes_path() {
+    local path="$1"
+    if [[ "$AIRPLANES_ROOT" == "/" ]]; then
+        printf '%s' "$path"
+    else
+        printf '%s%s' "${AIRPLANES_ROOT%/}" "$path"
+    fi
+}
+
+airplanes_init_paths() {
+    IPATH="$(airplanes_path /usr/local/share/airplanes)"
+    GIT="$IPATH/git"
+    LOGFILE="$IPATH/lastlog"
+    BOOT_CONFIG="$(airplanes_path /boot/airplanes-config.txt)"
+    BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
+    ETC_AIRPLANES="$(airplanes_path /etc/airplanes)"
+    FEED_ENV="$ETC_AIRPLANES/feed.env"
+    LEGACY_FEED_ENV="$(airplanes_path /etc/default/airplanes)"
+    LOCAL_BIN="$(airplanes_path /usr/local/bin)"
+    SYSTEMD_DIR="$(airplanes_path /lib/systemd/system)"
+}
+
+airplanes_require_root() {
+    if [[ "${AIRPLANES_SKIP_ROOT_CHECK:-0}" == "1" ]]; then
+        return 0
+    fi
+    if [[ "$(id -u)" != "0" ]]; then
+        echo -e "\033[33m"
+        echo "This script must be ran using sudo or as root."
+        echo -e "\033[37m"
+        exit 1
+    fi
+}
+
+airplanes_refuse_image_install() {
+    [[ -f "$BOOT_CONFIG" ]] || return 0
+    echo --------
+    echo "You are using the airplanes.live image, the feed setup script does not need to be installed."
+    echo --------
+    exit 1
+}
+
+airplanes_apt_install() {
+    if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
+        apt-get update
+        if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
+            apt-get clean || true
+            apt-get -f install -y || true
+            apt-get install --no-install-recommends --no-install-suggests -y "$@"
+        fi
+    fi
+}
+
+airplanes_is_legacy_os() {
+    grep -E 'wheezy|jessie' "$(airplanes_path /etc/os-release)" -qs
+}
+
+airplanes_install_bootstrap_deps() {
+    if ! command -v git &>/dev/null || ! command -v wget &>/dev/null || ! command -v unzip &>/dev/null || ! command -v whiptail &>/dev/null || ! command -v awk &>/dev/null; then
+        apt-get update || true
+        apt-get install -y --no-install-recommends --no-install-suggests git wget unzip whiptail mawk || true
+    fi
+}
+
+airplanes_update_packages() {
+    local packages
+    packages="git wget unzip curl jq build-essential pkg-config python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
+    if ! airplanes_is_legacy_os; then
+        packages+=" libzstd-dev libzstd1"
+    fi
+    printf '%s' "$packages"
+}
+
+airplanes_install_update_deps() {
+    local packages package_manager
+    packages="$(airplanes_update_packages)"
+    package_manager="${AIRPLANES_PACKAGE_MANAGER:-auto}"
+
+    if [[ "$package_manager" == "apt" ]] || { [[ "$package_manager" == "auto" ]] && command -v apt-get &>/dev/null; }; then
+        # shellcheck disable=SC2086
+        airplanes_apt_install $packages
+        if ! command -v nc &>/dev/null; then
+            airplanes_apt_install netcat-openbsd || true
+        fi
+    elif [[ "$package_manager" == "yum" ]] || { [[ "$package_manager" == "auto" ]] && command -v yum &>/dev/null; }; then
+        yum install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconfig ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
+    elif [[ "$package_manager" == "dnf" ]] || { [[ "$package_manager" == "auto" ]] && command -v dnf &>/dev/null; }; then
+        dnf install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconf-pkg-config ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
+    elif [[ "$package_manager" != "none" ]]; then
+        echo "No supported package manager found; continuing with existing system packages." >&2
+    fi
+}
+
+revision() {
+    git rev-parse HEAD 2>/dev/null || echo "$RANDOM-$RANDOM"
+}
+
+getGIT() {
+    # getGIT REPO BRANCH TARGET-DIR
+    local repo branch target tmp previous_dir
+    if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+        echo "getGIT wrong usage, check your script or tell the author!" 1>&2
+        return 1
+    fi
+    repo="$1"
+    branch="$2"
+    target="$3"
+    previous_dir="$(pwd)"
+    tmp="/tmp/getGIT-tmp.$RANDOM.$RANDOM"
+
+    if cd "$target" &>/dev/null && [[ "$(git remote get-url origin)" == "$repo" ]] && git fetch --depth 1 origin "$branch" && git reset --hard FETCH_HEAD; then
+        cd "$previous_dir" || return 1
+        return 0
+    fi
+
+    cd "$previous_dir" || return 1
+    if ! cd /tmp || ! rm -rf "$target"; then
+        return 1
+    fi
+    if git clone --depth 1 --single-branch --branch "$branch" "$repo" "$target"; then
+        cd "$previous_dir" || return 1
+        return 0
+    fi
+    if wget -O "$tmp" "${repo%".git"}/archive/$branch.zip" && unzip "$tmp" -d "$tmp.folder"; then
+        if mv -fT "$tmp.folder/$(ls "$tmp.folder")" "$target"; then
+            rm -rf "$tmp" "$tmp.folder"
+            cd "$previous_dir" || return 1
+            return 0
+        fi
+    fi
+    rm -rf "$tmp" "$tmp.folder"
+    cd "$previous_dir" || return 1
+    return 1
+}

--- a/setup.sh
+++ b/setup.sh
@@ -29,19 +29,17 @@
 
 set -e
 
-IPATH=/usr/local/share/airplanes
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/install-update-common.sh
+source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+airplanes_init_paths
 
 ## we need to install stuff that require root, check for that
-if [ "$(id -u)" != "0" ]; then
-    echo -e "\033[33m"
-    echo "This script must be ran using sudo or as root."
-    echo -e "\033[37m"
-    exit 1
-fi
+airplanes_require_root
 
 ## REFUSE INSTALLATION ON AIRPLANES.LIVE IMAGE
 
-if [ -f /boot/airplanes-config.txt ]; then
+if [ -f "$BOOT_CONFIG" ]; then
     echo --------
     echo "You are using the airplanes.live image, the feed setup script does not need to be installed."
     echo "You should already be feeding."
@@ -57,6 +55,7 @@ fi
 
 bash "$IPATH/git/configure.sh"
 
+BACKTITLETEXT="${BACKTITLETEXT:-airplanes.live Setup Script}"
 whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "We are now ready to begin setting up your receiver to feed airplanes.live.\n\nDo you wish to proceed?" 9 78 || exit 1
 
 bash "$IPATH/git/update.sh"

--- a/test/installer-smoke.sh
+++ b/test/installer-smoke.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AIRPLANES_FEED_REPO:?AIRPLANES_FEED_REPO is required}"
+: "${AIRPLANES_FEED_BRANCH:?AIRPLANES_FEED_BRANCH is required}"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends bash ca-certificates git python3
+git config --global --add safe.directory '*'
+
+install -d -m 0755 /usr/local/sbin
+
+cat > /usr/local/sbin/whiptail <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+counter=/tmp/whiptail-counter
+if printf '%s\n' "$@" | grep -q -- '--inputbox'; then
+    n=0
+    [[ -f "$counter" ]] && n="$(cat "$counter")"
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$counter"
+    case "$n" in
+        1) printf '%s\n' "ci-feeder" >&2 ;;
+        2) printf '%s\n' "52.52000" >&2 ;;
+        3) printf '%s\n' "13.40500" >&2 ;;
+        *) printf '%s\n' "35m" >&2 ;;
+    esac
+fi
+exit 0
+SH
+chmod +x /usr/local/sbin/whiptail
+
+cat > /usr/local/sbin/systemctl <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'systemctl %s\n' "$*" >> /tmp/systemctl.log
+if [[ "${1:-}" == "is-enabled" ]]; then
+    printf '%s\n' disabled
+fi
+exit 0
+SH
+chmod +x /usr/local/sbin/systemctl
+
+cat > /usr/local/sbin/journalctl <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x /usr/local/sbin/journalctl
+
+cat > /usr/local/sbin/nc <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x /usr/local/sbin/nc
+
+python3 - <<'PY' &
+import http.server
+import json
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        if self.path != "/api/feeders/secret":
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"version": 1}).encode())
+
+    def log_message(self, *args):
+        pass
+
+server = http.server.HTTPServer(("127.0.0.1", 18080), Handler)
+server.serve_forever()
+PY
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null || true' EXIT
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export APL_FEED_SERVER_URL="http://127.0.0.1:18080"
+export APL_FEED_MAX_RETRY_TIME=5
+export AIRPLANES_PACKAGE_MANAGER=apt
+
+bash /workspace/install.sh
+bash /usr/local/share/airplanes/git/update.sh
+
+test -d /usr/local/share/airplanes/git
+test -x /usr/local/bin/apl-feed
+test -f /usr/local/share/airplanes/airplanes-uuid
+test -f /usr/local/share/airplanes/apl-feed/common.sh
+test -f /lib/systemd/system/airplanes-feed.service
+test -f /lib/systemd/system/airplanes-mlat.service
+test -f /etc/airplanes/feed.env
+test -f /etc/airplanes/claim-secret
+test "$(readlink /etc/default/airplanes)" = "/etc/airplanes/feed.env"
+grep -q 'systemctl restart airplanes-feed' /tmp/systemctl.log
+grep -q 'UAT_INPUT="127.0.0.1:30978"' /etc/airplanes/feed.env

--- a/test/installer-smoke.sh
+++ b/test/installer-smoke.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 : "${AIRPLANES_FEED_REPO:?AIRPLANES_FEED_REPO is required}"
 : "${AIRPLANES_FEED_BRANCH:?AIRPLANES_FEED_BRANCH is required}"
+TEST_PATH="${AIRPLANES_TEST_PATH:-bundled}"
+case "$TEST_PATH" in
+    bundled|standalone) ;;
+    *) echo "Unknown AIRPLANES_TEST_PATH: $TEST_PATH (expected bundled|standalone)" >&2; exit 1 ;;
+esac
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
@@ -79,21 +84,49 @@ PY
 mock_pid=$!
 trap 'kill "$mock_pid" 2>/dev/null || true' EXIT
 
+# Wait for the mock server to bind before continuing.
+ready=0
+for _ in $(seq 1 50); do
+    if python3 -c 'import urllib.request, sys
+try:
+    urllib.request.urlopen("http://127.0.0.1:18080/_probe", timeout=0.2)
+except urllib.error.HTTPError:
+    sys.exit(0)
+except Exception:
+    sys.exit(1)
+sys.exit(0)' 2>/dev/null; then
+        ready=1
+        break
+    fi
+    sleep 0.1
+done
+[[ "$ready" -eq 1 ]] || { echo "mock HTTP server did not become ready" >&2; exit 1; }
+
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export APL_FEED_SERVER_URL="http://127.0.0.1:18080"
 export APL_FEED_MAX_RETRY_TIME=5
 export AIRPLANES_PACKAGE_MANAGER=apt
 
-bash /workspace/install.sh
-bash /usr/local/share/airplanes/git/update.sh
+if [[ "$TEST_PATH" == "standalone" ]]; then
+    mkdir -p /tmp/standalone
+    cp /workspace/install.sh /tmp/standalone/install.sh
+    bash /tmp/standalone/install.sh
+else
+    bash /workspace/install.sh
+fi
 
+# Post-install assertions (catch install-only regressions before update repairs them).
 test -d /usr/local/share/airplanes/git
 test -x /usr/local/bin/apl-feed
+test -f /etc/airplanes/feed.env
+
+bash /usr/local/share/airplanes/git/update.sh
+
+# Post-update assertions.
 test -f /usr/local/share/airplanes/airplanes-uuid
 test -f /usr/local/share/airplanes/apl-feed/common.sh
 test -f /lib/systemd/system/airplanes-feed.service
 test -f /lib/systemd/system/airplanes-mlat.service
-test -f /etc/airplanes/feed.env
 test -f /etc/airplanes/claim-secret
 test "$(readlink /etc/default/airplanes)" = "/etc/airplanes/feed.env"
 grep -q 'systemctl restart airplanes-feed' /tmp/systemctl.log

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+setup() {
+    CONFIGURE="$BATS_TEST_DIRNAME/../configure.sh"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$STUB_DIR"
+    WHIPTAIL_LOG="$ROOT_DIR/whiptail.log"
+    WHIPTAIL_COUNTER="$ROOT_DIR/whiptail-counter"
+    write_whiptail_stub
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+write_whiptail_stub() {
+    cat > "$STUB_DIR/whiptail" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'whiptail %s\n' "$*" >> "$WHIPTAIL_LOG"
+
+if printf '%s\n' "$@" | grep -q -- '--yesno'; then
+    exit 0
+fi
+
+if printf '%s\n' "$@" | grep -q -- '--inputbox'; then
+    n=0
+    [[ -f "$WHIPTAIL_COUNTER" ]] && n="$(cat "$WHIPTAIL_COUNTER")"
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$WHIPTAIL_COUNTER"
+    value="$(printf '%s' "$WHIPTAIL_INPUTS" | sed -n "${n}p")"
+    printf '%s\n' "$value" >&2
+    exit 0
+fi
+
+# --msgbox and anything else: succeed silently (already logged above).
+exit 0
+SH
+    chmod +x "$STUB_DIR/whiptail"
+}
+
+run_configure() {
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR" \
+        WHIPTAIL_LOG="$WHIPTAIL_LOG" \
+        WHIPTAIL_COUNTER="$WHIPTAIL_COUNTER" \
+        WHIPTAIL_INPUTS="$1" \
+        bash "$CONFIGURE"
+}
+
+@test "configure.sh accepts canonical decimal latitude and longitude" {
+    run_configure $'ci-feeder\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'LATITUDE="52.52000"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'LONGITUDE="13.40500"' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Hardcoded uuid path (F1 fix): no AIRPLANES_ROOT prefix in feed.env.
+    grep -q '\-\-uuid-file /usr/local/share/airplanes/airplanes-uuid' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q 'Invalid latitude' "$WHIPTAIL_LOG"
+    ! grep -q 'Invalid longitude' "$WHIPTAIL_LOG"
+}
+
+@test "configure.sh rejects non-numeric latitude with Invalid msgbox" {
+    run_configure $'ci-feeder\nabc\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    # The "Invalid latitude" msgbox fired during the syntax-invalid attempt.
+    grep -q 'Invalid latitude' "$WHIPTAIL_LOG"
+    # Final value is the valid one, not "abc".
+    grep -q 'LATITUDE="52.52000"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh rejects non-numeric longitude with Invalid msgbox" {
+    run_configure $'ci-feeder\n52.52000\nbad\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'Invalid longitude' "$WHIPTAIL_LOG"
+    grep -q 'LONGITUDE="13.40500"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh accepts +signed latitude (regex broadened in F11 fix)" {
+    run_configure $'ci-feeder\n+52.52\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'LATITUDE="+52.52"' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q 'Invalid latitude' "$WHIPTAIL_LOG"
+}
+
+@test "configure.sh re-prompts silently on out-of-range latitude (regex passes, awk rejects)" {
+    # 91.0 passes the syntax regex but fails the awk range check; the loop
+    # continues without firing the "Invalid latitude" msgbox.
+    run_configure $'ci-feeder\n91.0\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'Invalid latitude' "$WHIPTAIL_LOG"
+    grep -q 'LATITUDE="52.52000"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-prompts silently on out-of-range longitude" {
+    run_configure $'ci-feeder\n52.52000\n181.0\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'Invalid longitude' "$WHIPTAIL_LOG"
+    grep -q 'LONGITUDE="13.40500"' "$ROOT_DIR/etc/airplanes/feed.env"
+}

--- a/test/test_inline_fallback_drift.bats
+++ b/test/test_inline_fallback_drift.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    LIB="$REPO_ROOT/scripts/lib/install-update-common.sh"
+    INSTALL="$REPO_ROOT/install.sh"
+    UPDATE="$REPO_ROOT/update.sh"
+}
+
+# Extract the inline fallback block from install.sh / update.sh — the content
+# between the top-level `else` (column 0) and its matching `fi` (column 0).
+# Internal `fi`s inside function bodies are indented and do not match.
+extract_fallback() {
+    local script="$1"
+    awk '
+        /^else$/ { in_block = 1; next }
+        in_block && /^fi$/ { exit }
+        in_block { print }
+    ' "$script"
+}
+
+# Dump the body of a single function from a script via `declare -f` in a clean subshell.
+function_body() {
+    local source_text="$1"
+    local fn="$2"
+    bash -c '
+        # Source the provided text with a guard so any imperative statements
+        # at the bottom do not run (we only care about function defs).
+        set +e
+        eval "$1"
+        declare -f "$2" 2>/dev/null
+    ' _ "$source_text" "$fn"
+}
+
+@test "install.sh inline fallback shared helpers match lib byte-for-byte" {
+    local stub
+    stub="$(extract_fallback "$INSTALL")"
+    [ -n "$stub" ]
+
+    local lib
+    lib="$(<"$LIB")"
+
+    # install.sh's inline fallback intentionally omits airplanes_init_paths
+    # (covered separately as a strict subset) and the rpm/legacy helpers.
+    for fn in airplanes_path airplanes_require_root airplanes_install_bootstrap_deps getGIT; do
+        local install_body lib_body
+        install_body="$(function_body "$stub" "$fn")"
+        lib_body="$(function_body "$lib" "$fn")"
+        [ -n "$install_body" ]
+        [ -n "$lib_body" ]
+        if [[ "$install_body" != "$lib_body" ]]; then
+            echo "drift in $fn:" >&2
+            diff <(echo "$install_body") <(echo "$lib_body") >&2 || true
+            return 1
+        fi
+    done
+}
+
+@test "install.sh inline airplanes_init_paths is a strict subset of lib" {
+    local stub
+    stub="$(extract_fallback "$INSTALL")"
+
+    local lib
+    lib="$(<"$LIB")"
+
+    local install_body lib_body
+    install_body="$(function_body "$stub" airplanes_init_paths)"
+    lib_body="$(function_body "$lib" airplanes_init_paths)"
+    [ -n "$install_body" ]
+    [ -n "$lib_body" ]
+
+    # Strict subset: every non-trivial line in install.sh's body must also
+    # appear verbatim in lib's body. Lib may have additional path globals.
+    local line
+    while IFS= read -r line; do
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*airplanes_init_paths[[:space:]]*\(\) ]] && continue
+        [[ "${line//[[:space:]]/}" == "{" || "${line//[[:space:]]/}" == "}" ]] && continue
+        if [[ "$lib_body" != *"$line"* ]]; then
+            echo "install.sh init_paths line not present in lib: $line" >&2
+            return 1
+        fi
+    done <<< "$install_body"
+}
+
+@test "update.sh inline fallback shared helpers match lib byte-for-byte" {
+    local stub
+    stub="$(extract_fallback "$UPDATE")"
+    [ -n "$stub" ]
+
+    local lib
+    lib="$(<"$LIB")"
+
+    for fn in \
+        airplanes_path \
+        airplanes_init_paths \
+        airplanes_require_root \
+        airplanes_apt_install \
+        airplanes_is_legacy_os \
+        airplanes_update_packages \
+        airplanes_install_update_deps \
+        revision \
+        getGIT
+    do
+        local update_body lib_body
+        update_body="$(function_body "$stub" "$fn")"
+        lib_body="$(function_body "$lib" "$fn")"
+        [ -n "$update_body" ]
+        [ -n "$lib_body" ]
+        if [[ "$update_body" != "$lib_body" ]]; then
+            echo "drift in $fn:" >&2
+            diff <(echo "$update_body") <(echo "$lib_body") >&2 || true
+            return 1
+        fi
+    done
+}

--- a/test/test_install_script.bats
+++ b/test/test_install_script.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+setup() {
+    INSTALL="$BATS_TEST_DIRNAME/../install.sh"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$STUB_DIR"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+write_stub() {
+    local name="$1"
+    local body="$2"
+    cat > "$STUB_DIR/$name" <<SH
+#!/usr/bin/env bash
+$body
+SH
+    chmod +x "$STUB_DIR/$name"
+}
+
+make_git_repo() {
+    local repo="$1"
+    mkdir -p "$repo"
+    git -C "$repo" init -q -b main
+    git -C "$repo" config user.email test@example.invalid
+    git -C "$repo" config user.name "Test User"
+}
+
+commit_all() {
+    local repo="$1"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m fixture
+}
+
+@test "install.sh reports a clear error when not run as root" {
+    write_stub id 'if [[ "$1" == "-u" ]]; then echo 1000; exit 0; fi; /usr/bin/id "$@"'
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" AIRPLANES_ROOT="$ROOT_DIR" bash "$INSTALL"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "must be ran using sudo or as root" ]]
+}
+
+@test "install.sh fetches configured repo branch and runs setup.sh" {
+    local repo="$ROOT_DIR/source"
+    make_git_repo "$repo"
+    cat > "$repo/setup.sh" <<'SH'
+#!/usr/bin/env bash
+set -e
+mkdir -p "$AIRPLANES_ROOT"
+printf '%s\n' "$PWD" > "$AIRPLANES_ROOT/setup-pwd"
+SH
+    chmod +x "$repo/setup.sh"
+    commit_all "$repo"
+
+    write_stub whiptail 'exit 0'
+    write_stub apt-get 'printf "%s\n" "$@" >> "$APT_GET_LOG"; exit 0'
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR/root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_FEED_REPO="$repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        APT_GET_LOG="$ROOT_DIR/apt-get.log" \
+        bash "$INSTALL"
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/root/setup-pwd" ]
+    [ "$(cat "$ROOT_DIR/root/setup-pwd")" = "$ROOT_DIR/root/usr/local/share/airplanes/git" ]
+    [ "$(git -C "$ROOT_DIR/root/usr/local/share/airplanes/git" remote get-url origin)" = "$repo" ]
+}
+
+@test "standalone install.sh works without scripts/lib checkout" {
+    local repo="$ROOT_DIR/source"
+    local standalone="$ROOT_DIR/standalone"
+    mkdir -p "$standalone"
+    cp "$INSTALL" "$standalone/install.sh"
+    chmod +x "$standalone/install.sh"
+
+    make_git_repo "$repo"
+    cat > "$repo/setup.sh" <<'SH'
+#!/usr/bin/env bash
+set -e
+mkdir -p "$AIRPLANES_ROOT"
+printf '%s\n' "$PWD" > "$AIRPLANES_ROOT/standalone-setup-pwd"
+SH
+    chmod +x "$repo/setup.sh"
+    commit_all "$repo"
+
+    write_stub apt-get 'printf "%s\n" "$@" >> "$APT_GET_LOG"; exit 0'
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR/root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_FEED_REPO="$repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        APT_GET_LOG="$ROOT_DIR/apt-get.log" \
+        bash "$standalone/install.sh"
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/root/standalone-setup-pwd" ]
+    [ "$(cat "$ROOT_DIR/root/standalone-setup-pwd")" = "$ROOT_DIR/root/usr/local/share/airplanes/git" ]
+}

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+
+setup() {
+    HELPER="$BATS_TEST_DIRNAME/../scripts/lib/install-update-common.sh"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$STUB_DIR" "$ROOT_DIR/etc"
+    echo 'VERSION_ID="13"' > "$ROOT_DIR/etc/os-release"
+    export AIRPLANES_ROOT="$ROOT_DIR"
+    # shellcheck source=../scripts/lib/install-update-common.sh
+    source "$HELPER"
+    airplanes_init_paths
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+make_git_repo() {
+    local repo="$1"
+    local branch="${2:-main}"
+    mkdir -p "$repo"
+    git -C "$repo" init -q -b "$branch"
+    git -C "$repo" config user.email test@example.invalid
+    git -C "$repo" config user.name "Test User"
+}
+
+commit_file() {
+    local repo="$1"
+    local path="$2"
+    local content="$3"
+    mkdir -p "$(dirname "$repo/$path")"
+    printf '%s\n' "$content" > "$repo/$path"
+    git -C "$repo" add "$path"
+    git -C "$repo" commit -q -m "write $path"
+}
+
+write_stub() {
+    local name="$1"
+    local body="$2"
+    cat > "$STUB_DIR/$name" <<SH
+#!/usr/bin/env bash
+$body
+SH
+    chmod +x "$STUB_DIR/$name"
+}
+
+write_archive_fallback_stubs() {
+    write_stub wget 'output=""; while [[ $# -gt 0 ]]; do case "$1" in -O) output="$2"; shift 2 ;; *) shift ;; esac; done; printf "%s\n" "zip" > "$output"; exit 0'
+    write_stub unzip 'if [[ "${2:-}" != "-d" ]]; then exit 1; fi; mkdir -p "$3/archive-main"; printf "%s\n" "fallback" > "$3/archive-main/setup.sh"; exit 0'
+}
+
+@test "airplanes_path maps absolute paths under AIRPLANES_ROOT" {
+    [ "$(airplanes_path /etc/airplanes/feed.env)" = "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "getGIT clones the configured branch from a local repository" {
+    local repo="$ROOT_DIR/source"
+    local target="$ROOT_DIR/target"
+    make_git_repo "$repo" main
+    commit_file "$repo" setup.sh "first"
+
+    run getGIT "$repo" main "$target"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$target/setup.sh")" = "first" ]
+    [ "$(git -C "$target" remote get-url origin)" = "$repo" ]
+}
+
+@test "getGIT updates an existing checkout from the same origin" {
+    local repo="$ROOT_DIR/source"
+    local target="$ROOT_DIR/target"
+    make_git_repo "$repo" main
+    commit_file "$repo" setup.sh "first"
+    getGIT "$repo" main "$target"
+    commit_file "$repo" setup.sh "second"
+
+    run getGIT "$repo" main "$target"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$target/setup.sh")" = "second" ]
+}
+
+@test "getGIT falls back to wget archive when git clone fails" {
+    local target="$ROOT_DIR/target"
+    write_stub git 'exit 1'
+    write_archive_fallback_stubs
+    PATH="$STUB_DIR:/usr/bin:/bin"
+    export PATH
+
+    run getGIT "https://example.invalid/feed.git" main "$target"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$target/setup.sh")" = "fallback" ]
+}
+
+@test "getGIT falls back to wget archive when git is unavailable" {
+    local target="$ROOT_DIR/target"
+    write_stub git 'exit 127'
+    write_archive_fallback_stubs
+    PATH="$STUB_DIR:/usr/bin:/bin"
+    export PATH
+
+    run getGIT "https://example.invalid/feed.git" main "$target"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$target/setup.sh")" = "fallback" ]
+}
+
+@test "apt package installer includes Debian package set and netcat fallback" {
+    write_stub apt-get 'printf "%s\n" "$@" >> "$APT_GET_LOG"; exit 0'
+    PATH="$STUB_DIR:/usr/bin:/bin"
+    export PATH APT_GET_LOG="$ROOT_DIR/apt-get.log" AIRPLANES_PACKAGE_MANAGER=apt
+
+    run airplanes_install_update_deps
+
+    [ "$status" -eq 0 ]
+    grep -q -- '--no-install-recommends' "$APT_GET_LOG"
+    grep -q -- 'build-essential' "$APT_GET_LOG"
+    grep -q -- 'pkg-config' "$APT_GET_LOG"
+    grep -q -- 'libzstd-dev' "$APT_GET_LOG"
+}
+
+@test "yum package branch is selectable without apt autodetection" {
+    write_stub yum 'printf "%s\n" "$@" >> "$YUM_LOG"; exit 0'
+    PATH="$STUB_DIR:/usr/bin:/bin"
+    export PATH YUM_LOG="$ROOT_DIR/yum.log" AIRPLANES_PACKAGE_MANAGER=yum
+
+    run airplanes_install_update_deps
+
+    [ "$status" -eq 0 ]
+    grep -q -- 'python3-virtualenv' "$YUM_LOG"
+    grep -q -- 'pkgconfig' "$YUM_LOG"
+    grep -q -- 'libzstd-devel' "$YUM_LOG"
+}
+
+@test "dnf package branch is selectable without apt autodetection" {
+    write_stub dnf 'printf "%s\n" "$@" >> "$DNF_LOG"; exit 0'
+    PATH="$STUB_DIR:/usr/bin:/bin"
+    export PATH DNF_LOG="$ROOT_DIR/dnf.log" AIRPLANES_PACKAGE_MANAGER=dnf
+
+    run airplanes_install_update_deps
+
+    [ "$status" -eq 0 ]
+    grep -q -- 'python3-virtualenv' "$DNF_LOG"
+    grep -q -- 'pkgconf-pkg-config' "$DNF_LOG"
+    grep -q -- 'libzstd-devel' "$DNF_LOG"
+}

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+
+setup() {
+    UPDATE="$BATS_TEST_DIRNAME/../update.sh"
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$STUB_DIR"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+write_stub() {
+    local name="$1"
+    local body="$2"
+    cat > "$STUB_DIR/$name" <<SH
+#!/usr/bin/env bash
+$body
+SH
+    chmod +x "$STUB_DIR/$name"
+}
+
+install_command_stubs() {
+    write_stub apt-get 'printf "apt-get %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    write_stub id 'if [[ "$1" == "-u" && "${2:-}" == "airplanes" ]]; then exit 0; fi; if [[ "$1" == "-u" ]]; then echo 0; exit 0; fi; /usr/bin/id "$@"'
+    write_stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; if [[ "$1" == "restart" && "${2:-}" == "airplanes-feed" && -n "${SYSTEMCTL_FEED_ENV:-}" ]]; then printf "target-at-restart=%s\n" "$(grep "^TARGET=" "$SYSTEMCTL_FEED_ENV")" >> "$COMMAND_LOG"; fi; if [[ "$1" == "is-enabled" ]]; then echo disabled; exit 0; fi; exit 0'
+    write_stub journalctl 'exit 0'
+    write_stub pgrep 'exit 1'
+    write_stub nc 'exit 1'
+    write_stub sleep 'exit 0'
+    write_stub renice 'exit 0'
+    write_stub adduser 'printf "adduser %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    write_stub useradd 'printf "useradd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+}
+
+make_git_repo() {
+    local repo="$1"
+    local branch="${2:-main}"
+    mkdir -p "$repo"
+    git -C "$repo" init -q -b "$branch"
+    git -C "$repo" config user.email test@example.invalid
+    git -C "$repo" config user.name "Test User"
+}
+
+commit_all() {
+    local repo="$1"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m fixture
+}
+
+copy_feed_fixture_repo() {
+    local repo="$1"
+    mkdir -p "$repo"
+    cp -a "$REPO_ROOT/." "$repo/"
+    rm -rf "$repo/.git"
+    make_git_repo "$repo" main
+    commit_all "$repo"
+}
+
+make_component_repo() {
+    local repo="$1"
+    local branch="$2"
+    make_git_repo "$repo" "$branch"
+    printf '%s\n' "$repo" > "$repo/README"
+    commit_all "$repo"
+}
+
+write_feed_env() {
+    local root="$1"
+    mkdir -p "$root/etc/airplanes" "$root/etc/default" "$root/etc"
+    echo 'VERSION_ID="13"' > "$root/etc/os-release"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+USER="0"
+LATITUDE="0"
+LONGITUDE="0"
+ALTITUDE="0"
+MLATSERVER="feed.airplanes.live:31090"
+TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed.airplanes.live,64004"
+NET_OPTIONS="--net-heartbeat 60 --uuid-file /usr/local/share/airplanes/airplanes-uuid"
+EOF
+}
+
+prepare_skip_build_state() {
+    local root="$1"
+    local feed_repo="$2"
+    local mlat_repo="$3"
+    local readsb_repo="$4"
+    local ipath="$root/usr/local/share/airplanes"
+    mkdir -p "$ipath/venv/bin"
+    cp "$feed_repo/update.sh" "$ipath/update.sh"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$ipath/venv/bin/mlat-client"
+    chmod +x "$ipath/venv/bin/mlat-client"
+    git -C "$mlat_repo" rev-parse HEAD > "$ipath/mlat_version"
+    git -C "$readsb_repo" rev-parse HEAD > "$ipath/readsb_version"
+    cat > "$ipath/feed-airplanes" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-V" ]] && exit 0
+exit 0
+SH
+    chmod +x "$ipath/feed-airplanes"
+}
+
+@test "update.sh replaces a missing or stale installed updater before continuing" {
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local ipath="$root/usr/local/share/airplanes"
+    mkdir -p "$feed_repo" "$ipath" "$root/etc"
+    echo 'VERSION_ID="13"' > "$root/etc/os-release"
+    cat > "$feed_repo/update.sh" <<'SH'
+#!/usr/bin/env bash
+set -e
+printf 'self-update-ran\n' > "$AIRPLANES_ROOT/self-update-marker"
+SH
+    chmod +x "$feed_repo/update.sh"
+    make_git_repo "$feed_repo" main
+    commit_all "$feed_repo"
+    printf 'old updater\n' > "$ipath/update.sh"
+
+    run env PATH="/usr/bin:/bin" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=none \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        bash "$UPDATE"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$root/self-update-marker")" = "self-update-ran" ]
+    cmp "$feed_repo/update.sh" "$ipath/update.sh"
+}
+
+@test "update.sh runs setup when no feed env exists" {
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local ipath="$root/usr/local/share/airplanes"
+    mkdir -p "$ipath" "$root/etc"
+    echo 'VERSION_ID="13"' > "$root/etc/os-release"
+    copy_feed_fixture_repo "$feed_repo"
+    cat > "$feed_repo/setup.sh" <<'SH'
+#!/usr/bin/env bash
+set -e
+mkdir -p "$AIRPLANES_ROOT"
+printf 'setup-ran\n' > "$AIRPLANES_ROOT/setup-marker"
+SH
+    chmod +x "$feed_repo/setup.sh"
+    commit_all "$feed_repo"
+    cp "$feed_repo/update.sh" "$ipath/update.sh"
+
+    run env PATH="/usr/bin:/bin" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=none \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        bash "$UPDATE"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$root/setup-marker")" = "setup-ran" ]
+}
+
+@test "update.sh runs configured update path without touching host root" {
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local mlat_repo="$ROOT_DIR/mlat-source"
+    local readsb_repo="$ROOT_DIR/readsb-source"
+    local claim_bin="$ROOT_DIR/apl-feed-stub"
+    local ipath="$root/usr/local/share/airplanes"
+
+    copy_feed_fixture_repo "$feed_repo"
+    make_component_repo "$mlat_repo" master
+    make_component_repo "$readsb_repo" dev
+    write_feed_env "$root"
+    sed -i -e 's/beast_reduce_plus_out/beast_reduce_out/' "$root/etc/airplanes/feed.env"
+    prepare_skip_build_state "$root" "$feed_repo" "$mlat_repo" "$readsb_repo"
+    install_command_stubs
+    cat > "$claim_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAIM_LOG"
+exit 0
+SH
+    chmod +x "$claim_bin"
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        COMMAND_LOG="$ROOT_DIR/commands.log" \
+        CLAIM_LOG="$ROOT_DIR/claim.log" \
+        SYSTEMCTL_FEED_ENV="$root/etc/airplanes/feed.env" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=apt \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        AIRPLANES_MLAT_REPO="$mlat_repo" \
+        AIRPLANES_MLAT_BRANCH=master \
+        AIRPLANES_READSB_REPO="$readsb_repo" \
+        AIRPLANES_READSB_BRANCH=dev \
+        APL_FEED_BIN="$claim_bin" \
+        bash "$UPDATE"
+
+    [ "$status" -eq 0 ]
+    [ -x "$root/usr/local/bin/apl-feed" ]
+    [ -f "$ipath/apl-feed/common.sh" ]
+    [ -f "$root/lib/systemd/system/airplanes-feed.service" ]
+    [ -f "$root/lib/systemd/system/airplanes-mlat.service" ]
+    [ -f "$ipath/airplanes-uuid" ]
+    grep -q 'UAT_INPUT="127.0.0.1:30978"' "$root/etc/airplanes/feed.env"
+    grep -q 'beast_reduce_plus_out,feed.airplanes.live,64004' "$root/etc/airplanes/feed.env"
+    [ -L "$root/etc/default/airplanes" ]
+    [ "$(readlink "$root/etc/default/airplanes")" = "$root/etc/airplanes/feed.env" ]
+    grep -q 'claim register' "$ROOT_DIR/claim.log"
+    grep -q -- '--max-retry-time 15' "$ROOT_DIR/claim.log"
+    grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
+    grep -q 'target-at-restart=TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed.airplanes.live,64004"' "$ROOT_DIR/commands.log"
+}

--- a/update.sh
+++ b/update.sh
@@ -77,7 +77,7 @@ else
 
     airplanes_apt_install() {
         if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
-            apt-get update
+            apt-get update || true
             if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
                 apt-get clean || true
                 apt-get -f install -y || true
@@ -92,7 +92,7 @@ else
 
     airplanes_update_packages() {
         local packages
-        packages="git wget unzip curl jq build-essential pkg-config python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
+        packages="git wget unzip curl jq build-essential pkg-config python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g whiptail mawk"
         if ! airplanes_is_legacy_os; then
             packages+=" libzstd-dev libzstd1"
         fi
@@ -110,10 +110,10 @@ else
             if ! command -v nc &>/dev/null; then
                 airplanes_apt_install netcat-openbsd || true
             fi
-        elif [[ "$package_manager" == "yum" ]] || { [[ "$package_manager" == "auto" ]] && command -v yum &>/dev/null; }; then
-            yum install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconfig ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
         elif [[ "$package_manager" == "dnf" ]] || { [[ "$package_manager" == "auto" ]] && command -v dnf &>/dev/null; }; then
-            dnf install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconf-pkg-config ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
+            dnf install -y git wget unzip curl jq socat python3-virtualenv python3-devel gcc make pkgconf-pkg-config ncurses-devel newt gawk nc uuid zlib-devel zlib libzstd-devel libzstd
+        elif [[ "$package_manager" == "yum" ]] || { [[ "$package_manager" == "auto" ]] && command -v yum &>/dev/null; }; then
+            yum install -y git wget unzip curl jq socat python3-virtualenv python3-devel gcc make pkgconfig ncurses-devel newt gawk nc uuid zlib-devel zlib libzstd-devel libzstd
         elif [[ "$package_manager" != "none" ]]; then
             echo "No supported package manager found; continuing with existing system packages." >&2
         fi
@@ -149,7 +149,9 @@ else
             return 0
         fi
         if wget -O "$tmp" "${repo%".git"}/archive/$branch.zip" && unzip "$tmp" -d "$tmp.folder"; then
-            if mv -fT "$tmp.folder/$(ls "$tmp.folder")" "$target"; then
+            local entries
+            mapfile -t entries < <(find "$tmp.folder" -mindepth 1 -maxdepth 1 -print)
+            if [[ "${#entries[@]}" -eq 1 ]] && mv -fT "${entries[0]}" "$target"; then
                 rm -rf "$tmp" "$tmp.folder"
                 cd "$previous_dir" || return 1
                 return 0
@@ -197,7 +199,7 @@ if [[ -f "$GIT/scripts/lib/install-update-common.sh" ]]; then
     airplanes_init_paths
 fi
 
-if [[ ! -f "$IPATH/update.sh" ]] || ! diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; then
+if [[ "$1" != "test" ]] && { [[ ! -f "$IPATH/update.sh" ]] || ! diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; }; then
     rm -f "$IPATH/update.sh"
     cp "$GIT/update.sh" "$IPATH/update.sh"
     bash "$IPATH/update.sh" "$@"
@@ -217,7 +219,7 @@ if [[ -f "$LEGACY_FEED_ENV" && ! -L "$LEGACY_FEED_ENV" ]]; then
 fi
 
 if [[ -f "$FEED_ENV" ]]; then
-    sed -i -e 's/beast_reduce_out,feed.airplanes.live,64004/beast_reduce_plus_out,feed.airplanes.live,64004/g' "$FEED_ENV" || true
+    sed -i -e 's/beast_reduce_out,/beast_reduce_plus_out,/g' "$FEED_ENV" || true
 fi
 
 if [[ -f "$BOOT_ENV" ]]; then

--- a/update.sh
+++ b/update.sh
@@ -29,101 +29,178 @@
 
 set -e
 trap 'echo "------------"; echo "[ERROR] Error in line $LINENO when executing: $BASH_COMMAND"' ERR
-renice 10 $$ &>/dev/null
+renice 10 $$ &>/dev/null || true
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -f "$SCRIPT_DIR/scripts/lib/install-update-common.sh" ]]; then
+    # shellcheck source=scripts/lib/install-update-common.sh
+    source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+else
+    AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
+    AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
+    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
+
+    airplanes_path() {
+        local path="$1"
+        if [[ "$AIRPLANES_ROOT" == "/" ]]; then
+            printf '%s' "$path"
+        else
+            printf '%s%s' "${AIRPLANES_ROOT%/}" "$path"
+        fi
+    }
+
+    airplanes_init_paths() {
+        IPATH="$(airplanes_path /usr/local/share/airplanes)"
+        GIT="$IPATH/git"
+        LOGFILE="$IPATH/lastlog"
+        BOOT_CONFIG="$(airplanes_path /boot/airplanes-config.txt)"
+        BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
+        ETC_AIRPLANES="$(airplanes_path /etc/airplanes)"
+        FEED_ENV="$ETC_AIRPLANES/feed.env"
+        LEGACY_FEED_ENV="$(airplanes_path /etc/default/airplanes)"
+        LOCAL_BIN="$(airplanes_path /usr/local/bin)"
+        SYSTEMD_DIR="$(airplanes_path /lib/systemd/system)"
+    }
+
+    airplanes_require_root() {
+        if [[ "${AIRPLANES_SKIP_ROOT_CHECK:-0}" == "1" ]]; then
+            return 0
+        fi
+        if [[ "$(id -u)" != "0" ]]; then
+            echo -e "\033[33m"
+            echo "This script must be ran using sudo or as root."
+            echo -e "\033[37m"
+            exit 1
+        fi
+    }
+
+    airplanes_apt_install() {
+        if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
+            apt-get update
+            if ! apt-get install -y --no-install-recommends --no-install-suggests "$@"; then
+                apt-get clean || true
+                apt-get -f install -y || true
+                apt-get install --no-install-recommends --no-install-suggests -y "$@"
+            fi
+        fi
+    }
+
+    airplanes_is_legacy_os() {
+        grep -E 'wheezy|jessie' "$(airplanes_path /etc/os-release)" -qs
+    }
+
+    airplanes_update_packages() {
+        local packages
+        packages="git wget unzip curl jq build-essential pkg-config python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
+        if ! airplanes_is_legacy_os; then
+            packages+=" libzstd-dev libzstd1"
+        fi
+        printf '%s' "$packages"
+    }
+
+    airplanes_install_update_deps() {
+        local packages package_manager
+        packages="$(airplanes_update_packages)"
+        package_manager="${AIRPLANES_PACKAGE_MANAGER:-auto}"
+
+        if [[ "$package_manager" == "apt" ]] || { [[ "$package_manager" == "auto" ]] && command -v apt-get &>/dev/null; }; then
+            # shellcheck disable=SC2086
+            airplanes_apt_install $packages
+            if ! command -v nc &>/dev/null; then
+                airplanes_apt_install netcat-openbsd || true
+            fi
+        elif [[ "$package_manager" == "yum" ]] || { [[ "$package_manager" == "auto" ]] && command -v yum &>/dev/null; }; then
+            yum install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconfig ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
+        elif [[ "$package_manager" == "dnf" ]] || { [[ "$package_manager" == "auto" ]] && command -v dnf &>/dev/null; }; then
+            dnf install -y git curl jq socat python3-virtualenv python3-devel gcc make pkgconf-pkg-config ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
+        elif [[ "$package_manager" != "none" ]]; then
+            echo "No supported package manager found; continuing with existing system packages." >&2
+        fi
+    }
+
+    revision() {
+        git rev-parse HEAD 2>/dev/null || echo "$RANDOM-$RANDOM"
+    }
+
+    getGIT() {
+        local repo branch target tmp previous_dir
+        if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+            echo "getGIT wrong usage, check your script or tell the author!" 1>&2
+            return 1
+        fi
+        repo="$1"
+        branch="$2"
+        target="$3"
+        previous_dir="$(pwd)"
+        tmp="/tmp/getGIT-tmp.$RANDOM.$RANDOM"
+
+        if cd "$target" &>/dev/null && [[ "$(git remote get-url origin)" == "$repo" ]] && git fetch --depth 1 origin "$branch" && git reset --hard FETCH_HEAD; then
+            cd "$previous_dir" || return 1
+            return 0
+        fi
+
+        cd "$previous_dir" || return 1
+        if ! cd /tmp || ! rm -rf "$target"; then
+            return 1
+        fi
+        if git clone --depth 1 --single-branch --branch "$branch" "$repo" "$target"; then
+            cd "$previous_dir" || return 1
+            return 0
+        fi
+        if wget -O "$tmp" "${repo%".git"}/archive/$branch.zip" && unzip "$tmp" -d "$tmp.folder"; then
+            if mv -fT "$tmp.folder/$(ls "$tmp.folder")" "$target"; then
+                rm -rf "$tmp" "$tmp.folder"
+                cd "$previous_dir" || return 1
+                return 0
+            fi
+        fi
+        rm -rf "$tmp" "$tmp.folder"
+        cd "$previous_dir" || return 1
+        return 1
+    }
+fi
 
 if [[ $1 == reinstall ]]; then
     REINSTALL=yes
 fi
 
-if [ "$(id -u)" != "0" ]; then
-    echo -e "\033[33m"
-    echo "This script must be ran using sudo or as root."
-    echo -e "\033[37m"
-    exit 1
-fi
+airplanes_init_paths
+airplanes_require_root
 
-if [ -f /boot/airplanes-config.txt ]; then
+if [[ -f "$BOOT_CONFIG" ]]; then
     echo --------
     echo "You are using the airplanes.live image, the feed setup script does not need to be installed."
     echo --------
     exit 1
 fi
 
-function aptInstall() {
-    if ! apt install -y --no-install-recommends --no-install-suggests "$@"; then
-        apt update
-        if ! apt install -y --no-install-recommends --no-install-suggests "$@"; then
-            apt clean -y || true
-            apt --fix-broken install -y || true
-            apt install --no-install-recommends --no-install-suggests -y $packages
-        fi
-    fi
-}
+mkdir -p "$IPATH"
+rm -f "$LOGFILE"
+touch "$LOGFILE"
 
-
-packages="git wget unzip curl jq build-essential python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
-if ! grep -E 'wheezy|jessie' /etc/os-release -qs; then
-    packages+=" libzstd-dev libzstd1"
-fi
-
-if command -v apt &>/dev/null; then
-    aptInstall $packages
-    if ! command -v nc &>/dev/null; then
-        aptInstall netcat-openbsd || true
-    fi
-elif command -v yum &>/dev/null; then
-    yum install -y git curl jq socat python3-virtualenv python3-devel gcc make ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
-elif command -v dnf &>/dev/null; then
-    dnf install -y git curl jq socat python3-virtualenv python3-devel gcc make ncurses-devel nc uuid zlib-devel zlib libzstd-devel libzstd
-fi
-
+airplanes_install_update_deps
 hash -r
 
-function revision() {
-    git rev-parse HEAD 2>/dev/null || echo "$RANDOM-$RANDOM"
-}
-function getGIT() {
-    # getGIT $REPO $BRANCH $TARGET (directory)
-    echo "--- start getGIT() ---"
-    if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then echo "getGIT wrong usage, check your script or tell the author!" 1>&2; return 1; fi
-    REPO="$1"; BRANCH="$2"; TARGET="$3"; pushd .; tmp=/tmp/getGIT-tmp.$RANDOM.$RANDOM
-    echo "--- 2nd getGIT() ---"
-    if cd "$TARGET" &>/dev/null && [[ $(git remote get-url origin) == "$REPO" ]] && git fetch --depth 1 origin "$BRANCH" && git reset --hard FETCH_HEAD; then popd && return 0; fi
-    popd; if ! cd /tmp || ! rm -rf "$TARGET"; then return 1; fi
-    echo "--- 3rd getGIT() ---"
-    if git clone --depth 1 --single-branch --branch "$2" "$1" "$3"; then return 0; fi
-    echo "--- 4th getGIT() ---"
-    if wget -O "$tmp" "${REPO%".git"}/archive/$BRANCH.zip" && unzip "$tmp" -d "$tmp.folder"; then
-        if mv -fT "$tmp.folder/$(ls $tmp.folder)" "$TARGET"; then rm -rf "$tmp" "$tmp.folder"; return 0; fi
-    fi
-    echo "--- 5th getGIT() ---"
-    rm -rf "$tmp" "$tmp.folder"; return 1
-    echo "--- end getGIT() ---"
-}
-
-REPO="https://github.com/airplanes-live/feed.git"
-BRANCH="main"
-
-IPATH=/usr/local/share/airplanes
-GIT="$IPATH/git"
-mkdir -p $IPATH
-
-LOGFILE="$IPATH/lastlog"
-rm -f $LOGFILE
-touch $LOGFILE
-
 if [[ "$1" == "test" ]]; then
-    cp -T -a ./ /tmp/ax_test
-    GIT=/tmp/ax_test
+    TEST_GIT="${AIRPLANES_TEST_GIT:-/tmp/ax_test}"
+    cp -T -a ./ "$TEST_GIT"
+    GIT="$TEST_GIT"
 else
-    getGIT "$REPO" "$BRANCH" "$GIT" >> $LOGFILE
+    getGIT "$AIRPLANES_FEED_REPO" "$AIRPLANES_FEED_BRANCH" "$GIT" >> "$LOGFILE"
 fi
 cd "$GIT"
 
-if diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; then
+if [[ -f "$GIT/scripts/lib/install-update-common.sh" ]]; then
+    # shellcheck source=scripts/lib/install-update-common.sh
+    source "$GIT/scripts/lib/install-update-common.sh"
+    airplanes_init_paths
+fi
+
+if [[ ! -f "$IPATH/update.sh" ]] || ! diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; then
     rm -f "$IPATH/update.sh"
     cp "$GIT/update.sh" "$IPATH/update.sh"
-    bash "$IPATH/update.sh"
+    bash "$IPATH/update.sh" "$@"
     exit $?
 fi
 
@@ -134,17 +211,21 @@ source "$GIT/scripts/lib/claim-registration.sh"
 
 # Migrate the env file from /etc/default/airplanes to /etc/airplanes/feed.env.
 # Idempotent: only fires when a regular file still exists at the legacy path.
-mkdir -p /etc/airplanes
-if [[ -f /etc/default/airplanes && ! -L /etc/default/airplanes ]]; then
-    cp -fp /etc/default/airplanes /etc/airplanes/feed.env
+mkdir -p "$ETC_AIRPLANES"
+if [[ -f "$LEGACY_FEED_ENV" && ! -L "$LEGACY_FEED_ENV" ]]; then
+    cp -fp "$LEGACY_FEED_ENV" "$FEED_ENV"
 fi
 
-if [ -f /boot/airplanes-env ]; then
-    source /boot/airplanes-env
-else
-    source /etc/airplanes/feed.env
-    if ! grep -qs -e UAT_INPUT /etc/airplanes/feed.env; then
-        cat >> /etc/airplanes/feed.env <<"EOF"
+if [[ -f "$FEED_ENV" ]]; then
+    sed -i -e 's/beast_reduce_out,feed.airplanes.live,64004/beast_reduce_plus_out,feed.airplanes.live,64004/g' "$FEED_ENV" || true
+fi
+
+if [[ -f "$BOOT_ENV" ]]; then
+    source "$BOOT_ENV"
+elif [[ -f "$FEED_ENV" ]]; then
+    source "$FEED_ENV"
+    if ! grep -qs -e UAT_INPUT "$FEED_ENV"; then
+        cat >> "$FEED_ENV" <<"EOF"
 
 # this is the source for 978 data, use port 30978 from dump978 --raw-port
 # if you're not receiving 978, don't worry about it, not doing any harm!
@@ -159,7 +240,6 @@ if [[ -z $INPUT ]] || [[ -z $INPUT_TYPE ]] || [[ -z $USER ]] \
     exit 0
 fi
 
-
 if [[ "$LATITUDE" == 0 ]] || [[ "$LONGITUDE" == 0 ]] || [[ "$USER" == 0 ]]; then
     MLAT_DISABLED=1
 else
@@ -170,8 +250,8 @@ cp "$GIT/uninstall.sh" "$IPATH"
 cp "$GIT"/scripts/*.sh "$IPATH"
 install -d -m 0755 "$IPATH/apl-feed"
 install -m 0644 "$GIT"/scripts/apl-feed/*.sh "$IPATH/apl-feed"
-mkdir -p /usr/local/bin
-install -m 0755 "$GIT/scripts/apl-feed.sh" /usr/local/bin/apl-feed
+mkdir -p "$LOCAL_BIN"
+install -m 0755 "$GIT/scripts/apl-feed.sh" "$LOCAL_BIN/apl-feed"
 
 UNAME=airplanes
 if ! id -u "${UNAME}" &>/dev/null
@@ -190,24 +270,23 @@ sleep 0.25
 # BUILD AND CONFIGURE THE MLAT-CLIENT PACKAGE
 
 echo
-bash "$IPATH/git/create-uuid.sh"
+bash "$GIT/create-uuid.sh"
 
 VENV=$IPATH/venv
-if [[ -f /usr/local/share/airplanes/venv/bin/python3.7 ]] && command -v python3.9 &>/dev/null;
+if [[ -f "$VENV/bin/python3.7" ]] && command -v python3.9 &>/dev/null;
 then
     rm -rf "$VENV"
 fi
 
-
-MLAT_REPO="https://github.com/airplanes-live/mlat-client"
-MLAT_BRANCH="master"
-MLAT_VERSION="$(git ls-remote $MLAT_REPO $MLAT_BRANCH | cut -f1 || echo $RANDOM-$RANDOM )"
-if [[ $REINSTALL != yes ]] && grep -e "$MLAT_VERSION" -qs $IPATH/mlat_version \
+MLAT_REPO="${AIRPLANES_MLAT_REPO:-https://github.com/airplanes-live/mlat-client}"
+MLAT_BRANCH="${AIRPLANES_MLAT_BRANCH:-master}"
+MLAT_VERSION="$(git ls-remote "$MLAT_REPO" "$MLAT_BRANCH" | cut -f1 || echo "$RANDOM-$RANDOM" )"
+if [[ $REINSTALL != yes ]] && grep -e "$MLAT_VERSION" -qs "$IPATH/mlat_version" \
     && grep -qs -e '#!' "$VENV/bin/mlat-client" && { systemctl is-active airplanes-mlat &>/dev/null || [[ "${MLAT_DISABLED}" == "1" ]]; }
 then
     echo
     echo "mlat-client already installed, git hash:"
-    cat $IPATH/mlat_version
+    cat "$IPATH/mlat_version"
     echo
 else
     echo
@@ -217,18 +296,18 @@ else
 
     MLAT_GIT="$IPATH/mlat-client-git"
 
-    # getGIT $REPO $BRANCH $TARGET-DIR
-    getGIT $MLAT_REPO $MLAT_BRANCH $MLAT_GIT &> $LOGFILE
+    # getGIT REPO BRANCH TARGET-DIR
+    getGIT "$MLAT_REPO" "$MLAT_BRANCH" "$MLAT_GIT" &> "$LOGFILE"
 
-    cd $MLAT_GIT
+    cd "$MLAT_GIT"
 
     echo 34
 
     rm "$VENV-backup" -rf
     mv "$VENV" "$VENV-backup" -f &>/dev/null || true
-    if /usr/bin/python3 -m venv $VENV >> $LOGFILE \
+    if /usr/bin/python3 -m venv "$VENV" >> "$LOGFILE" \
         && echo 36 \
-        && source $VENV/bin/activate >> $LOGFILE \
+        && source "$VENV/bin/activate" >> "$LOGFILE" \
         && echo 37 \
         && python3 -c "import setuptools" || python3 -m pip install setuptools \
         && echo 39 \
@@ -237,7 +316,7 @@ else
         && echo 40 \
         && pip install . \
         && echo 46 \
-        && revision > $IPATH/mlat_version || rm -f $IPATH/mlat_version \
+        && revision > "$IPATH/mlat_version" || rm -f "$IPATH/mlat_version" \
         && echo 48 \
     ; then
         rm "$VENV-backup" -rf
@@ -255,7 +334,8 @@ fi
 echo 50
 
 # copy airplanes-mlat service file
-cp "$GIT"/scripts/airplanes-mlat.service /lib/systemd/system
+mkdir -p "$SYSTEMD_DIR"
+cp "$GIT"/scripts/airplanes-mlat.service "$SYSTEMD_DIR"
 
 echo 60
 
@@ -271,7 +351,7 @@ else
         systemctl stop airplanes-mlat || true
     else
         # Enable airplanes-mlat service
-        systemctl enable airplanes-mlat >> $LOGFILE || true
+        systemctl enable airplanes-mlat >> "$LOGFILE" || true
         # Start or restart airplanes-mlat service
         systemctl restart airplanes-mlat || true
     fi
@@ -281,20 +361,20 @@ echo 70
 
 # SETUP FEEDER TO SEND DUMP1090 DATA TO airplanes.live
 
-READSB_REPO="https://github.com/airplanes-live/readsb.git"
-READSB_BRANCH="dev"
-if grep -E 'wheezy|jessie' /etc/os-release -qs; then
+READSB_REPO="${AIRPLANES_READSB_REPO:-https://github.com/airplanes-live/readsb.git}"
+READSB_BRANCH="${AIRPLANES_READSB_BRANCH:-dev}"
+if airplanes_is_legacy_os; then
     READSB_BRANCH="jessie"
 fi
-READSB_VERSION="$(git ls-remote $READSB_REPO $READSB_BRANCH | cut -f1 || echo $RANDOM-$RANDOM )"
+READSB_VERSION="$(git ls-remote "$READSB_REPO" "$READSB_BRANCH" | cut -f1 || echo "$RANDOM-$RANDOM" )"
 READSB_GIT="$IPATH/readsb-git"
 READSB_BIN="$IPATH/feed-airplanes"
-if [[ $REINSTALL != yes ]] && grep -e "$READSB_VERSION" -qs $IPATH/readsb_version \
+if [[ $REINSTALL != yes ]] && grep -e "$READSB_VERSION" -qs "$IPATH/readsb_version" \
     && "$READSB_BIN" -V && systemctl is-active airplanes-feed &>/dev/null
 then
     echo
     echo "Feed client already installed, git hash:"
-    cat $IPATH/readsb_version
+    cat "$IPATH/readsb_version"
     echo
 else
     echo
@@ -304,36 +384,36 @@ else
     #compile readsb
     echo 72
 
-    # getGIT $REPO $BRANCH $TARGET-DIR
-    getGIT "$READSB_REPO" "$READSB_BRANCH" "$READSB_GIT" &> $LOGFILE
+    # getGIT REPO BRANCH TARGET-DIR
+    getGIT "$READSB_REPO" "$READSB_BRANCH" "$READSB_GIT" &> "$LOGFILE"
 
     cd "$READSB_GIT"
-    
-    echo "-----------------------------------------------" 
+
+    echo "-----------------------------------------------"
     echo "Now compiling code can take a few minutes"
     echo "-----------------------------------------------"
 
     echo 74
 
     make clean
-    make -j2 AIRCRAFT_HASH_BITS=12 >> $LOGFILE
+    make -j2 AIRCRAFT_HASH_BITS=12 >> "$LOGFILE"
     echo 80
     rm -f "$READSB_BIN"
     cp readsb "$READSB_BIN"
-    revision > $IPATH/readsb_version || rm -f $IPATH/readsb_version
+    revision > "$IPATH/readsb_version" || rm -f "$IPATH/readsb_version"
 
     echo
 fi
 
 #end compile readsb
 
-cp "$GIT"/scripts/airplanes-feed.service /lib/systemd/system
+cp "$GIT"/scripts/airplanes-feed.service "$SYSTEMD_DIR"
 
 echo 82
 
 if ! is_unit_masked airplanes-feed.service; then
     # Enable airplanes-feed service
-    systemctl enable airplanes-feed >> $LOGFILE || true
+    systemctl enable airplanes-feed >> "$LOGFILE" || true
     echo 92
     # Start or restart airplanes-feed service
     systemctl restart airplanes-feed || true
@@ -348,7 +428,7 @@ fi
 echo 94
 
 systemctl is-active airplanes-feed &>/dev/null || {
-    rm -f $IPATH/readsb_version
+    rm -f "$IPATH/readsb_version"
     echo "---------------------------------"
     journalctl -u airplanes-feed | tail -n10
     echo "---------------------------------"
@@ -360,7 +440,7 @@ systemctl is-active airplanes-feed &>/dev/null || {
 
 echo 96
 [[ "${MLAT_DISABLED}" == "1" ]] || systemctl is-active airplanes-mlat &>/dev/null || {
-    rm -f $IPATH/mlat_version
+    rm -f "$IPATH/mlat_version"
     echo "---------------------------------"
     journalctl -u airplanes-mlat | tail -n10
     echo "---------------------------------"
@@ -374,33 +454,31 @@ register_claim_secret
 
 # Remove old method of starting the feed scripts if present from rc.local
 # Kill the old airplanes.live scripts in case they are still running from a previous install including spawned programs
+RC_LOCAL="$(airplanes_path /etc/rc.local)"
 for name in airplanes-netcat_maint.sh airplanes-socat_maint.sh airplanes-mlat_maint.sh; do
-    if grep -qs -e "$name" /etc/rc.local; then
-        sed -i -e "/$name/d" /etc/rc.local || true
+    if [[ -f "$RC_LOCAL" ]] && grep -qs -e "$name" "$RC_LOCAL"; then
+        sed -i -e "/$name/d" "$RC_LOCAL" || true
     fi
-    if PID="$(pgrep -f "$name" 2>/dev/null)" && PIDS="$PID $(pgrep -P $PID 2>/dev/null)"; then
-        echo killing: $PIDS >> $LOGFILE 2>&1 || true
-        kill -9 $PIDS >> $LOGFILE 2>&1 || true
+    if PID="$(pgrep -f "$name" 2>/dev/null)" && PIDS="$PID $(pgrep -P "$PID" 2>/dev/null)"; then
+        echo killing: "$PIDS" >> "$LOGFILE" 2>&1 || true
+        kill -9 $PIDS >> "$LOGFILE" 2>&1 || true
     fi
 done
 
 # in case the mlat-client service using /etc/default/mlat-client as config is using airplanes.live as a host, disable the service
-if grep -qs 'SERVER_HOSTPORT.*feed.airplanes.live' /etc/default/mlat-client &>/dev/null; then
-    systemctl disable --now mlat-client >> $LOGFILE 2>&1 || true
-fi
-
-if [[ -f /etc/airplanes/feed.env ]]; then
-    sed -i -e 's/feed.airplanes.live,30004,beast_reduce_out,feed.airplanes.live,64004/feed.airplanes.live,30004,beast_reduce_out,feed.airplanes.live,64004/' /etc/airplanes/feed.env || true
+MLAT_CLIENT_DEFAULT="$(airplanes_path /etc/default/mlat-client)"
+if grep -qs 'SERVER_HOSTPORT.*feed.airplanes.live' "$MLAT_CLIENT_DEFAULT" &>/dev/null; then
+    systemctl disable --now mlat-client >> "$LOGFILE" 2>&1 || true
 fi
 
 # Replace the legacy regular file with a compat symlink, only after the
-# services have been restarted using the new path (above). Idempotent —
+# services have been restarted using the new path (above). Idempotent:
 # ln -sfn updates an existing symlink in place.
-if [[ -f /etc/default/airplanes && ! -L /etc/default/airplanes ]]; then
-    rm -f /etc/default/airplanes
+mkdir -p "$(dirname "$LEGACY_FEED_ENV")"
+if [[ -f "$LEGACY_FEED_ENV" && ! -L "$LEGACY_FEED_ENV" ]]; then
+    rm -f "$LEGACY_FEED_ENV"
 fi
-ln -sfn /etc/airplanes/feed.env /etc/default/airplanes
-
+ln -sfn "$FEED_ENV" "$LEGACY_FEED_ENV"
 
 echo 100
 echo "---------------------"
@@ -423,15 +501,15 @@ Web interface to show the data transmitted? Run this command:
 sudo bash /usr/local/share/airplanes/git/install-or-update-interface.sh
 "
 
-INPUT_IP=$(echo $INPUT | cut -d: -f1)
-INPUT_PORT=$(echo $INPUT | cut -d: -f2)
+INPUT_IP=$(echo "$INPUT" | cut -d: -f1)
+INPUT_PORT=$(echo "$INPUT" | cut -d: -f2)
 
 ENDTEXT2="
 ---------------------
 No data available from IP $INPUT_IP on port $INPUT_PORT!
 ---------------------
 "
-if [ -f /etc/fr24feed.ini ] || [ -f /etc/rb24.ini ]; then
+if [[ -f "$(airplanes_path /etc/fr24feed.ini)" ]] || [[ -f "$(airplanes_path /etc/rb24.ini)" ]]; then
     ENDTEXT2+="
 It looks like you are running FR24 or RB24
 This means you will need to install a stand-alone decoder so data are avaible on port 30005!


### PR DESCRIPTION
Adds bats coverage and a Docker-based installer smoke matrix for `install.sh` and `update.sh` — the standalone `curl | bash` path, the `getGIT` wget fallback, and an end-to-end update against a fake `feed.airplanes.live` HTTP endpoint. To make this practical, `install.sh` and `update.sh` now share `scripts/lib/install-update-common.sh` (with inline fallbacks preserved so the standalone path keeps working). CI gates on shellcheck (warning), `bash -n`, and the bats suite; `.shellcheckrc` disables `SC1090`/`SC2034` for the dynamic-source and library-globals patterns intentional throughout the codebase.

Writing the tests surfaced — and this PR also fixes — a handful of latent bugs:

- The `update.sh` migration from `beast_reduce_out` to `beast_reduce_plus_out` (the `_plus_` variant transmits the feeder UUID on connect, so the server can attribute the feed to a specific receiver) was a no-op — `sed` source and replacement were byte-identical — and ran after the service had already restarted with the stale value. Existing feeders kept connecting anonymously and never picked up the new value.
- Package installer used `apt` instead of `apt-get` (Debian documents `apt` as unstable for scripting).
- `source "$FEED_ENV"` was unguarded; a missing config aborted under `set -e` instead of triggering the setup re-run path.
- `configure.sh` accepted any string for latitude/longitude, allowing numeric-prefix garbage to land in a sourced env file.
