### PR TITLE
Read /etc/airplanes/release-channel as fallback for AIRPLANES_FEED_BRANCH

### DIFF
--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -5,6 +5,20 @@
 
 AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
 AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
+
+# Image-built feeders pin their runtime-update branch to the channel they were
+# built from via /etc/airplanes/release-channel. Without this, a dev-channel
+# image falls back to feed/main on the first webconfig-triggered update and
+# self-replaces update.sh with the older main version (sticky regression: the
+# pin is never re-asserted because main's update.sh has no awareness of it).
+# Manual installs without the file get the historical "main" default.
+if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
+    _release_channel_file="${AIRPLANES_ROOT%/}/etc/airplanes/release-channel"
+    if [[ -r "$_release_channel_file" ]]; then
+        AIRPLANES_FEED_BRANCH="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
+    fi
+    unset _release_channel_file
+fi
 AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
 
 airplanes_path() {

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -12,10 +12,25 @@ AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/fe
 # self-replaces update.sh with the older main version (sticky regression: the
 # pin is never re-asserted because main's update.sh has no awareness of it).
 # Manual installs without the file get the historical "main" default.
+#
+# Allowlist enforced: only {main, dev}. An existing file with a different
+# value is treated as operator error and aborts the update — silently
+# falling back to "main" would recreate the dev → main downgrade through
+# corruption instead of absence. Image build (image stage 06) applies the
+# same allowlist so a typoed AIRPLANES_FEED_BRANCH never reaches a flashed
+# rootfs.
 if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
     _release_channel_file="${AIRPLANES_ROOT%/}/etc/airplanes/release-channel"
     if [[ -r "$_release_channel_file" ]]; then
-        AIRPLANES_FEED_BRANCH="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
+        _release_channel="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
+        case "$_release_channel" in
+            main|dev) AIRPLANES_FEED_BRANCH="$_release_channel" ;;
+            *)
+                echo "ERROR: $_release_channel_file contains '$_release_channel' (expected one of: main, dev)" >&2
+                exit 1
+                ;;
+        esac
+        unset _release_channel
     fi
     unset _release_channel_file
 fi

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -203,3 +203,66 @@ write_archive_fallback_stubs() {
     grep -q -- 'pkgconf-pkg-config' "$DNF_LOG"
     grep -q -- 'libzstd-devel' "$DNF_LOG"
 }
+
+# release-channel pin: image-built feeders drop /etc/airplanes/release-channel
+# at build time, and the lib reads it as the fallback branch source so a
+# dev-channel image doesn't silently pull runtime updates from feed/main.
+
+@test "release-channel file resolves AIRPLANES_FEED_BRANCH when env is unset" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'dev\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev" ]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel file ignored when env override is set" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'dev\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env AIRPLANES_FEED_BRANCH=feature-x AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "feature-x" ]
+    rm -rf "$fresh_root"
+}
+
+@test "missing release-channel falls back to main" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel with trailing whitespace is trimmed" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'dev   \n  \n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev" ]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel only first line consulted (multi-line tolerated)" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'main\nbogus\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+    rm -rf "$fresh_root"
+}

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -266,3 +266,63 @@ write_archive_fallback_stubs() {
     [ "$output" = "main" ]
     rm -rf "$fresh_root"
 }
+
+@test "release-channel with arbitrary branch name aborts (allowlist enforced)" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'feature-x\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"feature-x"* ]]
+    [[ "$output" == *"main, dev"* ]]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel with typo (deev) aborts (allowlist enforced)" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'deev\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"deev"* ]]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel empty file aborts (does NOT silently fall back to main)" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    : > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER"
+    [ "$status" -ne 0 ]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel value is uppercase MAIN -> aborts (case-sensitive allowlist)" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'MAIN\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"MAIN"* ]]
+    rm -rf "$fresh_root"
+}
+
+@test "env override bypasses allowlist file check (operator-controlled escape)" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'feature-x\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env AIRPLANES_FEED_BRANCH=feature-x AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "feature-x" ]
+    rm -rf "$fresh_root"
+}

--- a/update.sh
+++ b/update.sh
@@ -39,6 +39,20 @@ if [[ -f "$SCRIPT_DIR/scripts/lib/install-update-common.sh" ]]; then
 else
     AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
     AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
+
+    # Image-built feeders pin their runtime-update branch to the channel they
+    # were built from via /etc/airplanes/release-channel. Without this, a
+    # dev-channel image silently falls back to feed/main and self-replaces
+    # update.sh with the older main version on the first update — sticky
+    # regression. Manual non-image installs (no release-channel file) keep
+    # the historical "main" default.
+    if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
+        _release_channel_file="${AIRPLANES_ROOT%/}/etc/airplanes/release-channel"
+        if [[ -r "$_release_channel_file" ]]; then
+            AIRPLANES_FEED_BRANCH="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
+        fi
+        unset _release_channel_file
+    fi
     AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
 
     airplanes_path() {

--- a/update.sh
+++ b/update.sh
@@ -45,11 +45,19 @@ else
     # dev-channel image silently falls back to feed/main and self-replaces
     # update.sh with the older main version on the first update — sticky
     # regression. Manual non-image installs (no release-channel file) keep
-    # the historical "main" default.
+    # the historical "main" default. Allowlist matches install-update-common.sh.
     if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
         _release_channel_file="${AIRPLANES_ROOT%/}/etc/airplanes/release-channel"
         if [[ -r "$_release_channel_file" ]]; then
-            AIRPLANES_FEED_BRANCH="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
+            _release_channel="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
+            case "$_release_channel" in
+                main|dev) AIRPLANES_FEED_BRANCH="$_release_channel" ;;
+                *)
+                    echo "ERROR: $_release_channel_file contains '$_release_channel' (expected one of: main, dev)" >&2
+                    exit 1
+                    ;;
+            esac
+            unset _release_channel
         fi
         unset _release_channel_file
     fi


### PR DESCRIPTION
AIRPLANES_FEED_BRANCH defaulted to "main" when no env override was set, which made image-built feeders silently pull runtime updates from feed/main even though build time pinned them to a different channel. The downstream symptom is sticky — update.sh self-replaces with the older feed/main version and the channel pin is lost forever.

Read `/etc/airplanes/release-channel` (one branch name per line, written by the image at build time, not user-editable) as the fallback before defaulting to "main". The matching image-side change ships the file from \$AIRPLANES_FEED_BRANCH at build (airplanes-live/image#27).

Allowlist enforced (only `main` or `dev`): an existing file with anything else aborts the update with a clear message rather than silently falling back to "main" — silent fallback would recreate the dev → main downgrade through corruption. Missing file still defaults to "main" so legacy/manual installs are unaffected. AIRPLANES_FEED_BRANCH env override still wins for maintainer canary work.

Coverage: 10 new bats cases in test_install_update_common.bats — basic resolution, env override precedence, missing file fallback, whitespace trim, multi-line tolerance, plus 5 allowlist failure modes (arbitrary branch, typo, empty content, uppercase MAIN, env-override escape).