### PR TITLE
Detect image install via marker for build-mode contract

### DIFF
--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -15,9 +15,10 @@ BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
 FEED_ENV="$(airplanes_path /etc/airplanes/feed.env)"
 FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
 IMAGE_FEED_BIN="$(airplanes_path /usr/bin/airplanes-feeder)"
+IMAGE_INSTALL_MARKER="$(airplanes_path /etc/airplanes/image-install)"
 
 IMAGE_INSTALL=0
-if [[ -x "$IMAGE_FEED_BIN" ]]; then
+if [[ -x "$IMAGE_FEED_BIN" || -f "$IMAGE_INSTALL_MARKER" ]]; then
     IMAGE_INSTALL=1
 fi
 
@@ -56,13 +57,18 @@ if [[ "${MODEAC:-}" == "yes" ]]; then
     MODEAC_OPTION="--modeac"
 fi
 
+if [[ -x "$IMAGE_FEED_BIN" ]]; then
+    DEFAULT_FEED_BIN="$IMAGE_FEED_BIN"
+else
+    DEFAULT_FEED_BIN="$(airplanes_path /usr/local/share/airplanes/feed-airplanes)"
+fi
+FEED_BIN="${AIRPLANES_FEED_BIN:-$DEFAULT_FEED_BIN}"
+
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
-    FEED_BIN="${AIRPLANES_FEED_BIN:-$IMAGE_FEED_BIN}"
     TARGET="${TARGET:-"--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"}"
     FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-"--net-ro-interval 0.2"}"
     FEED_IMAGE_OPTIONS="${FEED_IMAGE_OPTIONS:-"--db-file=none --max-range 450"}"
 else
-    FEED_BIN="${AIRPLANES_FEED_BIN:-$(airplanes_path /usr/local/share/airplanes/feed-airplanes)}"
     FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-$NET_OPTIONS}"
     FEED_IMAGE_OPTIONS=""
 fi

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -33,7 +33,18 @@ airplanes_init_paths() {
 }
 
 airplanes_is_image_install() {
-    [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
+    [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]] \
+        || [[ -f "$(airplanes_path /etc/airplanes/image-install)" && -f "$FEED_ENV" ]]
+}
+
+airplanes_image_feed_bin_default() {
+    local legacy
+    legacy="$(airplanes_path /usr/bin/airplanes-feeder)"
+    if [[ -x "$legacy" ]]; then
+        printf '%s' "$legacy"
+    else
+        printf '%s' "$(airplanes_path /usr/local/share/airplanes/feed-airplanes)"
+    fi
 }
 
 airplanes_image_target_default() {

--- a/test/image-release-rootfs-smoke.sh
+++ b/test/image-release-rootfs-smoke.sh
@@ -465,6 +465,7 @@ assert_updated_image_contracts() {
         assert_symlink_target "$ipath/airplanes-uuid" '../../../../etc/airplanes/feeder-id'
     else
         [[ -f "$ROOT_MNT/etc/airplanes/feed.env" ]] || fail "missing canonical feed.env"
+        [[ -f "$ROOT_MNT/etc/airplanes/image-install" ]] || fail "missing image-install marker"
         assert_not_exists "$ROOT_MNT/etc/airplanes/feeder-id"
         assert_not_exists "$ipath/airplanes-uuid"
     fi

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -125,6 +125,76 @@ SH
     fi
 }
 
+@test "airplanes-feed.sh detects new-contract image via marker without /usr/bin/airplanes-feeder" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/args.log"
+    local feed_bin="$root/usr/local/share/airplanes/feed-airplanes"
+    mkdir -p "$root/etc/airplanes" "$root/usr/local/share/airplanes"
+    : > "$root/etc/airplanes/image-install"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="1"
+LONGITUDE="2"
+ALTITUDE="3m"
+USER="image-marker"
+MLATSERVER="feed.airplanes.live:31090"
+NET_OPTIONS="--decoder-option-that-must-not-feed --net-bi-port 30004,30104"
+EOF
+    cat > "$feed_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$feed_bin"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q -- '--db-file=none' "$arg_log"
+    grep -q -- '--max-range 450' "$arg_log"
+    grep -q -- '--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004' "$arg_log"
+    grep -q -- '--net-ro-interval 0.2' "$arg_log"
+    if grep -q -- '--decoder-option-that-must-not-feed' "$arg_log"; then
+        return 1
+    fi
+    if grep -q -- '--net-bi-port 30004,30104' "$arg_log"; then
+        return 1
+    fi
+}
+
+@test "airplanes-feed.sh stays in manual-install branch when neither marker nor legacy binary present" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/args.log"
+    local feed_bin="$root/usr/local/share/airplanes/feed-airplanes"
+    mkdir -p "$root/etc/airplanes" "$root/usr/local/share/airplanes"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="1"
+LONGITUDE="2"
+ALTITUDE="3m"
+USER="manual-install"
+MLATSERVER="feed.airplanes.live:31090"
+TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"
+NET_OPTIONS="--manual-net-option"
+EOF
+    cat > "$feed_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$feed_bin"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    if grep -q -- '--db-file=none' "$arg_log"; then
+        return 1
+    fi
+    grep -q -- '--manual-net-option' "$arg_log"
+}
+
 @test "runtime scripts prefer canonical feed.env over boot config when both exist" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/args.log"

