### PR TITLE
Harden update.sh self-replace with atomic same-dir rename

### DIFF
--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -197,6 +197,36 @@ SH
     [ "$status" -eq 0 ]
     [ "$(cat "$root/self-update-marker")" = "self-update-ran" ]
     cmp "$feed_repo/update.sh" "$ipath/update.sh"
+    [ "$(stat -c '%a' "$ipath/update.sh")" = "755" ]
+}
+
+@test "update.sh self-replace tolerates a 0644 destination from older feed" {
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local ipath="$root/usr/local/share/airplanes"
+    mkdir -p "$feed_repo" "$ipath" "$root/etc"
+    echo 'VERSION_ID="13"' > "$root/etc/os-release"
+    cat > "$feed_repo/update.sh" <<'SH'
+#!/usr/bin/env bash
+set -e
+printf 'self-update-ran\n' > "$AIRPLANES_ROOT/self-update-marker"
+SH
+    chmod +x "$feed_repo/update.sh"
+    make_git_repo "$feed_repo" main
+    commit_all "$feed_repo"
+    printf 'old updater\n' > "$ipath/update.sh"
+    chmod 0644 "$ipath/update.sh"
+
+    run env PATH="/usr/bin:/bin" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=none \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        bash "$UPDATE"
+
+    [ "$status" -eq 0 ]
+    [ "$(stat -c '%a' "$ipath/update.sh")" = "755" ]
 }
 
 @test "update.sh runs setup when no feed env exists" {

--- a/update.sh
+++ b/update.sh
@@ -240,8 +240,12 @@ if [[ -f "$GIT/scripts/lib/install-update-common.sh" ]]; then
 fi
 
 if [[ "$1" != "test" ]] && { [[ ! -f "$IPATH/update.sh" ]] || ! diff "$GIT/update.sh" "$IPATH/update.sh" &>/dev/null; }; then
-    rm -f "$IPATH/update.sh"
-    cp "$GIT/update.sh" "$IPATH/update.sh"
+    # Atomic rename via same-dir tempfile so we don't overwrite the file
+    # currently being interpreted, and 0755 is set explicitly (downstream
+    # callers exec this path directly).
+    update_tmp="$(mktemp "$IPATH/update.sh.XXXXXX")"
+    install -m 0755 "$GIT/update.sh" "$update_tmp"
+    mv -fT "$update_tmp" "$IPATH/update.sh"
     bash "$IPATH/update.sh" "$@"
     exit $?
 fi


### PR DESCRIPTION
The self-replace path in `update.sh` relied on `rm -f` followed by `cp` and depended on the default umask producing 0755 from a +x source. That happens to work today but is fragile: a `cp` into an existing 0644 destination would silently leave the file non-executable, and downstream callers exec `/usr/local/share/airplanes/update.sh` directly.

This switches to `install -m 0755` into a same-directory `mktemp` plus `mv -fT`. The mode is set explicitly, the rename is atomic, and the file currently being interpreted is never overwritten in place. Bats coverage now asserts the destination is 0755 after self-replace, including a case where it started out 0644.
