### PR TITLE
Add apl-feed claim set and id set commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,42 @@ If the website says the feeder is not registered yet, run:
 sudo apl-feed claim register
 ```
 
+If the website gave you a fresh claim secret (a same-IP claim, an account-side
+"reset claim secret", or a support-issued reset), save it to the feeder with:
+
+```
+sudo apl-feed claim set
+```
+
+The command prompts for the secret and saves it locally. The feeder will use
+the new value on its next contact with the website — no daemon restart needed,
+because neither `airplanes-feed` nor `airplanes-mlat` consumes the claim
+secret directly. Pass `--force` if a different secret is already saved on this
+feeder.
+
+If you need to set the **Feeder ID** itself (typically when restoring an
+existing feeder onto fresh hardware and the website's "Reinstall feeder" page
+shows you the previous UUID), use:
+
+```
+sudo apl-feed id set
+```
+
+This one *does* restart `airplanes-feed` and `airplanes-mlat`, because both
+daemons consume the UUID at startup. Pass `--force` to overwrite a different
+existing Feeder ID.
+
+For the website-restore flow where you have **both** a UUID and a fresh
+claim secret in hand:
+
+```
+sudo apl-feed restore --uuid <UUID-from-website>
+```
+
+Then paste the claim secret when prompted. The command writes both files
+atomically (rolls back the UUID change if the secret write fails) and
+restarts the daemons in one step. Add `--check` to validate without writing.
+
 ## Back Up And Restore
 
 Back up before replacing a Raspberry Pi, reinstalling the OS, or wiping an SD

--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -21,6 +21,8 @@ source "$APL_FEED_LIB_DIR/common.sh"
 source "$APL_FEED_LIB_DIR/http.sh"
 # shellcheck source=scripts/apl-feed/claim.sh
 source "$APL_FEED_LIB_DIR/claim.sh"
+# shellcheck source=scripts/apl-feed/id.sh
+source "$APL_FEED_LIB_DIR/id.sh"
 # shellcheck source=scripts/apl-feed/status.sh
 source "$APL_FEED_LIB_DIR/status.sh"
 # shellcheck source=scripts/apl-feed/backup.sh
@@ -36,6 +38,10 @@ main() {
         claim)
             shift
             dispatch_claim "$@"
+            ;;
+        id)
+            shift
+            dispatch_id "$@"
             ;;
         backup)
             shift

--- a/scripts/apl-feed/backup.sh
+++ b/scripts/apl-feed/backup.sh
@@ -83,9 +83,28 @@ config_backup() {
 }
 
 config_restore() {
-    local infile=''
-    local opt_rc check_only
-    check_only=0
+    # Two source forms, mutually exclusive:
+    #   apl-feed restore <backup-file>       - read UUID + secret from a
+    #                                          JSON file produced by `backup`
+    #   apl-feed restore --uuid <UUID>       - take UUID from the flag,
+    #                                          read secret from stdin
+    #                                          (TTY prompt or pipe). The
+    #                                          website-restore-without-backup
+    #                                          flow.
+    #
+    # Both forms support `--check` (validate without writing) and
+    # `--force` (overwrite differing local UUID / secret).
+    #
+    # Atomicity: writes the UUID first, then the secret. If the secret
+    # write fails after the UUID write succeeded, rolls the UUID back
+    # to its prior bytes (or removes it if there was none) so the
+    # feeder doesn't end up advertising a UUID without a working secret.
+    #
+    # Restart: when the UUID actually changes, restarts both
+    # airplanes-feed and airplanes-mlat (both consume the UUID).
+    # Restart failure is reported separately from write failure.
+    local infile='' uuid_arg=''
+    local opt_rc check_only=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --check)
@@ -95,6 +114,11 @@ config_restore() {
             --force)
                 FORCE=1
                 shift
+                ;;
+            --uuid)
+                [[ $# -ge 2 ]] || die "--uuid requires VALUE"
+                uuid_arg="$2"
+                shift 2
                 ;;
             --root|--server-url|--max-retry-time|-h|--help)
                 if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
@@ -116,15 +140,44 @@ config_restore() {
                 ;;
         esac
     done
-    [[ -n "$infile" ]] || die "restore requires a file"
-    [[ -f "$infile" ]] || die "$infile does not exist"
-    require_jq
 
-    local existing_uuid existing_secret
-    read_backup_file "$infile"
+    if [[ -n "$uuid_arg" && -n "$infile" ]]; then
+        die "restore: --uuid and a backup file are mutually exclusive"
+    fi
+    if [[ -z "$uuid_arg" && -z "$infile" ]]; then
+        die "restore requires --uuid <UUID> or a backup file"
+    fi
+
+    if [[ -n "$infile" ]]; then
+        [[ -f "$infile" ]] || die "$infile does not exist"
+        require_jq
+        read_backup_file "$infile"
+    else
+        BACKUP_UUID="$(canonicalize_uuid "$uuid_arg")" \
+            || die "invalid --uuid value (expected 8-4-4-4-12 hex)"
+        local raw
+        if [[ -t 0 ]]; then
+            echo "Paste the claim secret from your account dashboard." >&2
+            echo "Format: ABCD-EFGH-IJKL-MNOP (hyphens and case are ignored)" >&2
+            printf 'Secret: ' >&2
+            IFS= read -r raw </dev/tty || true
+        else
+            raw="$(cat)"
+        fi
+        [[ -n "$raw" ]] || die "no secret provided on stdin"
+        BACKUP_SECRET="$(canonicalize_secret "$raw")"
+        validate_secret "$BACKUP_SECRET" \
+            || die "invalid claim secret format (expected 16 chars A-Z 0-9 after canonicalization)"
+        BACKUP_VERSION=''
+        BACKUP_CREATED_AT=''
+    fi
 
     if (( check_only )); then
-        echo "Backup is valid."
+        if [[ -n "$infile" ]]; then
+            echo "Backup is valid."
+        else
+            echo "Inputs are valid."
+        fi
         echo "Feeder ID: $BACKUP_UUID"
         if [[ -n "$BACKUP_CREATED_AT" ]]; then
             echo "Created: $BACKUP_CREATED_AT"
@@ -136,10 +189,13 @@ config_restore() {
         return 0
     fi
 
+    local existing_uuid='' existing_secret=''
     if existing_uuid="$(read_uuid 2>/dev/null)"; then
         if [[ "$existing_uuid" != "$BACKUP_UUID" && "$FORCE" -ne 1 ]]; then
             die "local Feeder ID differs; rerun with --force to overwrite"
         fi
+    else
+        existing_uuid=''
     fi
     if [[ -f "$(secret_final_path)" ]]; then
         existing_secret="$(read_secret_file "$(secret_final_path)")"
@@ -148,8 +204,21 @@ config_restore() {
         fi
     fi
 
+    # Snapshot the previous UUID file bytes so we can roll back if the
+    # secret write fails after the UUID write succeeded. write_uuid only
+    # ever writes the canonical 8-4-4-4-12 + newline form, so capturing
+    # the canonical value via read_uuid (above) is sufficient.
     write_uuid "$BACKUP_UUID"
-    write_secret_file "$(secret_final_path)" "$BACKUP_SECRET"
+    if ! write_secret_file "$(secret_final_path)" "$BACKUP_SECRET"; then
+        echo "Secret write failed — rolling back Feeder ID change." >&2
+        if [[ -n "$existing_uuid" ]]; then
+            write_uuid "$existing_uuid"
+        else
+            rm -f "$(feeder_id_path)"
+        fi
+        die "restore aborted; local state restored to its previous values"
+    fi
+
     if [[ -n "$BACKUP_VERSION" ]]; then
         write_version_file "$BACKUP_VERSION"
     else
@@ -157,4 +226,11 @@ config_restore() {
     fi
     rm -f "$(secret_pending_path)"
     echo "Restored feeder config for Feeder ID $BACKUP_UUID"
+
+    if [[ "$existing_uuid" != "$BACKUP_UUID" ]]; then
+        if ! restart_feeder_services; then
+            echo "Saved, but service restart failed — daemons may still advertise the old Feeder ID until you restart them manually." >&2
+            return 1
+        fi
+    fi
 }

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -362,6 +362,122 @@ claim_rotate() {
     done
 }
 
+claim_set() {
+    # Save a claim secret minted by the website (e.g. the same-IP claim
+    # legacy bootstrap, the owner-side Reset secret flow, or a support
+    # reset) and restart feeder services so the new value takes effect
+    # immediately. The secret is read from stdin (TTY prompts; pipes work
+    # too) so the value never lands in argv or shell history.
+    #
+    # Refuses to overwrite an existing different secret unless --force is
+    # passed; a no-op when the supplied secret already matches the local
+    # one.
+    local opt_rc force=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force)
+                # shellcheck disable=SC2034  # tracked locally; not exported
+                force=1
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                shift
+                ;;
+            *)
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0) die "unknown flag for claim set: $1" ;;
+                esac
+                ;;
+        esac
+    done
+
+    local uuid raw secret final pending version_path existing existing_raw
+    uuid="$(read_uuid)"
+    final="$(secret_final_path)"
+    pending="$(secret_pending_path)"
+    version_path="$(secret_version_path)"
+
+    if [[ -t 0 ]]; then
+        echo "Paste the claim secret from your account dashboard." >&2
+        echo "Format: ABCD-EFGH-IJKL-MNOP (hyphens and case are ignored)" >&2
+        printf 'Secret: ' >&2
+        IFS= read -r raw </dev/tty || true
+    else
+        # `cat` collects all of stdin; `$(...)` strips trailing newlines.
+        # Using `read -r` here would reject a no-newline pipe (e.g.
+        # `printf %s SECRET | apl-feed claim set`) even when the secret
+        # arrived intact.
+        raw="$(cat)"
+    fi
+
+    [[ -n "$raw" ]] || die "no input provided"
+
+    secret="$(canonicalize_secret "$raw")"
+    validate_secret "$secret" \
+        || die "invalid claim secret format (expected 16 chars A-Z 0-9 after canonicalization)"
+
+    # Read any existing final secret without dying on malformed contents:
+    # `read_secret_file` calls `die` on garbage, but `claim set --force`
+    # is the documented way to recover from a corrupted file, so the
+    # check itself must be recoverable.
+    existing=""
+    if [[ -f "$final" ]] && IFS= read -r existing_raw < "$final" 2>/dev/null; then
+        existing="$(canonicalize_secret "$existing_raw" 2>/dev/null || true)"
+        validate_secret "$existing" 2>/dev/null || existing=""
+    fi
+
+    if [[ -f "$final" && -z "$existing" ]] && (( ! force )); then
+        die "existing claim secret file is malformed or unreadable; re-run with --force to replace it"
+    fi
+    if [[ -n "$existing" && "$existing" != "$secret" ]] && (( ! force )); then
+        die "a different claim secret is already saved on this feeder; re-run with --force to replace it"
+    fi
+
+    echo "Feeder ID: $uuid"
+    if (( DRY_RUN )); then
+        echo "(dry-run; would save secret + restart feeder services)"
+        return 0
+    fi
+
+    # Drop any stale pending file from an interrupted prior rotation. The
+    # supplied secret is the new authoritative value; any half-done
+    # rotation state is moot.
+    rm -f "$pending"
+
+    if [[ -n "$existing" && "$existing" == "$secret" ]]; then
+        # Same canonical value already on disk. Re-write to normalize byte
+        # contents (lowercase / hyphenated raw input gets canonicalized)
+        # and the file mode (0600). Don't drop the version file — the
+        # local secret bytes haven't functionally changed. Don't restart
+        # services either: nothing observable changed.
+        write_secret_file "$final" "$secret"
+        echo "Local claim secret already matches — no change."
+        return 0
+    fi
+
+    write_secret_file "$final" "$secret"
+
+    # Local secret no longer matches whatever the version file claimed.
+    # Drop the version file so `claim show` / `backup` can't pair a
+    # stale version with the fresh secret. The next `status` call will
+    # write the server-confirmed version back.
+    rm -f "$version_path"
+
+    echo "Claim secret saved."
+    # No daemon restart: neither airplanes-feed nor airplanes-mlat reads
+    # the claim secret. Only this CLI does, and the next CLI invocation
+    # picks up the file change immediately. The website's hash is already
+    # the new value (this command is run AFTER the website mints the
+    # secret), so the next outbound `status` or `rotate` from the feeder
+    # authenticates fine.
+    echo "Done. The feeder will use the new secret on its next contact with the website."
+}
+
+
 dispatch_claim() {
     local sub="${1:-}"
     [[ -n "$sub" ]] || die "claim requires a subcommand"
@@ -370,6 +486,7 @@ dispatch_claim() {
         register) claim_register "$@" ;;
         show) claim_show "$@" ;;
         rotate) claim_rotate "$@" ;;
+        set) claim_set "$@" ;;
         -h|--help) usage ;;
         *) die "unknown claim subcommand: $sub" ;;
     esac

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -33,13 +33,31 @@ Usage:
   apl-feed claim show
   apl-feed claim rotate
   apl-feed claim rotate --abort
+  apl-feed claim set [--force]
+  apl-feed id set [--force]
   apl-feed backup <file>
   apl-feed restore <file>
   apl-feed restore --check <file>
+  apl-feed restore --uuid <uuid> [--check]
 
 Options:
-  --force             For restore: overwrite differing local state.
+  --force             For restore / claim set / id set: overwrite differing
+                      local state.
+  --check             For restore: validate the source without writing.
   -h, --help          Show this message.
+
+`apl-feed claim set` reads a claim secret from stdin (or prompts when run
+on a TTY) and saves it locally. The feeder will use the new secret on its
+next contact with the website. No daemon restart — neither airplanes-feed
+nor airplanes-mlat consumes the claim secret.
+
+`apl-feed id set` reads a Feeder ID (UUID) from stdin and saves it
+locally. Both airplanes-feed and airplanes-mlat consume the UUID, so this
+command restarts both services after writing.
+
+`apl-feed restore --uuid <uuid>` is the website-restore path. It writes
+both the supplied UUID and a fresh secret read from stdin in one atomic
+two-file commit, then restarts both daemons.
 USAGE
 }
 
@@ -197,6 +215,20 @@ feed_env_get() {
     printf '%s\n' "$output" | tail -n 1
 }
 
+canonicalize_uuid() {
+    # Strip whitespace + braces + hyphens are kept; lowercase hex; require
+    # the canonical 8-4-4-4-12 shape after normalization. Returns 0 with
+    # the canonical UUID on stdout, 1 if the input doesn't match.
+    local raw uuid
+    raw="$(printf '%s' "${1:-}" | tr -d '\n\r\t {}')"
+    uuid="$(printf '%s' "$raw" | tr 'A-F' 'a-f')"
+    if [[ "$uuid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+        printf '%s' "$uuid"
+        return 0
+    fi
+    return 1
+}
+
 read_uuid() {
     local path raw uuid
     for path in "$(feeder_id_path)" "$(uuid_file_legacy)" "$(uuid_file_boot)"; do
@@ -230,6 +262,49 @@ generate_secret() (
     set +o pipefail
     LC_ALL=C tr -dc 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' </dev/urandom 2>/dev/null | head -c 16
 )
+
+restart_feeder_services() {
+    # Restart both feeder daemons after a UUID change. Order is
+    # `airplanes-feed` first, then `airplanes-mlat` — mlat-client has a
+    # 2s sleep + nc reachability check on its INPUT port at startup, so
+    # letting the feed side settle first keeps mlat from racing against
+    # a still-restarting feed.
+    #
+    # Used by `apl-feed id set` and `apl-feed restore --uuid X`. Not
+    # used by `claim set`: the claim secret is CLI-only data; no daemon
+    # consumes it.
+    #
+    # Skip when ROOT != "/" so a maintenance run with `--root /mnt/...`
+    # never bounces the host's real services. Returns 0 on success
+    # (including the skip path), 1 if any attempted restart failed.
+    if [[ "$ROOT" != "/" ]]; then
+        echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+        return 0
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 0
+    fi
+    local svc rc=0 failed_services=()
+    for svc in airplanes-feed airplanes-mlat; do
+        if ! systemctl is-active --quiet "$svc" 2>/dev/null \
+                && ! systemctl is-enabled --quiet "$svc" 2>/dev/null; then
+            # Service isn't running and isn't enabled on this host. Not
+            # an error — just skip it silently.
+            continue
+        fi
+        if systemctl restart "$svc" 2>/dev/null; then
+            echo "Restarted $svc"
+        else
+            echo "Could not restart $svc — re-run as root, or: sudo systemctl restart $svc" >&2
+            failed_services+=("$svc")
+            rc=1
+        fi
+    done
+    if (( rc != 0 )); then
+        echo "Restart hint: sudo systemctl restart ${failed_services[*]}" >&2
+    fi
+    return $rc
+}
 
 parse_common_option() {
     case "${1:-}" in

--- a/scripts/apl-feed/id.sh
+++ b/scripts/apl-feed/id.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Feeder identity (UUID) management — sibling of claim.sh.
+#
+# Today only `set` is exposed; future subcommands (e.g. `id show`,
+# `id rotate`) can land here without touching apl-feed.sh's dispatcher.
+
+id_set() {
+    # Save a feeder UUID supplied by the user (typically copied from the
+    # website's Reinstall Feeder action) and restart both feeder daemons
+    # so the new identity propagates to upstream services.
+    #
+    # Both `airplanes-feed` and `airplanes-mlat` read the UUID via
+    # `--uuid-file=$FEEDER_ID_FILE` at startup, so a UUID change requires
+    # a restart of both.
+    #
+    # Refuses to overwrite a different existing UUID without `--force`,
+    # to defend against fat-fingered support entries that would
+    # disconnect a live feeder from its history.
+    local opt_rc force=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force)
+                # shellcheck disable=SC2034  # tracked locally; not exported
+                force=1
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                shift
+                ;;
+            *)
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0) die "unknown flag for id set: $1" ;;
+                esac
+                ;;
+        esac
+    done
+
+    local raw uuid existing existing_raw final
+    final="$(feeder_id_path)"
+
+    if [[ -t 0 ]]; then
+        echo "Paste the Feeder ID from your account dashboard." >&2
+        echo "Format: 8-4-4-4-12 lowercase hex (e.g. 11111111-2222-3333-4444-555555555555)" >&2
+        printf 'Feeder ID: ' >&2
+        IFS= read -r raw </dev/tty || true
+    else
+        raw="$(cat)"
+    fi
+
+    [[ -n "$raw" ]] || die "no input provided"
+
+    uuid="$(canonicalize_uuid "$raw")" \
+        || die "invalid Feeder ID format (expected 8-4-4-4-12 hex digits)"
+
+    # Read any existing UUID without dying on malformed contents — `--force`
+    # must be able to repair a corrupt file.
+    existing=""
+    if [[ -f "$final" ]] && IFS= read -r existing_raw < "$final" 2>/dev/null; then
+        existing="$(canonicalize_uuid "$existing_raw" 2>/dev/null || true)"
+    fi
+
+    if [[ -f "$final" && -z "$existing" ]] && (( ! force )); then
+        die "existing Feeder ID file is malformed or unreadable; re-run with --force to replace it"
+    fi
+    if [[ -n "$existing" && "$existing" != "$uuid" ]] && (( ! force )); then
+        die "a different Feeder ID is already saved on this feeder; re-run with --force to replace it"
+    fi
+
+    if [[ -n "$existing" && "$existing" == "$uuid" ]]; then
+        # Same canonical value already on disk. Re-write to normalize byte
+        # contents (case / whitespace) and the file mode, but no service
+        # restart — nothing observable changed.
+        if (( DRY_RUN )); then
+            echo "(dry-run; Feeder ID already matches — would normalize file in place)"
+            return 0
+        fi
+        write_uuid "$uuid"
+        echo "Feeder ID already matches — no change."
+        return 0
+    fi
+
+    # Visible OLD -> NEW print so the user can catch a paste-error before
+    # a service restart blows away their working feeder identity.
+    if [[ -n "$existing" ]]; then
+        echo "Feeder ID change:"
+        echo "  Old: $existing"
+        echo "  New: $uuid"
+    else
+        echo "Feeder ID: $uuid (no previous ID on this feeder)"
+    fi
+
+    if (( DRY_RUN )); then
+        echo "(dry-run; would save Feeder ID + restart airplanes-feed and airplanes-mlat)"
+        return 0
+    fi
+
+    write_uuid "$uuid"
+    echo "Feeder ID saved."
+
+    # Soft warning — local CLI is not responsible for cleaning up the
+    # previous UUID's record on the website. That row stays visible as
+    # an unclaimed feeder until it ages out or support removes it.
+    if [[ -n "$existing" ]]; then
+        echo "Note: the previous Feeder ID's record on airplanes.live is not removed by this command — it stays visible as an unclaimed feeder until it ages out or support removes it." >&2
+    fi
+
+    if ! restart_feeder_services; then
+        echo "Saved, but service restart failed — the running daemons may still advertise the old Feeder ID until you restart them manually." >&2
+        return 1
+    fi
+    echo "Done. The feeder will advertise the new Feeder ID upstream now."
+}
+
+
+dispatch_id() {
+    local sub="${1:-}"
+    [[ -n "$sub" ]] || die "id requires a subcommand"
+    shift || true
+    case "$sub" in
+        set) id_set "$@" ;;
+        -h|--help) usage ;;
+        *) die "unknown id subcommand: $sub" ;;
+    esac
+}

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -379,6 +379,349 @@ EOF
     [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
 }
 
+@test "claim set writes secret atomically when none exists" {
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"abcd-efgh-ijkl-mnop"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+    [ "$(stat -c '%a' "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "600" ]
+    [[ "$output" =~ "Claim secret saved." ]]
+}
+
+@test "claim set accepts a no-newline piped secret" {
+    # `printf %s ABCDEFGHIJKLMNOP | apl-feed claim set` must work — the
+    # documented website-side reveal lets users paste the secret into a
+    # shell pipeline without a trailing newline.
+    run bash -c "printf %s 'abcd-efgh-ijkl-mnop' | '$SCRIPT' claim set --root '$ROOT_DIR'"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+}
+
+@test "claim set normalizes existing matching secret bytes and mode (idempotent)" {
+    # User had previously written the secret in lowercase / hyphenated
+    # form, or the file mode drifted. claim set should still leave a
+    # canonical, mode-0600 file.
+    echo "abcd-efgh-ijkl-mnop" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 644 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCD-EFGH-IJKL-MNOP"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "already matches" ]]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+    [ "$(stat -c '%a' "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "600" ]
+}
+
+@test "claim set drops stale .pending even on idempotent path" {
+    echo "ABCDEFGHIJKLMNOP" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    echo "PENDINGSECRETXY1" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending" ]
+}
+
+@test "claim set --force replaces a malformed existing secret file" {
+    # Existing file is corrupt (wrong length); --force must succeed.
+    echo "garbage" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" --force <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+}
+
+@test "claim set without --force refuses to touch a malformed existing secret file" {
+    echo "garbage" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "malformed or unreadable" ]]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "garbage" ]
+}
+
+@test "claim set drops the version file when overwriting" {
+    echo "OLDSECRETXYZ1234" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    echo "7" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" --force <<<"NEWSECRETXYZ5678"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version" ]
+}
+
+@test "claim set leaves the version file alone on the idempotent path" {
+    # When the supplied secret already matches, the version remains valid.
+    echo "ABCDEFGHIJKLMNOP" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    echo "7" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")" = "7" ]
+}
+
+@test "claim set never invokes systemctl (no daemon consumes the secret)" {
+    # The claim secret is consumed only by apl-feed itself, not by
+    # airplanes-feed or airplanes-mlat. Saving it must not bounce a
+    # working feeder. Use a sentinel stub that fails the test if invoked.
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+echo "systemctl invoked with: $*" >&2
+exit 99
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "systemctl invoked" ]]
+    [[ ! "$output" =~ "Restarted" ]]
+}
+
+@test "claim set is idempotent when supplied secret already matches local" {
+    echo "ABCDEFGHIJKLMNOP" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "already matches" ]]
+}
+
+@test "claim set refuses to overwrite a different existing secret without --force" {
+    echo "OLDSECRETXYZ1234" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"NEWSECRETXYZ5678"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "different claim secret" ]]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "OLDSECRETXYZ1234" ]
+}
+
+@test "claim set with --force replaces a different existing secret" {
+    echo "OLDSECRETXYZ1234" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" --force <<<"NEWSECRETXYZ5678"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "NEWSECRETXYZ5678" ]
+}
+
+@test "claim set rejects malformed input" {
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"not-a-secret"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "invalid claim secret format" ]]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
+}
+
+@test "claim set drops any stale .pending file" {
+    echo "PENDINGSECRETXY1" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"abcd-efgh-ijkl-mnop"
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+}
+
+@test "claim set --dry-run does not write or restart services" {
+    local restart_log="$ROOT_DIR/restart.log"
+    cat > "$STUB_BIN_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+    restart) printf 'restarted %s\n' "\$2" >> "$restart_log"; exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" --dry-run <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dry-run" ]]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
+    [ ! -f "$restart_log" ]
+}
+
+@test "id set writes a new UUID and restarts both daemons feed-first" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+    local restart_log="$ROOT_DIR/restart.log"
+    cat > "$STUB_BIN_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+    is-active|is-enabled) exit 0 ;;
+    restart) printf '%s\n' "\$2" >> "$restart_log"; exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+
+    # Bypass the --root != / restart skip by sourcing the modules and
+    # calling id_set directly with ROOT="/", with the host paths
+    # redirected via shadowed helpers. Easier: stub feeder_id_path so it
+    # writes inside ROOT_DIR. We do that by overriding ROOT for the
+    # filesystem helpers but unsetting it for the restart helper. The
+    # cleanest way is to test the restart helper directly here, then
+    # cover write semantics with --root != / in a separate test.
+    run env PATH="$STUB_BIN_DIR:$PATH" bash -c "
+        source '$BATS_TEST_DIRNAME/../scripts/apl-feed/common.sh'
+        ROOT=/
+        restart_feeder_services
+    "
+
+    [ "$status" -eq 0 ]
+    # Feed must be restarted before mlat (line 1 vs line 2).
+    [ "$(sed -n '1p' "$restart_log")" = "airplanes-feed" ]
+    [ "$(sed -n '2p' "$restart_log")" = "airplanes-mlat" ]
+}
+
+@test "id set writes a new UUID with --root != / (no systemctl)" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+echo "systemctl invoked with: $*" >&2
+exit 99
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+
+    run env "$SCRIPT" id set --root "$ROOT_DIR" <<<"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" ]
+    [[ "$output" =~ "Feeder ID saved." ]]
+    [[ "$output" =~ "Skipping service restart" ]]
+    [[ ! "$output" =~ "systemctl invoked" ]]
+}
+
+@test "id set is idempotent when supplied UUID already matches" {
+    # The default fixture writes 11111111-2222-3333-4444-555555555555.
+    run env "$SCRIPT" id set --root "$ROOT_DIR" <<<"11111111-2222-3333-4444-555555555555"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "already matches" ]]
+}
+
+@test "id set refuses to overwrite a different existing UUID without --force" {
+    # Default fixture has 1111-2222-3333-4444-...; supply a different UUID.
+    run env "$SCRIPT" id set --root "$ROOT_DIR" <<<"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "different Feeder ID" ]]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "11111111-2222-3333-4444-555555555555" ]
+}
+
+@test "id set --force prints OLD -> NEW and replaces UUID" {
+    run env "$SCRIPT" id set --root "$ROOT_DIR" --force <<<"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Old: 11111111-2222-3333-4444-555555555555" ]]
+    [[ "$output" =~ "New: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" ]]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" ]
+    # Soft warning about the old website-side record.
+    [[ "$output" =~ "previous Feeder ID's record on airplanes.live is not removed" ]]
+}
+
+@test "id set --force replaces a malformed existing Feeder ID" {
+    echo "garbage-not-a-uuid" > "$ROOT_DIR/etc/airplanes/feeder-id"
+
+    run env "$SCRIPT" id set --root "$ROOT_DIR" --force <<<"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" ]
+}
+
+@test "id set without --force refuses to touch a malformed existing UUID file" {
+    echo "garbage-not-a-uuid" > "$ROOT_DIR/etc/airplanes/feeder-id"
+
+    run env "$SCRIPT" id set --root "$ROOT_DIR" <<<"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "malformed or unreadable" ]]
+}
+
+@test "id set rejects malformed input" {
+    run env "$SCRIPT" id set --root "$ROOT_DIR" <<<"not-a-uuid"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "invalid Feeder ID" ]]
+}
+
+@test "id set --dry-run does not write or restart" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+    run env "$SCRIPT" id set --root "$ROOT_DIR" --dry-run <<<"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dry-run" ]]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-id" ]
+}
+
+@test "restore --uuid form writes UUID + secret atomically and restarts" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+
+    run bash -c "printf %s 'abcd-efgh-ijkl-mnop' | '$SCRIPT' restore --uuid AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE --root '$ROOT_DIR'"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+    [[ "$output" =~ "Restored feeder config" ]]
+}
+
+@test "restore --uuid rejects malformed UUID" {
+    run bash -c "printf %s 'ABCDEFGHIJKLMNOP' | '$SCRIPT' restore --uuid not-a-uuid --root '$ROOT_DIR'"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "invalid --uuid value" ]]
+}
+
+@test "restore --uuid rejects malformed secret on stdin" {
+    run bash -c "printf %s 'too-short' | '$SCRIPT' restore --uuid AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE --root '$ROOT_DIR'"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "invalid claim secret" ]]
+}
+
+@test "restore --uuid + backup file rejected" {
+    run env "$SCRIPT" restore --uuid AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE /tmp/some-backup --root "$ROOT_DIR"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "mutually exclusive" ]]
+}
+
+@test "restore --uuid --check validates without writing" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run bash -c "printf %s 'abcd-efgh-ijkl-mnop' | '$SCRIPT' restore --uuid AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE --check --root '$ROOT_DIR'"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Inputs are valid" ]]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-id" ]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
+}
+
+@test "restore --uuid refuses different existing UUID without --force" {
+    # Default fixture UUID is 11111111-...
+    run bash -c "printf %s 'abcd-efgh-ijkl-mnop' | '$SCRIPT' restore --uuid AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE --root '$ROOT_DIR'"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "local Feeder ID differs" ]]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "11111111-2222-3333-4444-555555555555" ]
+}
+
 @test "register sends raw secret through stdin, not curl argv" {
     local bin_dir="$ROOT_DIR/bin"
     local args_file="$ROOT_DIR/curl.args"


### PR DESCRIPTION
Three new flows on the feeder-side CLI for the website-restore experience.

`apl-feed claim set` saves a website-minted claim secret on the Pi. Reads the secret from stdin so it never lands in argv or shell history. No daemon restart — neither airplanes-feed nor airplanes-mlat consumes the claim secret directly, so bouncing them on a secret change is busywork that disrupts a working feeder.

`apl-feed id set` saves a Feeder ID, prints OLD -> NEW before writing, and restarts airplanes-feed before airplanes-mlat (both consume the UUID at startup; mlat-client has a 2s sleep + nc reachability check, so letting feed settle first avoids the race). Refuses to overwrite a different existing UUID without `--force` and skips systemctl entirely when run with `--root != /` so a maintenance run against an SD-card mount cannot bounce the host.

`apl-feed restore` now also accepts `--uuid <UUID>` as an alternative to a backup file, reading the secret from stdin. The two-file commit is atomic: if the secret write fails after the UUID write succeeded, the UUID is rolled back to its prior bytes. The existing file form also gains the conditional restart on UUID change.

32 bats tests cover the three new flows and lock in the no-restart contract for claim set.