--- a/test/test_inline_fallback_drift.bats
+++ b/test/test_inline_fallback_drift.bats
@@ -95,6 +95,7 @@ function_body() {
         airplanes_path \
         airplanes_init_paths \
         airplanes_is_image_install \
+        airplanes_image_feed_bin_default \
         airplanes_image_target_default \
         airplanes_is_build_mode \
         airplanes_enable_build_mode_from_args \

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -65,6 +65,52 @@ write_archive_fallback_stubs() {
     [ "$status" -eq 0 ]
 }
 
+@test "image install detection accepts marker file with feed.env (new contract)" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
+    printf 'USER="image"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+
+    run airplanes_is_image_install
+
+    [ "$status" -eq 0 ]
+}
+
+@test "image install detection rejects marker file alone without feed.env" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
+
+    run airplanes_is_image_install
+
+    [ "$status" -ne 0 ]
+}
+
+@test "image install detection returns false for manual install (no marker, no legacy binary)" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    printf 'USER="manual"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+
+    run airplanes_is_image_install
+
+    [ "$status" -ne 0 ]
+}
+
+@test "feed-bin resolver picks legacy /usr/bin/airplanes-feeder when present" {
+    mkdir -p "$ROOT_DIR/usr/bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+
+    run airplanes_image_feed_bin_default
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/usr/bin/airplanes-feeder" ]
+}
+
+@test "feed-bin resolver falls back to /usr/local/share/airplanes/feed-airplanes when legacy missing" {
+    run airplanes_image_feed_bin_default
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/usr/local/share/airplanes/feed-airplanes" ]
+}
+
 @test "getGIT clones the configured branch from a local repository" {
     local repo="$ROOT_DIR/source"
     local target="$ROOT_DIR/target"

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -148,6 +148,28 @@ SH
     chmod +x "$root/usr/bin/airplanes-feeder"
 }
 
+prepare_marker_image_skip_build_state() {
+    local root="$1"
+    local feed_repo="$2"
+    local mlat_repo="$3"
+    local readsb_repo="$4"
+    local ipath="$root/usr/local/share/airplanes"
+    mkdir -p "$ipath/venv/bin"
+    cp "$feed_repo/update.sh" "$ipath/update.sh"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$ipath/venv/bin/mlat-client"
+    chmod +x "$ipath/venv/bin/mlat-client"
+    git -C "$mlat_repo" rev-parse HEAD > "$ipath/mlat_version"
+    git -C "$readsb_repo" rev-parse HEAD > "$ipath/readsb_version"
+    cat > "$ipath/feed-airplanes" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-V" ]] && exit 0
+exit 0
+SH
+    chmod +x "$ipath/feed-airplanes"
+    mkdir -p "$root/etc/airplanes"
+    : > "$root/etc/airplanes/image-install"
+}
+
 @test "update.sh replaces a missing or stale installed updater before continuing" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
@@ -308,6 +330,7 @@ SH
     grep -q 'After=airplanes-first-run.service' "$root/etc/systemd/system/airplanes-mlat.service"
     [ -x "$root/usr/local/share/airplanes/feed-airplanes" ]
     [ ! -x "$root/usr/bin/airplanes-feeder" ]
+    [ -f "$root/etc/airplanes/image-install" ]
     grep -q 'systemctl enable airplanes-feed' "$ROOT_DIR/commands.log"
     grep -q 'systemctl enable airplanes-mlat' "$ROOT_DIR/commands.log"
     ! grep -q 'systemctl restart' "$ROOT_DIR/commands.log"
@@ -367,6 +390,53 @@ SH
     [ ! -x "$root/usr/bin/airplanes-feeder" ]
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
     [ "$(grep -c 'systemctl daemon-reload' "$ROOT_DIR/commands.log")" = "1" ]
