### PR TITLE
Switch manual-install connector fallback to feed2.airplanes.live

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -154,7 +154,7 @@ PRIVACY=""
 INPUT_TYPE="$INPUT_TYPE"
 
 MLATSERVER="feed.airplanes.live:31090"
-TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed.airplanes.live,64004"
+TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"
 NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --write-json-every 1 --uuid-file /usr/local/share/airplanes/airplanes-uuid"
 JSON_OPTIONS="--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"
 EOF

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -207,11 +207,11 @@ SH
     [ -f "$root/lib/systemd/system/airplanes-mlat.service" ]
     [ -f "$ipath/airplanes-uuid" ]
     grep -q 'UAT_INPUT="127.0.0.1:30978"' "$root/etc/airplanes/feed.env"
-    grep -q 'beast_reduce_plus_out,feed.airplanes.live,64004' "$root/etc/airplanes/feed.env"
+    grep -q 'beast_reduce_plus_out,feed2.airplanes.live,64004' "$root/etc/airplanes/feed.env"
     [ -L "$root/etc/default/airplanes" ]
     [ "$(readlink "$root/etc/default/airplanes")" = "$root/etc/airplanes/feed.env" ]
     grep -q 'claim register' "$ROOT_DIR/claim.log"
     grep -q -- '--max-retry-time 15' "$ROOT_DIR/claim.log"
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
-    grep -q 'target-at-restart=TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed.airplanes.live,64004"' "$ROOT_DIR/commands.log"
+    grep -q 'target-at-restart=TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"' "$ROOT_DIR/commands.log"
 }

--- a/update.sh
+++ b/update.sh
@@ -220,6 +220,7 @@ fi
 
 if [[ -f "$FEED_ENV" ]]; then
     sed -i -e 's/beast_reduce_out,/beast_reduce_plus_out,/g' "$FEED_ENV" || true
+    sed -i -e 's/beast_reduce_plus_out,feed\.airplanes\.live,64004/beast_reduce_plus_out,feed2.airplanes.live,64004/g' "$FEED_ENV" || true
 fi
 
 if [[ -f "$BOOT_ENV" ]]; then


### PR DESCRIPTION
Manual installs have been writing TARGET with feed.airplanes.live as both the primary and the fallback hostname, while feed2.airplanes.live is the dedicated backup ingest. This change updates configure.sh's literal TARGET line and adds a sed migration in update.sh (mirroring the existing beast_reduce_out → beast_reduce_plus_out migration pattern), so existing feed.env files pick up the new fallback on their next update.sh run.
