### PR TITLE
Support image build mode in feed scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           AIRPLANES_IMAGE_RELEASE_REPO: airplanes-live/image-releases
+          AIRPLANES_IMAGE_CONTRACT: legacy
           AIRPLANES_RELEASE_ROOTFS_WORK_DIR: ${{ runner.temp }}/airplanes-image-release-rootfs-smoke
         run: |
-          sudo --preserve-env=GITHUB_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
+          sudo --preserve-env=GITHUB_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
             bash test/image-release-rootfs-smoke.sh

--- a/.github/workflows/image-boot-smoke.yml
+++ b/.github/workflows/image-boot-smoke.yml
@@ -6,11 +6,23 @@ on:
       image_release_repo:
         description: GitHub repository that publishes the image release
         required: false
-        default: airplanes-live/image-releases
-      image_asset_regex:
-        description: Regex used to select the release asset
+        default: airplanes-live/image
+      image_contract:
+        description: Expected image contract: new or legacy
         required: false
-        default: '(?i)\.(img|img\.xz|img\.gz|zip|7z)$'
+        default: new
+      image_channel:
+        description: Image release channel to select when no explicit regex is provided
+        required: false
+        default: stable
+      image_arch:
+        description: Image architecture to select when no explicit regex is provided
+        required: false
+        default: arm64
+      image_asset_regex:
+        description: Optional regex used to select the release asset
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -51,9 +63,12 @@ jobs:
       - name: Run booted image smoke
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          AIRPLANES_IMAGE_RELEASE_REPO: ${{ github.event.inputs.image_release_repo || 'airplanes-live/image-releases' }}
-          AIRPLANES_IMAGE_ASSET_REGEX: ${{ github.event.inputs.image_asset_regex || '(?i)\.(img|img\.xz|img\.gz|zip|7z)$' }}
+          AIRPLANES_IMAGE_RELEASE_REPO: ${{ github.event.inputs.image_release_repo || 'airplanes-live/image' }}
+          AIRPLANES_IMAGE_CONTRACT: ${{ github.event.inputs.image_contract || 'new' }}
+          AIRPLANES_IMAGE_CHANNEL: ${{ github.event.inputs.image_channel || 'stable' }}
+          AIRPLANES_IMAGE_ARCH: ${{ github.event.inputs.image_arch || 'arm64' }}
+          AIRPLANES_IMAGE_ASSET_REGEX: ${{ github.event.inputs.image_asset_regex || '' }}
           AIRPLANES_BOOT_SMOKE_WORK_DIR: ${{ runner.temp }}/airplanes-image-boot-smoke
         run: |