+}
+
+@test "update.sh runs against marker-only image without legacy /usr/bin/airplanes-feeder" {
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local mlat_repo="$ROOT_DIR/mlat-source"
+    local readsb_repo="$ROOT_DIR/readsb-source"
+    local claim_bin="$ROOT_DIR/apl-feed-stub"
+    local ipath="$root/usr/local/share/airplanes"
+
+    copy_feed_fixture_repo "$feed_repo"
+    make_component_repo "$mlat_repo" master
+    make_component_repo "$readsb_repo" dev
+    write_feed_env "$root"
+    prepare_marker_image_skip_build_state "$root" "$feed_repo" "$mlat_repo" "$readsb_repo"
+    install_command_stubs
+    cat > "$claim_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAIM_LOG"
+exit 0
+SH
+    chmod +x "$claim_bin"
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        COMMAND_LOG="$ROOT_DIR/commands.log" \
+        CLAIM_LOG="$ROOT_DIR/claim.log" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=apt \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        AIRPLANES_MLAT_REPO="$mlat_repo" \
+        AIRPLANES_MLAT_BRANCH=master \
+        AIRPLANES_READSB_REPO="$readsb_repo" \
+        AIRPLANES_READSB_BRANCH=dev \
+        APL_FEED_BIN="$claim_bin" \
+        bash "$UPDATE"
+
+    [ "$status" -eq 0 ]
+    # Marker-only path must not exit with "Image feed binary missing".
+    ! [[ "$output" =~ "Image feed binary missing" ]]
+    grep -q "Using image-provided feed client: $ipath/feed-airplanes" <<< "$output"
+    [ -x "$ipath/feed-airplanes" ]
+    [ ! -e "$root/usr/bin/airplanes-feeder" ]
+    [ -f "$root/etc/airplanes/image-install" ]
+    [ -f "$root/etc/systemd/system/airplanes-feed.service" ]
+    grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
 }
 
 @test "update.sh updates image feed stack without migrating boot config to feed.env" {

--- a/update.sh
+++ b/update.sh
@@ -67,7 +67,18 @@ else
     }
 
     airplanes_is_image_install() {
-        [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
+        [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]] \
+            || [[ -f "$(airplanes_path /etc/airplanes/image-install)" && -f "$FEED_ENV" ]]
+    }
+
+    airplanes_image_feed_bin_default() {
+        local legacy
+        legacy="$(airplanes_path /usr/bin/airplanes-feeder)"
+        if [[ -x "$legacy" ]]; then
+            printf '%s' "$legacy"
+        else
+            printf '%s' "$(airplanes_path /usr/local/share/airplanes/feed-airplanes)"
+        fi
     }
 
     airplanes_image_target_default() {
@@ -434,7 +445,7 @@ echo 70
 # SETUP FEEDER TO SEND DUMP1090 DATA TO airplanes.live
 
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
-    READSB_BIN="$(airplanes_path /usr/bin/airplanes-feeder)"
+    READSB_BIN="$(airplanes_image_feed_bin_default)"
     if [[ ! -x "$READSB_BIN" ]]; then
         echo "Image feed binary missing at $READSB_BIN; run the image updater first." >&2
         exit 1
@@ -623,6 +634,11 @@ https://github.com/wiedehopf/adsb-scripts/wiki/Automatic-installation-for-readsb
 fi
 
 if airplanes_is_build_mode; then
+    # Persistent on-disk signal that this filesystem was produced via
+    # --build-mode. Runtime scripts use this to detect image installs that
+    # don't ship the legacy /usr/bin/airplanes-feeder binary.
+    mkdir -p "$ETC_AIRPLANES"
+    : > "$ETC_AIRPLANES/image-install"
     echo "Build mode setup complete; skipping receiver connectivity probe."
 elif ! timeout 5 nc -z "$INPUT_IP" "$INPUT_PORT" && command -v nc &>/dev/null; then
     #whiptail --title "airplanes.live Setup Script" --msgbox "$ENDTEXT2" 24 73


### PR DESCRIPTION
Build-mode images install the feed binary at `/usr/local/share/airplanes/feed-airplanes` and explicitly do not ship `/usr/bin/airplanes-feeder`. `airplanes_is_image_install` previously relied on the legacy binary path alone, so build-mode images stayed in the manual-install branch at runtime — `airplanes-feed.sh` dropped the image-specific `--db-file=none --max-range 450` options, and the rootfs smoke caught it.

`update.sh` now writes `/etc/airplanes/image-install` at the end of a successful build-mode run, and `airplanes_is_image_install` accepts either signal. A new helper `airplanes_image_feed_bin_default` resolves the feed binary to the legacy path when present and `/usr/local/share/airplanes/feed-airplanes` otherwise; `update.sh`'s image-branch binary check uses it. `airplanes-feed.sh` mirrors the marker detection inline (it doesn't source the lib at boot). The rootfs smoke contract gains the marker assertion. Bats coverage exercises marker-only detection, manual-install rejection, the resolver, the build-mode marker write, and an `update.sh` run against a marker-only fixture.

Boot-config fallback in `airplanes-mlat.sh` and `apl-feed/common.sh` stays unchanged: new images never ship `/boot/airplanes-config.txt` and always have `feed.env`, so those legacy paths are already dead for the new contract.