-          sudo --preserve-env=GITHUB_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_ASSET_REGEX,AIRPLANES_BOOT_SMOKE_WORK_DIR \
+          sudo --preserve-env=GITHUB_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_IMAGE_CHANNEL,AIRPLANES_IMAGE_ARCH,AIRPLANES_IMAGE_ASSET_REGEX,AIRPLANES_BOOT_SMOKE_WORK_DIR \
             bash test/image-boot-smoke.sh

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ curl -L -o /tmp/update.sh https://raw.githubusercontent.com/airplanes-live/feed/
 sudo bash /tmp/update.sh
 ```
 
+## Image Builder Integration
+
+Image builds should use build mode so the rootfs is prepared without touching
+live host services or baking per-device state into the image.
+
+To run the full installer in a chroot, provide placeholder feeder config:
+
+```
+sudo AIRPLANES_BUILD_MODE=1 \
+  AIRPLANES_MLAT_USER=airplanes_initial \
+  AIRPLANES_LATITUDE=0 \
+  AIRPLANES_LONGITUDE=0 \
+  AIRPLANES_ALTITUDE=0 \
+  bash install.sh --build-mode
+```
+
+Build mode still installs packages, writes files, enables systemd units, and
+builds the feed components. It skips service starts/restarts, health checks,
+claim registration, feeder ID generation, legacy process killing, and receiver
+connectivity probing.
+
+Image builders that create `/etc/airplanes/feed.env` themselves can call
+`update.sh --build-mode` directly instead. New images should treat
+`/etc/airplanes/feed.env` as canonical and generate `/etc/airplanes/feeder-id`
+on first boot. Legacy images continue to be supported by the updater through
+the `/boot/airplanes-config.txt`, `/boot/airplanes-env`, and
+`/boot/airplanes-uuid` fallbacks.
+
 ## Local Map
 
 Optional: install a local map interface for your data:

--- a/configure.sh
+++ b/configure.sh
@@ -34,6 +34,7 @@ renice 10 $$ &>/dev/null || true
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/install-update-common.sh
 source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+airplanes_enable_build_mode_from_args "$@"
 airplanes_init_paths
 
 function abort() {
@@ -48,90 +49,54 @@ function abort() {
 
 BACKTITLETEXT="airplanes.live Setup Script"
 
-whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "Thanks for choosing to share your data with airplanes.live!\n\nairplanes.live is a co-op of ADS-B/Mode S/MLAT feeders from around the world. This script will configure your current ADS-B receiver to feed data to airplanes.live.\n\nWould you like to continue setup?" 13 78 || abort
+sanitize_mlat_user() {
+    printf '%s' "$1" | tr -c '[a-zA-Z0-9]_\- ' '_'
+}
 
-ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy)\n\nExample: \"william34-london\", \"william34-jersey\", etc.\nDisable MLAT: enter a zero: 0" 12 78 3>&1 1>&2 2>&3) || abort
+valid_latitude() {
+    [[ "$1" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]] \
+        && awk -v LAT="$1" 'BEGIN { exit !(LAT < 90 && LAT > -90) }'
+}
 
-NOSPACENAME="$(echo -n -e "${ADSBFIUSERNAME}" | tr -c '[a-zA-Z0-9]_\- ' '_')"
+valid_longitude() {
+    [[ "$1" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]] \
+        && awk -v LON="$1" 'BEGIN { exit !(LON < 180 && LON > -180) }'
+}
 
-if [[ "$NOSPACENAME" != 0 ]]; then
-    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
-        --msgbox "For MLAT the precise location of your antenna is required.\
-        \n\nA small error of 15m/45ft will cause issues with MLAT!\
-        \n\nTo get your location, use any online map service or this website: https://www.mapcoordinates.net/en" 12 78 || abort
-else
-    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
-        --msgbox "MLAT DISABLED!.\
-        \n\n For some local functions the approximate location is still useful, it won't be sent to the server." 12 78 || abort
-fi
+valid_altitude() {
+    [[ "$1" =~ ^-?[0-9]+(ft|m)?$ ]]
+}
 
-#((-90 <= RECEIVERLATITUDE <= 90))
-LAT_OK=0
-until [ "$LAT_OK" -eq 1 ]; do
-    RECEIVERLATITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Latitude ${RECEIVERLATITUDE}" --nocancel --inputbox "\nEnter the latitude of your antenna in degrees with 5 decimal places.\n(Example: 32.36291)" 12 78 3>&1 1>&2 2>&3) || abort
-    if [[ "$RECEIVERLATITUDE" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
-        LAT_OK=`awk -v LAT="$RECEIVERLATITUDE" 'BEGIN {printf (LAT<90 && LAT>-90 ? "1" : "0")}'`
+normalize_altitude() {
+    local alt="$1"
+    if [[ $alt =~ ^-([0-9]+)ft$ ]]; then
+        awk -v NUM="${BASH_REMATCH[1]}" 'BEGIN { printf "-%0.2f", NUM / 3.28 }'
+    elif [[ $alt =~ ^-([0-9]+)m$ ]]; then
+        printf -- '-%s' "${BASH_REMATCH[1]}"
     else
-        LAT_OK=0
-        whiptail --backtitle "$BACKTITLETEXT" --title "Invalid latitude" --msgbox "Latitude must be a decimal number." 10 60 || abort
+        printf '%s' "$alt"
     fi
-done
+}
 
+detect_receiver_input() {
+    INPUT="127.0.0.1:30005"
+    INPUT_TYPE="dump1090"
 
-#((-180<= RECEIVERLONGITUDE <= 180))
-LON_OK=0
-until [ "$LON_OK" -eq 1 ]; do
-    RECEIVERLONGITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Longitude ${RECEIVERLONGITUDE}" --nocancel --inputbox "\nEnter the longitude of your antenna in degrees with 5 decimal places.\n(Example: -64.71492)" 12 78 3>&1 1>&2 2>&3) || abort
-    if [[ "$RECEIVERLONGITUDE" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
-        LON_OK=`awk -v LON="$RECEIVERLONGITUDE" 'BEGIN {printf (LON<180 && LON>-180 ? "1" : "0")}'`
-    else
-        LON_OK=0
-        whiptail --backtitle "$BACKTITLETEXT" --title "Invalid longitude" --msgbox "Longitude must be a decimal number." 10 60 || abort
+    # `hostname` and `pgrep` (procps) are absent on some minimal images — guard both.
+    HOSTNAME_VAL="$(hostname 2>/dev/null || uname -n 2>/dev/null || cat /etc/hostname 2>/dev/null || true)"
+    if [[ "$HOSTNAME_VAL" == "radarcape" ]] || { command -v pgrep &>/dev/null && pgrep rcd &>/dev/null; }; then
+        INPUT="127.0.0.1:10003"
+        INPUT_TYPE="radarcape_gps"
     fi
-done
+}
 
-ALT=0
-until [[ "$NOSPACENAME" == 0 ]] || [[ $ALT =~ ^-?[0-9]+ft$ ]] || [[ $ALT =~ ^-?[0-9]+m$ ]]; do
-    ALT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Altitude above sea level (at the antenna):" \
-        --nocancel --inputbox \
-"\nEnter the altitude of your antenna, above sea level, including the unit with no spaces:\n\n\
-in feet like this:                   255ft\n\
-or in meters like this:               78m\n" \
-        12 78 3>&1 1>&2 2>&3) || abort
-done
-
-if [[ $ALT =~ ^-([0-9]+)ft$ ]]; then
-        NUM=${BASH_REMATCH[1]}
-        NEW_ALT=`echo "$NUM" "3.28" | awk '{printf "-%0.2f", $1 / $2 }'`
-        ALT=$NEW_ALT
-fi
-if [[ $ALT =~ ^-([0-9]+)m$ ]]; then
-        NEW_ALT="-${BASH_REMATCH[1]}"
-        ALT=$NEW_ALT
-fi
-
-RECEIVERALTITUDE="$ALT"
-
-#RECEIVERPORT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Receiver Feed Port" --nocancel --inputbox "\nChange only if you were assigned a custom feed port.\nFor most all users it is required this port remain set to port 30005." 10 78 "30005" 3>&1 1>&2 2>&3)
-
-
-
-INPUT="127.0.0.1:30005"
-INPUT_TYPE="dump1090"
-
-# `hostname` and `pgrep` (procps) are absent on some minimal images — guard both.
-HOSTNAME_VAL="$(hostname 2>/dev/null || uname -n 2>/dev/null || cat /etc/hostname 2>/dev/null || true)"
-if [[ "$HOSTNAME_VAL" == "radarcape" ]] || { command -v pgrep &>/dev/null && pgrep rcd &>/dev/null; }; then
-    INPUT="127.0.0.1:10003"
-    INPUT_TYPE="radarcape_gps"
-fi
-
-mkdir -p "$ETC_AIRPLANES"
-tee "$FEED_ENV" >/dev/null <<EOF
+write_feed_env() {
+    mkdir -p "$ETC_AIRPLANES"
+    tee "$FEED_ENV" >/dev/null <<EOF
 INPUT="$INPUT"
 REDUCE_INTERVAL="0.5"
 
-# feed name for checking MLAT sync 
+# feed name for checking MLAT sync
 # also displayed on the MLAT map
 USER="$NOSPACENAME"
 
@@ -158,3 +123,104 @@ TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.ai
 NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --write-json-every 1"
 JSON_OPTIONS="--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"
 EOF
+}
+
+has_noninteractive_config_env() {
+    [[ -v AIRPLANES_MLAT_USER || -v AIRPLANES_LATITUDE || -v AIRPLANES_LONGITUDE || -v AIRPLANES_ALTITUDE ]]
+}
+
+configure_noninteractive() {
+    local missing=0 name
+    for name in AIRPLANES_MLAT_USER AIRPLANES_LATITUDE AIRPLANES_LONGITUDE AIRPLANES_ALTITUDE; do
+        if [[ ! -v "$name" ]]; then
+            echo "Missing required non-interactive configure value: $name" >&2
+            missing=1
+        fi
+    done
+    [[ "$missing" == "0" ]] || exit 1
+
+    ADSBFIUSERNAME="$AIRPLANES_MLAT_USER"
+    NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
+    RECEIVERLATITUDE="$AIRPLANES_LATITUDE"
+    RECEIVERLONGITUDE="$AIRPLANES_LONGITUDE"
+    ALT="$AIRPLANES_ALTITUDE"
+
+    valid_latitude "$RECEIVERLATITUDE" || { echo "Latitude must be a decimal number between -90 and 90." >&2; exit 1; }
+    valid_longitude "$RECEIVERLONGITUDE" || { echo "Longitude must be a decimal number between -180 and 180." >&2; exit 1; }
+    valid_altitude "$ALT" || { echo "Altitude must be an integer with optional ft or m suffix." >&2; exit 1; }
+
+    RECEIVERALTITUDE="$(normalize_altitude "$ALT")"
+    detect_receiver_input
+    write_feed_env
+}
+
+if has_noninteractive_config_env || airplanes_is_build_mode; then
+    configure_noninteractive
+    exit 0
+fi
+
+whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "Thanks for choosing to share your data with airplanes.live!\n\nairplanes.live is a co-op of ADS-B/Mode S/MLAT feeders from around the world. This script will configure your current ADS-B receiver to feed data to airplanes.live.\n\nWould you like to continue setup?" 13 78 || abort
+
+ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy)\n\nExample: \"william34-london\", \"william34-jersey\", etc.\nDisable MLAT: enter a zero: 0" 12 78 3>&1 1>&2 2>&3) || abort
+
+NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
+
+if [[ "$NOSPACENAME" != 0 ]]; then
+    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
+        --msgbox "For MLAT the precise location of your antenna is required.\
+        \n\nA small error of 15m/45ft will cause issues with MLAT!\
+        \n\nTo get your location, use any online map service or this website: https://www.mapcoordinates.net/en" 12 78 || abort
+else
+    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
+        --msgbox "MLAT DISABLED!.\
+        \n\n For some local functions the approximate location is still useful, it won't be sent to the server." 12 78 || abort
+fi
+
+#((-90 <= RECEIVERLATITUDE <= 90))
+LAT_OK=0
+until [ "$LAT_OK" -eq 1 ]; do
+    RECEIVERLATITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Latitude ${RECEIVERLATITUDE}" --nocancel --inputbox "\nEnter the latitude of your antenna in degrees with 5 decimal places.\n(Example: 32.36291)" 12 78 3>&1 1>&2 2>&3) || abort
+    if valid_latitude "$RECEIVERLATITUDE"; then
+        LAT_OK=1
+    else
+        LAT_OK=0
+        if [[ ! "$RECEIVERLATITUDE" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
+            whiptail --backtitle "$BACKTITLETEXT" --title "Invalid latitude" --msgbox "Latitude must be a decimal number." 10 60 || abort
+        fi
+    fi
+done
+
+
+#((-180<= RECEIVERLONGITUDE <= 180))
+LON_OK=0
+until [ "$LON_OK" -eq 1 ]; do
+    RECEIVERLONGITUDE=$(whiptail --backtitle "$BACKTITLETEXT" --title "Antenna Longitude ${RECEIVERLONGITUDE}" --nocancel --inputbox "\nEnter the longitude of your antenna in degrees with 5 decimal places.\n(Example: -64.71492)" 12 78 3>&1 1>&2 2>&3) || abort
+    if valid_longitude "$RECEIVERLONGITUDE"; then
+        LON_OK=1
+    else
+        LON_OK=0
+        if [[ ! "$RECEIVERLONGITUDE" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
+            whiptail --backtitle "$BACKTITLETEXT" --title "Invalid longitude" --msgbox "Longitude must be a decimal number." 10 60 || abort
+        fi
+    fi
+done
+
+ALT=0
+until [[ "$NOSPACENAME" == 0 ]] || [[ $ALT =~ ^-?[0-9]+ft$ ]] || [[ $ALT =~ ^-?[0-9]+m$ ]]; do
+    ALT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Altitude above sea level (at the antenna):" \
+        --nocancel --inputbox \
+"\nEnter the altitude of your antenna, above sea level, including the unit with no spaces:\n\n\
+in feet like this:                   255ft\n\
+or in meters like this:               78m\n" \
+        12 78 3>&1 1>&2 2>&3) || abort
+done
+
+ALT="$(normalize_altitude "$ALT")"
+
+RECEIVERALTITUDE="$ALT"
+
+#RECEIVERPORT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Receiver Feed Port" --nocancel --inputbox "\nChange only if you were assigned a custom feed port.\nFor most all users it is required this port remain set to port 30005." 10 78 "30005" 3>&1 1>&2 2>&3)
+
+
+detect_receiver_input
+write_feed_env

--- a/create-uuid.sh
+++ b/create-uuid.sh
@@ -5,7 +5,13 @@ set -e
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/install-update-common.sh
 source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+airplanes_enable_build_mode_from_args "$@"
 airplanes_init_paths
+
+if airplanes_is_build_mode; then
+    echo "Build mode: skipping per-device feeder ID generation."
+    exit 0
+fi
 
 valid_uuid() {
     [[ "$1" =~ ^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$ ]]

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,20 @@ else
         GIT="$IPATH/git"
     }
 
+    airplanes_is_build_mode() {
+        [[ "${AIRPLANES_BUILD_MODE:-0}" == "1" || "${AIRPLANES_BUILD_MODE:-}" == "true" || "${AIRPLANES_BUILD_MODE:-}" == "yes" ]]
+    }
+
+    airplanes_enable_build_mode_from_args() {
+        local arg
+        for arg in "$@"; do
+            if [[ "$arg" == "--build-mode" ]]; then
+                AIRPLANES_BUILD_MODE=1
+                export AIRPLANES_BUILD_MODE
+            fi
+        done
+    }
+
     airplanes_require_root() {
         if [[ "${AIRPLANES_SKIP_ROOT_CHECK:-0}" == "1" ]]; then
             return 0
@@ -84,6 +98,8 @@ else
     }
 fi
 
+airplanes_enable_build_mode_from_args "$@"
+
 airplanes_init_paths
 airplanes_require_root
 mkdir -p "$IPATH"
@@ -91,4 +107,4 @@ airplanes_install_bootstrap_deps
 getGIT "$AIRPLANES_FEED_REPO" "$AIRPLANES_FEED_BRANCH" "$GIT"
 
 cd "$GIT"
-bash "$GIT/setup.sh"
+bash "$GIT/setup.sh" "$@"

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -40,6 +40,20 @@ airplanes_image_target_default() {
     printf '%s' '--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004'
 }
 
+airplanes_is_build_mode() {
+    [[ "${AIRPLANES_BUILD_MODE:-0}" == "1" || "${AIRPLANES_BUILD_MODE:-}" == "true" || "${AIRPLANES_BUILD_MODE:-}" == "yes" ]]
+}
+
+airplanes_enable_build_mode_from_args() {
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == "--build-mode" ]]; then
+            AIRPLANES_BUILD_MODE=1
+            export AIRPLANES_BUILD_MODE
+        fi
+    done
+}
+
 airplanes_require_root() {
     if [[ "${AIRPLANES_SKIP_ROOT_CHECK:-0}" == "1" ]]; then
         return 0

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,7 @@ set -e
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/install-update-common.sh
 source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+airplanes_enable_build_mode_from_args "$@"
 airplanes_init_paths
 
 ## we need to install stuff that require root, check for that
@@ -39,7 +40,7 @@ airplanes_require_root
 
 ## REFUSE INSTALLATION ON AIRPLANES.LIVE IMAGE
 
-if airplanes_is_image_install; then
+if ! airplanes_is_build_mode && airplanes_is_image_install; then
     echo --------
     echo "You are using the airplanes.live image, the feed setup script does not need to be installed."
     echo "You should already be feeding."
@@ -53,11 +54,13 @@ if airplanes_is_image_install; then
     exit 1
 fi
 
-bash "$IPATH/git/configure.sh"
+bash "$IPATH/git/configure.sh" "$@"
 
 BACKTITLETEXT="${BACKTITLETEXT:-airplanes.live Setup Script}"
-whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "We are now ready to begin setting up your receiver to feed airplanes.live.\n\nDo you wish to proceed?" 9 78 || exit 1
+if ! airplanes_is_build_mode; then
+    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "We are now ready to begin setting up your receiver to feed airplanes.live.\n\nDo you wish to proceed?" 9 78 || exit 1
+fi
 
-bash "$IPATH/git/update.sh"
+bash "$IPATH/git/update.sh" "$@"
 
 exit 0

--- a/test/image-boot-smoke.sh
+++ b/test/image-boot-smoke.sh
@@ -6,8 +6,28 @@ if [[ "$(id -u)" != "0" ]]; then
 fi
 
 FEED_DIR="${AIRPLANES_FEED_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
-IMAGE_RELEASE_REPO="${AIRPLANES_IMAGE_RELEASE_REPO:-airplanes-live/image-releases}"
-IMAGE_ASSET_REGEX="${AIRPLANES_IMAGE_ASSET_REGEX:-(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$}"
+IMAGE_RELEASE_REPO="${AIRPLANES_IMAGE_RELEASE_REPO:-airplanes-live/image}"
+IMAGE_CHANNEL="${AIRPLANES_IMAGE_CHANNEL:-stable}"
+IMAGE_ARCH="${AIRPLANES_IMAGE_ARCH:-arm64}"
+IMAGE_CONTRACT="${AIRPLANES_IMAGE_CONTRACT:-}"
+if [[ -z "$IMAGE_CONTRACT" ]]; then
+    if [[ "$IMAGE_RELEASE_REPO" == "airplanes-live/image" ]]; then
+        IMAGE_CONTRACT="new"
+    else
+        IMAGE_CONTRACT="legacy"
+    fi
+fi
+if [[ -n "${AIRPLANES_IMAGE_ASSET_REGEX:-}" ]]; then
+    IMAGE_ASSET_REGEX="$AIRPLANES_IMAGE_ASSET_REGEX"
+elif [[ "$IMAGE_CONTRACT" == "new" ]]; then
+    IMAGE_ASSET_REGEX="(?i)^airplanes-feeder-${IMAGE_CHANNEL}-${IMAGE_ARCH}\\.img\\.xz$"
+else
+    IMAGE_ASSET_REGEX="(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$"
+fi
+IMAGE_ASSET_STRICT="${AIRPLANES_IMAGE_ASSET_STRICT:-}"
+if [[ -z "$IMAGE_ASSET_STRICT" ]]; then
+    [[ "$IMAGE_CONTRACT" == "new" ]] && IMAGE_ASSET_STRICT=1 || IMAGE_ASSET_STRICT=0
+fi
 FEED_BRANCH="${AIRPLANES_BOOT_SMOKE_FEED_BRANCH:-boot-smoke}"
 QEMU_TIMEOUT="${AIRPLANES_BOOT_SMOKE_QEMU_TIMEOUT:-8m}"
 MAX_BOOT_ATTEMPTS="${AIRPLANES_BOOT_SMOKE_MAX_BOOT_ATTEMPTS:-2}"
@@ -116,12 +136,24 @@ github_api() {
 }
 
 download_latest_release_image() {
-    local release_json asset_name asset_url output
+    local release_json asset_name asset_url output match_count
     mkdir -p "$DOWNLOAD_DIR"
     release_json="$DOWNLOAD_DIR/latest-release.json"
 
     echo "Fetching latest image release from $IMAGE_RELEASE_REPO" >&2
     github_api "https://api.github.com/repos/$IMAGE_RELEASE_REPO/releases/latest" > "$release_json"
+
+    match_count="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
+        [.assets[] | select(.name | test($re))] | length
+    ' "$release_json")"
+    if [[ "$match_count" == "0" ]]; then
+        jq -r '.assets[].name' "$release_json" >&2
+        fail "no release asset in $IMAGE_RELEASE_REPO matched $IMAGE_ASSET_REGEX"
+    fi
+    if [[ "$IMAGE_ASSET_STRICT" == "1" && "$match_count" != "1" ]]; then
+        jq -r --arg re "$IMAGE_ASSET_REGEX" '.assets[] | select(.name | test($re)) | .name' "$release_json" >&2
+        fail "expected exactly one release asset in $IMAGE_RELEASE_REPO to match $IMAGE_ASSET_REGEX, got $match_count"
+    fi
 
     asset_name="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
         [.assets[] | select(.name | test($re))] as $matches
@@ -132,10 +164,7 @@ download_latest_release_image() {
         .assets[] | select(.name == $name) | .browser_download_url
     ' "$release_json")"
 
-    [[ -n "$asset_name" && -n "$asset_url" ]] || {
-        jq -r '.assets[].name' "$release_json" >&2
-        fail "no release asset in $IMAGE_RELEASE_REPO matched $IMAGE_ASSET_REGEX"
-    }
+    [[ -n "$asset_name" && -n "$asset_url" ]] || fail "failed to resolve selected release asset URL: $asset_name"
 
     output="$DOWNLOAD_DIR/$asset_name"
     echo "Downloading image asset: $asset_name" >&2
@@ -413,6 +442,7 @@ write_guest_probe() {
     rsync -a --delete "$FEED_SOURCE/" "$ROOT_MNT/opt/airplanes-boot-smoke/feed-worktree/"
     rsync -a --delete "$FEED_BARE/" "$ROOT_MNT/opt/airplanes-boot-smoke/feed.git/"
     rsync -a --delete "$MLAT_BARE/" "$ROOT_MNT/opt/airplanes-boot-smoke/mlat.git/"
+    printf '%s\n' "$IMAGE_CONTRACT" > "$ROOT_MNT/opt/airplanes-boot-smoke/image-contract"
 
     cat > "$ROOT_MNT/opt/airplanes-boot-smoke/apl-feed-stub" <<'GUEST'
 #!/usr/bin/env bash
@@ -428,6 +458,7 @@ GUEST
 set -euo pipefail
 
 STATE_DIR=/var/lib/airplanes-boot-smoke
+IMAGE_CONTRACT="$(cat /opt/airplanes-boot-smoke/image-contract 2>/dev/null || echo legacy)"
 mkdir -p "$STATE_DIR"
 exec > >(tee -a "$STATE_DIR/run.log" /dev/console) 2>&1
 
@@ -473,8 +504,12 @@ assert_symlink_target() {
 }
 
 assert_image_contracts() {
-    assert_file /boot/airplanes-config.txt
-    assert_file /boot/airplanes-env
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        assert_file /boot/airplanes-config.txt
+        assert_file /boot/airplanes-env
+    else
+        assert_file /etc/airplanes/feed.env
+    fi
     assert_valid_uuid_file /etc/airplanes/feeder-id
     assert_symlink_target /usr/local/share/airplanes/airplanes-uuid '../../../../etc/airplanes/feeder-id'
     assert_exec /usr/bin/airplanes-feeder
@@ -486,17 +521,17 @@ assert_image_contracts() {
     assert_file /etc/systemd/system/airplanes-feed.service
     assert_file /etc/systemd/system/airplanes-mlat.service
     assert_file /etc/systemd/system/airplanes-first-run.service
-    assert_contains /etc/systemd/system/airplanes-feed.service 'EnvironmentFile=/boot/airplanes-config.txt'
     assert_contains /etc/systemd/system/airplanes-feed.service 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh'
     assert_contains /etc/systemd/system/airplanes-feed.service 'After=airplanes-first-run.service'
-    assert_contains /etc/systemd/system/airplanes-mlat.service 'EnvironmentFile=/boot/airplanes-config.txt'
     assert_contains /etc/systemd/system/airplanes-mlat.service 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh'
     assert_contains /etc/systemd/system/airplanes-mlat.service 'After=airplanes-first-run.service'
     assert_contains /usr/local/share/airplanes/airplanes-feed.sh 'feed2.airplanes.live,64004'
-    assert_not_exists /etc/airplanes/feed.env
-    [[ -L /etc/default/airplanes ]] || fail "/etc/default/airplanes is not a symlink"
-    [[ "$(readlink /etc/default/airplanes)" == "/boot/airplanes-config.txt" ]] \
-        || fail "/etc/default/airplanes does not point at /boot/airplanes-config.txt"
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        assert_not_exists /etc/airplanes/feed.env
+        [[ -L /etc/default/airplanes ]] || fail "/etc/default/airplanes is not a symlink"
+        [[ "$(readlink /etc/default/airplanes)" == "/boot/airplanes-config.txt" ]] \
+            || fail "/etc/default/airplanes does not point at /boot/airplanes-config.txt"
+    fi
 }
 
 prepare_mlat_fixture() {

--- a/test/image-boot-smoke.sh
+++ b/test/image-boot-smoke.sh
@@ -50,6 +50,8 @@ FEED_SOURCE="$WORK_DIR/feed-source"
 FEED_BARE="$WORK_DIR/feed.git"
 MLAT_SOURCE="$WORK_DIR/mlat-source"
 MLAT_BARE="$WORK_DIR/mlat.git"
+READSB_SOURCE="$WORK_DIR/readsb-source"
+READSB_BARE="$WORK_DIR/readsb.git"
 
 cleanup() {
     set +e
@@ -295,6 +297,18 @@ make_mlat_repo() {
     git clone --quiet --bare "$MLAT_SOURCE" "$MLAT_BARE"
 }
 
+make_readsb_repo() {
+    rm -rf "$READSB_SOURCE" "$READSB_BARE"
+    mkdir -p "$READSB_SOURCE"
+    git -C "$READSB_SOURCE" init -q -b dev
+    git -C "$READSB_SOURCE" config user.email "boot-smoke@example.invalid"
+    git -C "$READSB_SOURCE" config user.name "Image Boot Smoke"
+    printf '%s\n' "readsb fixture" > "$READSB_SOURCE/README"
+    git -C "$READSB_SOURCE" add README
+    git -C "$READSB_SOURCE" commit -q -m "readsb fixture"
+    git clone --quiet --bare "$READSB_SOURCE" "$READSB_BARE"
+}
+
 copy_boot_file() {
     local name="$1"
     [[ -f "$BOOT_MNT/$name" ]] || fail "boot file missing: $name"
@@ -442,6 +456,7 @@ write_guest_probe() {
     rsync -a --delete "$FEED_SOURCE/" "$ROOT_MNT/opt/airplanes-boot-smoke/feed-worktree/"
     rsync -a --delete "$FEED_BARE/" "$ROOT_MNT/opt/airplanes-boot-smoke/feed.git/"
     rsync -a --delete "$MLAT_BARE/" "$ROOT_MNT/opt/airplanes-boot-smoke/mlat.git/"
+    rsync -a --delete "$READSB_BARE/" "$ROOT_MNT/opt/airplanes-boot-smoke/readsb.git/"
     printf '%s\n' "$IMAGE_CONTRACT" > "$ROOT_MNT/opt/airplanes-boot-smoke/image-contract"
 
     cat > "$ROOT_MNT/opt/airplanes-boot-smoke/apl-feed-stub" <<'GUEST'
@@ -512,7 +527,11 @@ assert_image_contracts() {
     fi
     assert_valid_uuid_file /etc/airplanes/feeder-id
     assert_symlink_target /usr/local/share/airplanes/airplanes-uuid '../../../../etc/airplanes/feeder-id'
-    assert_exec /usr/bin/airplanes-feeder
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        assert_exec /usr/bin/airplanes-feeder
+    else
+        assert_exec /usr/local/share/airplanes/feed-airplanes
+    fi
     assert_exec /usr/local/bin/apl-feed
     assert_file /usr/local/share/airplanes/update.sh
     assert_file /usr/local/share/airplanes/airplanes-feed.sh
@@ -548,8 +567,23 @@ SH
     printf '%s\n' "$mlat_version" > /usr/local/share/airplanes/mlat_version
 }
 
+prepare_readsb_fixture() {
+    local readsb_version
+    install -d -m 0755 /usr/local/share/airplanes
+    if [[ ! -x /usr/bin/airplanes-feeder && ! -x /usr/local/share/airplanes/feed-airplanes ]]; then
+        cat > /usr/local/share/airplanes/feed-airplanes <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+        chmod 0755 /usr/local/share/airplanes/feed-airplanes
+    fi
+    readsb_version="$(git --git-dir=/opt/airplanes-boot-smoke/readsb.git rev-parse refs/heads/dev)"
+    printf '%s\n' "$readsb_version" > /usr/local/share/airplanes/readsb_version
+}
+
 run_feed_update() {
     prepare_mlat_fixture
+    prepare_readsb_fixture
     APL_FEED_BIN=/opt/airplanes-boot-smoke/apl-feed-stub \
     APL_FEED_MAX_RETRY_TIME=1 \
     AIRPLANES_PACKAGE_MANAGER=none \
@@ -557,6 +591,8 @@ run_feed_update() {
     AIRPLANES_FEED_BRANCH=boot-smoke \
     AIRPLANES_MLAT_REPO=file:///opt/airplanes-boot-smoke/mlat.git \
     AIRPLANES_MLAT_BRANCH=master \
+    AIRPLANES_READSB_REPO=file:///opt/airplanes-boot-smoke/readsb.git \
+    AIRPLANES_READSB_BRANCH=dev \
         bash /opt/airplanes-boot-smoke/feed-worktree/update.sh
 }
 
@@ -730,6 +766,7 @@ main() {
     resize_image_for_qemu_sd
     make_feed_repo
     make_mlat_repo
+    make_readsb_repo
 
     mount_partitions
     prepare_boot_files

--- a/test/image-release-rootfs-smoke.sh
+++ b/test/image-release-rootfs-smoke.sh
@@ -7,7 +7,27 @@ fi
 
 FEED_DIR="${AIRPLANES_FEED_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
 IMAGE_RELEASE_REPO="${AIRPLANES_IMAGE_RELEASE_REPO:-airplanes-live/image-releases}"
-IMAGE_ASSET_REGEX="${AIRPLANES_IMAGE_ASSET_REGEX:-(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$}"
+IMAGE_CHANNEL="${AIRPLANES_IMAGE_CHANNEL:-stable}"
+IMAGE_ARCH="${AIRPLANES_IMAGE_ARCH:-arm64}"
+IMAGE_CONTRACT="${AIRPLANES_IMAGE_CONTRACT:-}"
+if [[ -z "$IMAGE_CONTRACT" ]]; then
+    if [[ "$IMAGE_RELEASE_REPO" == "airplanes-live/image" ]]; then
+        IMAGE_CONTRACT="new"
+    else
+        IMAGE_CONTRACT="legacy"
+    fi
+fi
+if [[ -n "${AIRPLANES_IMAGE_ASSET_REGEX:-}" ]]; then
+    IMAGE_ASSET_REGEX="$AIRPLANES_IMAGE_ASSET_REGEX"
+elif [[ "$IMAGE_CONTRACT" == "new" ]]; then
+    IMAGE_ASSET_REGEX="(?i)^airplanes-feeder-${IMAGE_CHANNEL}-${IMAGE_ARCH}\\.img\\.xz$"
+else
+    IMAGE_ASSET_REGEX="(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$"
+fi
+IMAGE_ASSET_STRICT="${AIRPLANES_IMAGE_ASSET_STRICT:-}"
+if [[ -z "$IMAGE_ASSET_STRICT" ]]; then
+    [[ "$IMAGE_CONTRACT" == "new" ]] && IMAGE_ASSET_STRICT=1 || IMAGE_ASSET_STRICT=0
+fi
 FEED_BRANCH="${AIRPLANES_RELEASE_ROOTFS_FEED_BRANCH:-release-rootfs-smoke}"
 WORK_DIR="${AIRPLANES_RELEASE_ROOTFS_WORK_DIR:-}"
 KEEP_WORK_DIR="${AIRPLANES_RELEASE_ROOTFS_KEEP_WORK_DIR:-0}"
@@ -83,12 +103,24 @@ github_api() {
 }
 
 download_latest_release_image() {
-    local release_json asset_name asset_url output
+    local release_json asset_name asset_url output match_count
     mkdir -p "$DOWNLOAD_DIR"
     release_json="$DOWNLOAD_DIR/latest-release.json"
 
     echo "Fetching latest image release from $IMAGE_RELEASE_REPO" >&2
     github_api "https://api.github.com/repos/$IMAGE_RELEASE_REPO/releases/latest" > "$release_json"
+
+    match_count="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
+        [.assets[] | select(.name | test($re))] | length
+    ' "$release_json")"
+    if [[ "$match_count" == "0" ]]; then
+        jq -r '.assets[].name' "$release_json" >&2
+        fail "no release asset in $IMAGE_RELEASE_REPO matched $IMAGE_ASSET_REGEX"
+    fi
+    if [[ "$IMAGE_ASSET_STRICT" == "1" && "$match_count" != "1" ]]; then
+        jq -r --arg re "$IMAGE_ASSET_REGEX" '.assets[] | select(.name | test($re)) | .name' "$release_json" >&2
+        fail "expected exactly one release asset in $IMAGE_RELEASE_REPO to match $IMAGE_ASSET_REGEX, got $match_count"
+    fi
 
     asset_name="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
         [.assets[] | select(.name | test($re))] as $matches
@@ -99,10 +131,7 @@ download_latest_release_image() {
         .assets[] | select(.name == $name) | .browser_download_url
     ' "$release_json")"
 
-    [[ -n "$asset_name" && -n "$asset_url" ]] || {
-        jq -r '.assets[].name' "$release_json" >&2
-        fail "no release asset in $IMAGE_RELEASE_REPO matched $IMAGE_ASSET_REGEX"
-    }
+    [[ -n "$asset_name" && -n "$asset_url" ]] || fail "failed to resolve selected release asset URL: $asset_name"
 
     output="$DOWNLOAD_DIR/$asset_name"
     echo "Downloading image asset: $asset_name" >&2
@@ -314,16 +343,24 @@ prepare_mounted_image() {
     local ipath mlat_version
     ipath="$ROOT_MNT/usr/local/share/airplanes"
 
-    require_feed_boot_file airplanes-config.txt
-    require_feed_boot_file airplanes-env
     [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "release image lacks /usr/bin/airplanes-feeder"
     [[ -f "$ROOT_MNT/etc/systemd/system/airplanes-first-run.service" ]] \
         || fail "release image lacks airplanes-first-run.service"
 
-    set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" USER "image-release-rootfs-smoke"
-    set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" LATITUDE "52.52000"
-    set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" LONGITUDE "13.40500"
-    set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" ALTITUDE "35m"
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        require_feed_boot_file airplanes-config.txt
+        require_feed_boot_file airplanes-env
+        set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" USER "image-release-rootfs-smoke"
+        set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" LATITUDE "52.52000"
+        set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" LONGITUDE "13.40500"
+        set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" ALTITUDE "35m"
+    else
+        [[ -f "$ROOT_MNT/etc/airplanes/feed.env" ]] || fail "new image lacks /etc/airplanes/feed.env"
+        set_env_value "$ROOT_MNT/etc/airplanes/feed.env" USER "image-release-rootfs-smoke"
+        set_env_value "$ROOT_MNT/etc/airplanes/feed.env" LATITUDE "52.52000"
+        set_env_value "$ROOT_MNT/etc/airplanes/feed.env" LONGITUDE "13.40500"
+        set_env_value "$ROOT_MNT/etc/airplanes/feed.env" ALTITUDE "35m"
+    fi
 
     mkdir -p "$ipath/venv/bin"
     cat > "$ipath/venv/bin/mlat-client" <<'SH'
@@ -336,17 +373,25 @@ SH
 }
 
 run_update_against_image() {
-    PATH="$STUB_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-    COMMAND_LOG="$COMMAND_LOG" \
-    CLAIM_LOG="$CLAIM_LOG" \
-    AIRPLANES_ROOT="$ROOT_MNT" \
-    AIRPLANES_SKIP_ROOT_CHECK=1 \
-    AIRPLANES_PACKAGE_MANAGER=apt \
-    AIRPLANES_FEED_REPO="file://$FEED_BARE" \
-    AIRPLANES_FEED_BRANCH="$FEED_BRANCH" \
-    AIRPLANES_MLAT_REPO="file://$MLAT_BARE" \
-    AIRPLANES_MLAT_BRANCH=master \
-    APL_FEED_BIN="$STUB_DIR/apl-feed-stub" \
+    local -a build_mode_env
+    build_mode_env=()
+    if [[ "$IMAGE_CONTRACT" == "new" ]]; then
+        build_mode_env=(AIRPLANES_BUILD_MODE=1)
+    fi
+
+    env \
+        PATH="$STUB_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+        COMMAND_LOG="$COMMAND_LOG" \
+        CLAIM_LOG="$CLAIM_LOG" \
+        AIRPLANES_ROOT="$ROOT_MNT" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=apt \
+        AIRPLANES_FEED_REPO="file://$FEED_BARE" \
+        AIRPLANES_FEED_BRANCH="$FEED_BRANCH" \
+        AIRPLANES_MLAT_REPO="file://$MLAT_BARE" \
+        AIRPLANES_MLAT_BRANCH=master \
+        APL_FEED_BIN="$STUB_DIR/apl-feed-stub" \
+        "${build_mode_env[@]}" \
         bash "$FEED_SOURCE/update.sh"
 }
 
@@ -389,10 +434,16 @@ assert_symlink_target() {
 assert_updated_image_contracts() {
     local ipath="$ROOT_MNT/usr/local/share/airplanes"
 
-    [[ -f "$FEED_BOOT_DIR/airplanes-config.txt" ]] || fail "missing boot config"
-    [[ -f "$FEED_BOOT_DIR/airplanes-env" ]] || fail "missing boot env"
-    assert_valid_uuid_file "$ROOT_MNT/etc/airplanes/feeder-id"
-    assert_symlink_target "$ipath/airplanes-uuid" '../../../../etc/airplanes/feeder-id'
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        [[ -f "$FEED_BOOT_DIR/airplanes-config.txt" ]] || fail "missing boot config"
+        [[ -f "$FEED_BOOT_DIR/airplanes-env" ]] || fail "missing boot env"
+        assert_valid_uuid_file "$ROOT_MNT/etc/airplanes/feeder-id"
+        assert_symlink_target "$ipath/airplanes-uuid" '../../../../etc/airplanes/feeder-id'
+    else
+        [[ -f "$ROOT_MNT/etc/airplanes/feed.env" ]] || fail "missing canonical feed.env"
+        assert_not_exists "$ROOT_MNT/etc/airplanes/feeder-id"
+        assert_not_exists "$ipath/airplanes-uuid"
+    fi
     [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "missing image feed binary"
     [[ -x "$ROOT_MNT/usr/local/bin/apl-feed" ]] || fail "missing apl-feed command"
     [[ -f "$ipath/update.sh" ]] || fail "missing installed update.sh"
@@ -402,21 +453,32 @@ assert_updated_image_contracts() {
     [[ -f "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" ]] || fail "missing feed service"
     [[ -f "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" ]] || fail "missing mlat service"
     [[ -f "$ROOT_MNT/etc/systemd/system/airplanes-first-run.service" ]] || fail "missing first-run service"
-    assert_not_exists "$ROOT_MNT/etc/airplanes/feed.env"
-    [[ -L "$ROOT_MNT/etc/default/airplanes" ]] || fail "/etc/default/airplanes is not a symlink"
-    [[ "$(readlink "$ROOT_MNT/etc/default/airplanes")" == "/boot/airplanes-config.txt" ]] \
-        || fail "/etc/default/airplanes does not point at /boot/airplanes-config.txt"
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        assert_not_exists "$ROOT_MNT/etc/airplanes/feed.env"
+        [[ -L "$ROOT_MNT/etc/default/airplanes" ]] || fail "/etc/default/airplanes is not a symlink"
+        [[ "$(readlink "$ROOT_MNT/etc/default/airplanes")" == "/boot/airplanes-config.txt" ]] \
+            || fail "/etc/default/airplanes does not point at /boot/airplanes-config.txt"
+    fi
 
     assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh'
     assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" 'After=airplanes-first-run.service'
     assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh'
     assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" 'After=airplanes-first-run.service'
     assert_contains "$ipath/airplanes-feed.sh" 'feed2.airplanes.live,64004'
-    assert_contains "$CLAIM_LOG" 'claim register'
-    assert_contains "$COMMAND_LOG" 'systemctl restart airplanes-feed'
-    assert_contains "$COMMAND_LOG" 'systemctl restart airplanes-mlat'
-    [[ "$(grep -c 'systemctl daemon-reload' "$COMMAND_LOG")" == "1" ]] \
-        || fail "expected one systemctl daemon-reload call"
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        assert_contains "$CLAIM_LOG" 'claim register'
+        assert_contains "$COMMAND_LOG" 'systemctl restart airplanes-feed'
+        assert_contains "$COMMAND_LOG" 'systemctl restart airplanes-mlat'
+        [[ "$(grep -c 'systemctl daemon-reload' "$COMMAND_LOG")" == "1" ]] \
+            || fail "expected one systemctl daemon-reload call"
+    else
+        assert_not_exists "$CLAIM_LOG"
+        assert_contains "$COMMAND_LOG" 'systemctl enable airplanes-feed'
+        assert_contains "$COMMAND_LOG" 'systemctl enable airplanes-mlat'
+        ! grep -q 'systemctl restart' "$COMMAND_LOG" || fail "build mode restarted a service"
+        ! grep -q 'systemctl is-active' "$COMMAND_LOG" || fail "build mode checked live systemd state"
+        ! grep -q 'systemctl daemon-reload' "$COMMAND_LOG" || fail "build mode reloaded live systemd"
+    fi
 }
 
 assert_runtime_args() {

--- a/test/image-release-rootfs-smoke.sh
+++ b/test/image-release-rootfs-smoke.sh
@@ -48,6 +48,8 @@ FEED_SOURCE="$WORK_DIR/feed-source"
 FEED_BARE="$WORK_DIR/feed.git"
 MLAT_SOURCE="$WORK_DIR/mlat-source"
 MLAT_BARE="$WORK_DIR/mlat.git"
+READSB_SOURCE="$WORK_DIR/readsb-source"
+READSB_BARE="$WORK_DIR/readsb.git"
 STUB_DIR="$WORK_DIR/bin"
 COMMAND_LOG="$WORK_DIR/commands.log"
 CLAIM_LOG="$WORK_DIR/claim.log"
@@ -236,6 +238,13 @@ make_mlat_repo() {
     make_repo "$MLAT_SOURCE" master "$MLAT_BARE"
 }
 
+make_readsb_repo() {
+    rm -rf "$READSB_SOURCE" "$READSB_BARE"
+    mkdir -p "$READSB_SOURCE"
+    printf '%s\n' "readsb fixture" > "$READSB_SOURCE/README"
+    make_repo "$READSB_SOURCE" dev "$READSB_BARE"
+}
+
 write_stubs() {
     mkdir -p "$STUB_DIR"
     cat > "$STUB_DIR/apt-get" <<'SH'
@@ -276,6 +285,18 @@ exit 1
 SH
     cat > "$STUB_DIR/sleep" <<'SH'
 #!/usr/bin/env bash
+exit 0
+SH
+    cat > "$STUB_DIR/make" <<'SH'
+#!/usr/bin/env bash
+printf 'make %s\n' "$*" >> "${COMMAND_LOG:?}"
+if [[ "${1:-}" == "clean" ]]; then
+    rm -f readsb viewadsb
+    exit 0
+fi
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > readsb
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > viewadsb
+chmod +x readsb viewadsb
 exit 0
 SH
     cat > "$STUB_DIR/renice" <<'SH'
@@ -343,11 +364,11 @@ prepare_mounted_image() {
     local ipath mlat_version
     ipath="$ROOT_MNT/usr/local/share/airplanes"
 
-    [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "release image lacks /usr/bin/airplanes-feeder"
     [[ -f "$ROOT_MNT/etc/systemd/system/airplanes-first-run.service" ]] \
         || fail "release image lacks airplanes-first-run.service"
 
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "release image lacks /usr/bin/airplanes-feeder"
         require_feed_boot_file airplanes-config.txt
         require_feed_boot_file airplanes-env
         set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" USER "image-release-rootfs-smoke"
@@ -356,6 +377,7 @@ prepare_mounted_image() {
         set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" ALTITUDE "35m"
     else
         [[ -f "$ROOT_MNT/etc/airplanes/feed.env" ]] || fail "new image lacks /etc/airplanes/feed.env"
+        rm -f "$ROOT_MNT/usr/bin/airplanes-feeder"
         set_env_value "$ROOT_MNT/etc/airplanes/feed.env" USER "image-release-rootfs-smoke"
         set_env_value "$ROOT_MNT/etc/airplanes/feed.env" LATITUDE "52.52000"
         set_env_value "$ROOT_MNT/etc/airplanes/feed.env" LONGITUDE "13.40500"
@@ -390,6 +412,8 @@ run_update_against_image() {
         AIRPLANES_FEED_BRANCH="$FEED_BRANCH" \
         AIRPLANES_MLAT_REPO="file://$MLAT_BARE" \
         AIRPLANES_MLAT_BRANCH=master \
+        AIRPLANES_READSB_REPO="file://$READSB_BARE" \
+        AIRPLANES_READSB_BRANCH=dev \
         APL_FEED_BIN="$STUB_DIR/apl-feed-stub" \
         "${build_mode_env[@]}" \
         bash "$FEED_SOURCE/update.sh"
@@ -444,7 +468,13 @@ assert_updated_image_contracts() {
         assert_not_exists "$ROOT_MNT/etc/airplanes/feeder-id"
         assert_not_exists "$ipath/airplanes-uuid"
     fi
-    [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "missing image feed binary"
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "missing image feed binary"
+        [[ ! -e "$ipath/feed-airplanes" ]] || fail "legacy image should use image feed binary"
+    else
+        [[ ! -e "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "new image should not require /usr/bin/airplanes-feeder"
+        [[ -x "$ipath/feed-airplanes" ]] || fail "missing build-mode feed binary"
+    fi
     [[ -x "$ROOT_MNT/usr/local/bin/apl-feed" ]] || fail "missing apl-feed command"
     [[ -f "$ipath/update.sh" ]] || fail "missing installed update.sh"
     [[ -f "$ipath/airplanes-feed.sh" ]] || fail "missing airplanes-feed.sh"
@@ -506,6 +536,7 @@ main() {
     extract_image "$image_archive"
     make_feed_repo
     make_mlat_repo
+    make_readsb_repo
     write_stubs
 
     mount_partitions

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -49,6 +49,15 @@ run_configure() {
         bash "$CONFIGURE"
 }
 
+run_configure_env() {
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR" \
+        WHIPTAIL_LOG="$WHIPTAIL_LOG" \
+        WHIPTAIL_COUNTER="$WHIPTAIL_COUNTER" \
+        "$@" \
+        bash "$CONFIGURE"
+}
+
 @test "configure.sh accepts canonical decimal latitude and longitude" {
     run_configure $'ci-feeder\n52.52000\n13.40500\n35m'
 
@@ -102,4 +111,51 @@ run_configure() {
     [ "$status" -eq 0 ]
     ! grep -q 'Invalid longitude' "$WHIPTAIL_LOG"
     grep -q 'LONGITUDE="13.40500"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh writes feed.env from non-interactive env without whiptail" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="ci feeder" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'USER="ci feeder"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'LATITUDE="52.52000"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'LONGITUDE="13.40500"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'ALTITUDE="35m"' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ ! -e "$WHIPTAIL_LOG" ]
+}
+
+@test "configure.sh fails non-interactive mode when required env is partial" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="ci-feeder" \
+        AIRPLANES_LATITUDE="52.52000"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Missing required non-interactive configure value: AIRPLANES_LONGITUDE" ]]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+    [ ! -e "$WHIPTAIL_LOG" ]
+}
+
+@test "configure.sh fails build mode instead of prompting when config env is missing" {
+    run_configure_env AIRPLANES_BUILD_MODE=1
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Missing required non-interactive configure value" ]]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+    [ ! -e "$WHIPTAIL_LOG" ]
+}
+
+@test "configure.sh rejects invalid non-interactive latitude" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="ci-feeder" \
+        AIRPLANES_LATITUDE="north" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Latitude must be a decimal number" ]]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
 }

--- a/test/test_inline_fallback_drift.bats
+++ b/test/test_inline_fallback_drift.bats
@@ -42,7 +42,7 @@ function_body() {
 
     # install.sh's inline fallback intentionally omits airplanes_init_paths
     # (covered separately as a strict subset) and the rpm/legacy helpers.
-    for fn in airplanes_path airplanes_require_root airplanes_install_bootstrap_deps getGIT; do
+    for fn in airplanes_path airplanes_is_build_mode airplanes_enable_build_mode_from_args airplanes_require_root airplanes_install_bootstrap_deps getGIT; do
         local install_body lib_body
         install_body="$(function_body "$stub" "$fn")"
         lib_body="$(function_body "$lib" "$fn")"
@@ -96,6 +96,8 @@ function_body() {
         airplanes_init_paths \
         airplanes_is_image_install \
         airplanes_image_target_default \
+        airplanes_is_build_mode \
+        airplanes_enable_build_mode_from_args \
         airplanes_require_root \
         airplanes_apt_install \
         airplanes_is_legacy_os \

--- a/test/test_install_script.bats
+++ b/test/test_install_script.bats
@@ -73,6 +73,35 @@ SH
     [ "$(git -C "$ROOT_DIR/root/usr/local/share/airplanes/git" remote get-url origin)" = "$repo" ]
 }
 
+@test "install.sh propagates build mode to setup.sh" {
+    local repo="$ROOT_DIR/source"
+    make_git_repo "$repo"
+    cat > "$repo/setup.sh" <<'SH'
+#!/usr/bin/env bash
+set -e
+mkdir -p "$AIRPLANES_ROOT"
+printf '%s\n' "${AIRPLANES_BUILD_MODE:-}" > "$AIRPLANES_ROOT/build-mode"
+printf '%s\n' "$*" > "$AIRPLANES_ROOT/setup-args"
+SH
+    chmod +x "$repo/setup.sh"
+    commit_all "$repo"
+
+    write_stub whiptail 'exit 0'
+    write_stub apt-get 'printf "%s\n" "$@" >> "$APT_GET_LOG"; exit 0'
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR/root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_FEED_REPO="$repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        APT_GET_LOG="$ROOT_DIR/apt-get.log" \
+        bash "$INSTALL" --build-mode
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/root/build-mode")" = "1" ]
+    [ "$(cat "$ROOT_DIR/root/setup-args")" = "--build-mode" ]
+}
+
 @test "standalone install.sh works without scripts/lib checkout" {
     local repo="$ROOT_DIR/source"
     local standalone="$ROOT_DIR/standalone"

--- a/test/test_update_claim_registration.bats
+++ b/test/test_update_claim_registration.bats
@@ -53,7 +53,7 @@ last_line_containing() {
 @test "update.sh sources and calls claim registration helper" {
     local source_line call_line
     source_line="$(line_of_exact 'source "$GIT/scripts/lib/claim-registration.sh"')"
-    call_line="$(line_of_exact 'register_claim_secret')"
+    call_line="$(last_line_containing 'register_claim_secret')"
 
     [ -n "$source_line" ]
     [ -n "$call_line" ]
@@ -64,7 +64,7 @@ last_line_containing() {
     local feed_check_line mlat_check_line call_line
     feed_check_line="$(last_line_containing 'systemctl is-active airplanes-feed')"
     mlat_check_line="$(last_line_containing 'systemctl is-active airplanes-mlat')"
-    call_line="$(line_of_exact 'register_claim_secret')"
+    call_line="$(last_line_containing 'register_claim_secret')"
 
     [ -n "$feed_check_line" ]
     [ -n "$mlat_check_line" ]

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -27,7 +27,7 @@ install_command_stubs() {
     write_stub id 'if [[ "$1" == "-u" && "${2:-}" == "airplanes" ]]; then exit 0; fi; if [[ "$1" == "-u" ]]; then echo 0; exit 0; fi; /usr/bin/id "$@"'
     write_stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; if [[ "$1" == "restart" && "${2:-}" == "airplanes-feed" && -n "${SYSTEMCTL_FEED_ENV:-}" ]]; then printf "target-at-restart=%s\n" "$(grep "^TARGET=" "$SYSTEMCTL_FEED_ENV")" >> "$COMMAND_LOG"; fi; if [[ "$1" == "is-enabled" ]]; then echo disabled; exit 0; fi; exit 0'
     write_stub journalctl 'exit 0'
-    write_stub pgrep 'exit 1'
+    write_stub pgrep 'printf "pgrep %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
     write_stub nc 'exit 1'
     write_stub sleep 'exit 0'
     write_stub renice 'exit 0'
@@ -262,6 +262,56 @@ SH
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
     [ "$(grep -c 'systemctl daemon-reload' "$ROOT_DIR/commands.log")" = "1" ]
     grep -q 'target-at-restart=TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"' "$ROOT_DIR/commands.log"
+}
+
+@test "update.sh build mode enables units without live systemd or per-device state" {
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local mlat_repo="$ROOT_DIR/mlat-source"
+    local readsb_repo="$ROOT_DIR/readsb-source"
+    local claim_bin="$ROOT_DIR/apl-feed-stub"
+
+    copy_feed_fixture_repo "$feed_repo"
+    make_component_repo "$mlat_repo" master
+    make_component_repo "$readsb_repo" dev
+    write_feed_env "$root"
+    prepare_skip_build_state "$root" "$feed_repo" "$mlat_repo" "$readsb_repo"
+    install_command_stubs
+    cat > "$claim_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAIM_LOG"
+exit 0
+SH
+    chmod +x "$claim_bin"
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        COMMAND_LOG="$ROOT_DIR/commands.log" \
+        CLAIM_LOG="$ROOT_DIR/claim.log" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_BUILD_MODE=1 \
+        AIRPLANES_PACKAGE_MANAGER=apt \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        AIRPLANES_MLAT_REPO="$mlat_repo" \
+        AIRPLANES_MLAT_BRANCH=master \
+        AIRPLANES_READSB_REPO="$readsb_repo" \
+        AIRPLANES_READSB_BRANCH=dev \
+        APL_FEED_BIN="$claim_bin" \
+        bash "$UPDATE"
+
+    [ "$status" -eq 0 ]
+    grep -q 'systemctl enable airplanes-feed' "$ROOT_DIR/commands.log"
+    grep -q 'systemctl enable airplanes-mlat' "$ROOT_DIR/commands.log"
+    ! grep -q 'systemctl restart' "$ROOT_DIR/commands.log"
+    ! grep -q 'systemctl stop' "$ROOT_DIR/commands.log"
+    ! grep -q 'systemctl is-active' "$ROOT_DIR/commands.log"
+    ! grep -q 'systemctl daemon-reload' "$ROOT_DIR/commands.log"
+    ! grep -q '^pgrep ' "$ROOT_DIR/commands.log"
+    [ ! -e "$root/etc/airplanes/feeder-id" ]
+    [ ! -e "$root/usr/local/share/airplanes/airplanes-uuid" ]
+    [ ! -e "$ROOT_DIR/claim.log" ]
+    [[ "$output" =~ "Build mode setup complete" ]]
 }
 
 @test "update.sh treats lone boot config without image feeder as manual install" {

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -301,6 +301,13 @@ SH
         bash "$UPDATE"
 
     [ "$status" -eq 0 ]
+    [ -f "$root/etc/systemd/system/airplanes-feed.service" ]
+    [ -f "$root/etc/systemd/system/airplanes-mlat.service" ]
+    [ ! -e "$root/lib/systemd/system/airplanes-feed.service" ]
+    grep -q 'After=airplanes-first-run.service' "$root/etc/systemd/system/airplanes-feed.service"
+    grep -q 'After=airplanes-first-run.service' "$root/etc/systemd/system/airplanes-mlat.service"
+    [ -x "$root/usr/local/share/airplanes/feed-airplanes" ]
+    [ ! -x "$root/usr/bin/airplanes-feeder" ]
     grep -q 'systemctl enable airplanes-feed' "$ROOT_DIR/commands.log"
     grep -q 'systemctl enable airplanes-mlat' "$ROOT_DIR/commands.log"
     ! grep -q 'systemctl restart' "$ROOT_DIR/commands.log"

--- a/update.sh
+++ b/update.sh
@@ -74,6 +74,20 @@ else
         printf '%s' '--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004'
     }
 
+    airplanes_is_build_mode() {
+        [[ "${AIRPLANES_BUILD_MODE:-0}" == "1" || "${AIRPLANES_BUILD_MODE:-}" == "true" || "${AIRPLANES_BUILD_MODE:-}" == "yes" ]]
+    }
+
+    airplanes_enable_build_mode_from_args() {
+        local arg
+        for arg in "$@"; do
+            if [[ "$arg" == "--build-mode" ]]; then
+                AIRPLANES_BUILD_MODE=1
+                export AIRPLANES_BUILD_MODE
+            fi
+        done
+    }
+
     airplanes_require_root() {
         if [[ "${AIRPLANES_SKIP_ROOT_CHECK:-0}" == "1" ]]; then
             return 0
@@ -173,6 +187,8 @@ else
         return 1
     }
 fi
+
+airplanes_enable_build_mode_from_args "$@"
 
 if [[ $1 == reinstall ]]; then
     REINSTALL=yes
@@ -324,7 +340,7 @@ MLAT_REPO="${AIRPLANES_MLAT_REPO:-https://github.com/airplanes-live/mlat-client}
 MLAT_BRANCH="${AIRPLANES_MLAT_BRANCH:-master}"
 MLAT_VERSION="$(git ls-remote "$MLAT_REPO" "$MLAT_BRANCH" | cut -f1 || echo "$RANDOM-$RANDOM" )"
 if [[ $REINSTALL != yes ]] && grep -e "$MLAT_VERSION" -qs "$IPATH/mlat_version" \
-    && grep -qs -e '#!' "$VENV/bin/mlat-client" && { systemctl is-active airplanes-mlat &>/dev/null || [[ "${MLAT_DISABLED}" == "1" ]]; }
+    && grep -qs -e '#!' "$VENV/bin/mlat-client" && { airplanes_is_build_mode || systemctl is-active airplanes-mlat &>/dev/null || [[ "${MLAT_DISABLED}" == "1" ]]; }
 then
     echo
     echo "mlat-client already installed, git hash:"
@@ -383,11 +399,15 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
     sed -i '/^\[Service\]$/i After=airplanes-first-run.service' "$SYSTEMD_DIR/airplanes-mlat.service"
     sed -i '/^\[Service\]$/i After=airplanes-first-run.service' "$SYSTEMD_DIR/airplanes-feed.service"
 fi
-systemctl daemon-reload >> "$LOGFILE" || true
+if ! airplanes_is_build_mode; then
+    systemctl daemon-reload >> "$LOGFILE" || true
+fi
 
 echo 60
 
-if is_unit_masked airplanes-mlat.service; then
+if airplanes_is_build_mode; then
+    systemctl enable airplanes-mlat >> "$LOGFILE" || true
+elif is_unit_masked airplanes-mlat.service; then
     echo "--------------------"
     echo "CAUTION, airplanes-mlat is masked and won't run!"
     echo "If this is unexpected for you, please report this issue."
@@ -428,7 +448,7 @@ else
     READSB_GIT="$IPATH/readsb-git"
     READSB_BIN="$IPATH/feed-airplanes"
     if [[ $REINSTALL != yes ]] && grep -e "$READSB_VERSION" -qs "$IPATH/readsb_version" \
-        && "$READSB_BIN" -V && systemctl is-active airplanes-feed &>/dev/null
+        && "$READSB_BIN" -V && { airplanes_is_build_mode || systemctl is-active airplanes-feed &>/dev/null; }
     then
         echo
         echo "Feed client already installed, git hash:"
@@ -468,7 +488,10 @@ fi
 
 echo 82
 
-if ! is_unit_masked airplanes-feed.service; then
+if airplanes_is_build_mode; then
+    systemctl enable airplanes-feed >> "$LOGFILE" || true
+    echo 92
+elif ! is_unit_masked airplanes-feed.service; then
     # Enable airplanes-feed service
     systemctl enable airplanes-feed >> "$LOGFILE" || true
     echo 92
@@ -484,47 +507,54 @@ fi
 
 echo 94
 
-systemctl is-active airplanes-feed &>/dev/null || {
-    rm -f "$IPATH/readsb_version"
-    echo "---------------------------------"
-    journalctl -u airplanes-feed | tail -n10
-    echo "---------------------------------"
-    echo "airplanes-feed service couldn't be started, please report this error on Discord."
-    echo "Try an copy as much of the output above and include it in your report, thank you!"
-    echo "---------------------------------"
-    exit 1
-}
+if ! airplanes_is_build_mode; then
+    systemctl is-active airplanes-feed &>/dev/null || {
+        rm -f "$IPATH/readsb_version"
+        echo "---------------------------------"
+        journalctl -u airplanes-feed | tail -n10
+        echo "---------------------------------"
+        echo "airplanes-feed service couldn't be started, please report this error on Discord."
+        echo "Try an copy as much of the output above and include it in your report, thank you!"
+        echo "---------------------------------"
+        exit 1
+    }
+fi
 
 echo 96
-[[ "${MLAT_DISABLED}" == "1" ]] || systemctl is-active airplanes-mlat &>/dev/null || {
-    rm -f "$IPATH/mlat_version"
-    echo "---------------------------------"
-    journalctl -u airplanes-mlat | tail -n10
-    echo "---------------------------------"
-    echo "airplanes-mlat service couldn't be started, please report this error on Discord."
-    echo "Try an copy as much of the output above and include it in your report, thank you!"
-    echo "---------------------------------"
-    exit 1
-}
 
-register_claim_secret
+if ! airplanes_is_build_mode; then
+    [[ "${MLAT_DISABLED}" == "1" ]] || systemctl is-active airplanes-mlat &>/dev/null || {
+        rm -f "$IPATH/mlat_version"
+        echo "---------------------------------"
+        journalctl -u airplanes-mlat | tail -n10
+        echo "---------------------------------"
+        echo "airplanes-mlat service couldn't be started, please report this error on Discord."
+        echo "Try an copy as much of the output above and include it in your report, thank you!"
+        echo "---------------------------------"
+        exit 1
+    }
+
+    register_claim_secret
+fi
 
 # Remove old method of starting the feed scripts if present from rc.local
 # Kill the old airplanes.live scripts in case they are still running from a previous install including spawned programs
 RC_LOCAL="$(airplanes_path /etc/rc.local)"
-for name in airplanes-netcat_maint.sh airplanes-socat_maint.sh airplanes-mlat_maint.sh; do
-    if [[ -f "$RC_LOCAL" ]] && grep -qs -e "$name" "$RC_LOCAL"; then
-        sed -i -e "/$name/d" "$RC_LOCAL" || true
-    fi
-    if PID="$(pgrep -f "$name" 2>/dev/null)" && PIDS="$PID $(pgrep -P "$PID" 2>/dev/null)"; then
-        echo killing: "$PIDS" >> "$LOGFILE" 2>&1 || true
-        kill -9 $PIDS >> "$LOGFILE" 2>&1 || true
-    fi
-done
+if ! airplanes_is_build_mode; then
+    for name in airplanes-netcat_maint.sh airplanes-socat_maint.sh airplanes-mlat_maint.sh; do
+        if [[ -f "$RC_LOCAL" ]] && grep -qs -e "$name" "$RC_LOCAL"; then
+            sed -i -e "/$name/d" "$RC_LOCAL" || true
+        fi
+        if PID="$(pgrep -f "$name" 2>/dev/null)" && PIDS="$PID $(pgrep -P "$PID" 2>/dev/null)"; then
+            echo killing: "$PIDS" >> "$LOGFILE" 2>&1 || true
+            kill -9 $PIDS >> "$LOGFILE" 2>&1 || true
+        fi
+    done
+fi
 
 # in case the mlat-client service using /etc/default/mlat-client as config is using airplanes.live as a host, disable the service
 MLAT_CLIENT_DEFAULT="$(airplanes_path /etc/default/mlat-client)"
-if grep -qs 'SERVER_HOSTPORT.*feed.airplanes.live' "$MLAT_CLIENT_DEFAULT" &>/dev/null; then
+if ! airplanes_is_build_mode && grep -qs 'SERVER_HOSTPORT.*feed.airplanes.live' "$MLAT_CLIENT_DEFAULT" &>/dev/null; then
     systemctl disable --now mlat-client >> "$LOGFILE" 2>&1 || true
 fi
 
@@ -588,7 +618,9 @@ https://github.com/wiedehopf/adsb-scripts/wiki/Automatic-installation-for-readsb
 "
 fi
 
-if ! timeout 5 nc -z "$INPUT_IP" "$INPUT_PORT" && command -v nc &>/dev/null; then
+if airplanes_is_build_mode; then
+    echo "Build mode setup complete; skipping receiver connectivity probe."
+elif ! timeout 5 nc -z "$INPUT_IP" "$INPUT_PORT" && command -v nc &>/dev/null; then
     #whiptail --title "airplanes.live Setup Script" --msgbox "$ENDTEXT2" 24 73
     echo -e "$ENDTEXT2"
 else

--- a/update.sh
+++ b/update.sh
@@ -201,6 +201,10 @@ IMAGE_INSTALL=0
 if airplanes_is_image_install; then
     IMAGE_INSTALL=1
 fi
+IMAGE_SERVICE_LAYOUT=0
+if [[ "$IMAGE_INSTALL" == "1" ]] || airplanes_is_build_mode; then
+    IMAGE_SERVICE_LAYOUT=1
+fi
 
 mkdir -p "$IPATH"
 rm -f "$LOGFILE"
@@ -230,8 +234,8 @@ if [[ "$1" != "test" ]] && { [[ ! -f "$IPATH/update.sh" ]] || ! diff "$GIT/updat
     bash "$IPATH/update.sh" "$@"
     exit $?
 fi
-if [[ "$IMAGE_INSTALL" == "1" ]]; then
-    # Image builds ship these units in /etc/systemd/system, which overrides /lib.
+if [[ "$IMAGE_SERVICE_LAYOUT" == "1" ]]; then
+    # Images ship these units in /etc/systemd/system, which overrides /lib.
     SYSTEMD_DIR="$(airplanes_path /etc/systemd/system)"
 fi
 
@@ -395,7 +399,7 @@ echo 50
 mkdir -p "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-mlat.service "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-feed.service "$SYSTEMD_DIR"
-if [[ "$IMAGE_INSTALL" == "1" ]]; then
+if [[ "$IMAGE_SERVICE_LAYOUT" == "1" ]]; then
     sed -i '/^\[Service\]$/i After=airplanes-first-run.service' "$SYSTEMD_DIR/airplanes-mlat.service"
     sed -i '/^\[Service\]$/i After=airplanes-first-run.service' "$SYSTEMD_DIR/airplanes-feed.service"
 fi


### PR DESCRIPTION
## Summary

- add `AIRPLANES_BUILD_MODE=1` / `--build-mode` plumbing across install/setup/update/create-uuid
- add non-interactive `configure.sh` support via `AIRPLANES_MLAT_USER`, `AIRPLANES_LATITUDE`, `AIRPLANES_LONGITUDE`, and `AIRPLANES_ALTITUDE`
- make build-mode service layout independent from legacy image autodetection, so new images do not need `/usr/bin/airplanes-feeder`
- keep legacy image-release smoke coverage against `airplanes-live/image-releases` while adding new-image contract support for `airplanes-live/image`

## Behavior

Build mode still installs packages, copies files, enables units, builds mlat/readsb, and writes canonical `feed.env`. It skips live-system/per-device actions: service restarts/stops/health checks, claim registration, feeder ID generation, legacy process killing, old mlat-client disablement, and receiver connectivity probing.

For new images, build mode installs feed/MLAT units into `/etc/systemd/system` and adds `After=airplanes-first-run.service` even when `/usr/bin/airplanes-feeder` is absent. If the image builder uses the full installer, it must pass placeholder non-interactive config values; if it writes `/etc/airplanes/feed.env` itself, it can call `update.sh --build-mode` directly.

Old images remain supported as a compatibility path: `/boot/airplanes-config.txt` + `/boot/airplanes-env` stay authoritative and are not migrated to `/etc/airplanes/feed.env` by the old-image update smoke. Existing old-image users should receive this through the airplanes-update delegation PR, not through an ImageBuilder change.

## Tests

- `shellcheck -S warning $(find . -name '*.sh' -not -path './.git/*')`
- `bash -n $(find . -name '*.sh' -not -path './.git/*')`
- `bats test/test_update_script.bats test/test_configure_script.bats test/test_install_script.bats test/test_inline_fallback_drift.bats`
- `bats test`