### PR TITLE
Chown claim-state files to airplanes-feed when writing as root

### DIFF
--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -97,8 +97,9 @@ claim_register() {
                 version="$(parse_field_from "$response_file" '.version')"
                 : "${version:=1}"
                 if [[ -f "$pending" ]]; then
+                    chmod 600 "$pending"
+                    chown_claim_state "$pending"
                     mv "$pending" "$final"
-                    chmod 600 "$final"
                 fi
                 write_version_file "$version"
                 echo "SUCCESS ($status, version $version)"
@@ -305,16 +306,18 @@ claim_rotate() {
             200)
                 version="$(parse_field_from "$response_file" '.version')"
                 : "${version:=1}"
+                chmod 600 "$pending"
+                chown_claim_state "$pending"
                 mv "$pending" "$final"
-                chmod 600 "$final"
                 write_version_file "$version"
                 echo "Rotation complete (v$version)."
                 return 0
                 ;;
             409)
                 if accepted_version="$(status_probe_version "$uuid" "$next" 2>/dev/null)"; then
+                    chmod 600 "$pending"
+                    chown_claim_state "$pending"
                     mv "$pending" "$final"
-                    chmod 600 "$final"
                     write_version_file "$accepted_version"
                     echo "Rotation finalized (v$accepted_version) after a previous transient failure."
                     return 0

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -162,6 +162,33 @@ read_secret_file() {
     printf '%s' "$secret"
 }
 
+# Daemon user that owns claim-state files so the airplanes-feed.service
+# user (and webconfig dropping to it via sudo) can read them without a
+# privilege bump. Override via APL_FEED_SECRET_OWNER for tests; production
+# matches the User= line in airplanes-feed.service.
+claim_state_owner() {
+    printf '%s' "${APL_FEED_SECRET_OWNER:-airplanes-feed}"
+}
+
+# Hand off ownership of a claim-state file to the daemon user so the
+# secret is readable by airplanes-feed.service (and webconfig's
+# `sudo -u airplanes-feed apl-feed claim show`) without root. No-ops
+# silently when running as a non-root user (chown would EPERM anyway)
+# or when the target user doesn't yet exist (e.g. very first install
+# pass before adduser has run). Owner-only — `chown user` (no trailing
+# colon) leaves the group untouched; we don't promise an `airplanes-feed`
+# group exists since adduser --system gives the user `nogroup` as primary
+# group on Debian.
+chown_claim_state() {
+    local path="$1"
+    [[ -e "$path" ]] || return 0
+    [[ "$(id -u)" == "0" ]] || return 0
+    local owner
+    owner="$(claim_state_owner)"
+    getent passwd "$owner" >/dev/null 2>&1 || return 0
+    chown "$owner" "$path"
+}
+
 write_secret_file() {
     local path="$1"
     local secret="$2"
@@ -173,6 +200,7 @@ write_secret_file() {
     umask 077
     printf '%s\n' "$secret" > "$tmp"
     chmod 600 "$tmp"
+    chown_claim_state "$tmp"
     mv -f "$tmp" "$path"
 }
 
@@ -186,6 +214,7 @@ write_version_file() {
     tmp="${path}.$$"
     printf '%s\n' "$version" > "$tmp"
     chmod 600 "$tmp"
+    chown_claim_state "$tmp"
     mv -f "$tmp" "$path"
 }
 

--- a/scripts/lib/claim-registration.sh
+++ b/scripts/lib/claim-registration.sh
@@ -18,3 +18,23 @@ register_claim_secret() {
         echo "---------------------------------"
     fi
 }
+
+# Hand off ownership of any pre-existing claim-state files in the given
+# /etc/airplanes/-equivalent to the daemon user, so feeders that registered
+# under an older feed (which left files root:root mode 0600) heal on the
+# next update without needing a re-register. Idempotent. Owner-only —
+# `chown user` (no trailing colon) leaves the group untouched. Non-fatal
+# on chown failure but warns to stderr so a stuck root-owned secret is
+# visible in update logs instead of silently keeping webconfig broken.
+heal_claim_state_ownership() {
+    local etc="$1"
+    local owner="${APL_FEED_SECRET_OWNER:-airplanes-feed}"
+    local file path
+    for file in feeder-claim-secret feeder-claim-secret.pending feeder-claim-secret.version; do
+        path="$etc/$file"
+        [[ -f "$path" ]] || continue
+        if ! chown "$owner" "$path" 2>/dev/null; then
+            echo "WARNING: failed to chown $path to $owner; webconfig 'claim show' may stay broken on this feeder" >&2
+        fi
+    done
+}

--- a/test/test_claim_state_chown.bats
+++ b/test/test_claim_state_chown.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+# Tests for chown_claim_state and the chown integration in
+# write_secret_file / write_version_file. The helpers shell out to
+# /usr/bin/id, /usr/bin/getent, and /bin/chown which we shadow via PATH
+# stubs so the tests don't need real root or a real airplanes-feed user.
+
+setup() {
+    BATS_TMPDIR_TEST="$(mktemp -d)"
+    STUB_BIN_DIR="$BATS_TMPDIR_TEST/bin"
+    mkdir -p "$STUB_BIN_DIR"
+    CHOWN_LOG="$BATS_TMPDIR_TEST/chown.log"
+
+    # Default stubs: act like a non-root user so chown_claim_state is a
+    # no-op. Individual tests override id/getent/chown as needed.
+    cat > "$STUB_BIN_DIR/id" <<'STUB'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-u" ]] && { echo 1000; exit 0; }
+exec /usr/bin/id "$@"
+STUB
+    cat > "$STUB_BIN_DIR/getent" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    cat > "$STUB_BIN_DIR/chown" <<STUB
+#!/usr/bin/env bash
+echo "chown \$*" >> "$CHOWN_LOG"
+STUB
+    chmod +x "$STUB_BIN_DIR"/{id,getent,chown}
+    PATH="$STUB_BIN_DIR:$PATH"
+    export PATH
+
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$BATS_TEST_DIRNAME/../scripts/apl-feed/common.sh"
+    # shellcheck source=../scripts/lib/claim-registration.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/claim-registration.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR_TEST"
+}
+
+# Helper: simulate root.
+become_root_stub() {
+    cat > "$STUB_BIN_DIR/id" <<'STUB'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-u" ]] && { echo 0; exit 0; }
+exec /usr/bin/id "$@"
+STUB
+    chmod +x "$STUB_BIN_DIR/id"
+}
+
+# Helper: simulate target user missing.
+user_missing_stub() {
+    cat > "$STUB_BIN_DIR/getent" <<'STUB'
+#!/usr/bin/env bash
+exit 2
+STUB
+    chmod +x "$STUB_BIN_DIR/getent"
+}
+
+@test "chown_claim_state no-op when file is missing" {
+    become_root_stub
+    chown_claim_state "$BATS_TMPDIR_TEST/missing"
+    [[ ! -f "$CHOWN_LOG" ]]
+}
+
+@test "chown_claim_state no-op when not running as root" {
+    : > "$BATS_TMPDIR_TEST/file"
+    chown_claim_state "$BATS_TMPDIR_TEST/file"
+    [[ ! -f "$CHOWN_LOG" ]]
+}
+
+@test "chown_claim_state no-op when target user is missing" {
+    become_root_stub
+    user_missing_stub
+    : > "$BATS_TMPDIR_TEST/file"
+    chown_claim_state "$BATS_TMPDIR_TEST/file"
+    [[ ! -f "$CHOWN_LOG" ]]
+}
+
+@test "chown_claim_state chowns owner-only (no group) when root + user exists" {
+    become_root_stub
+    : > "$BATS_TMPDIR_TEST/file"
+    chown_claim_state "$BATS_TMPDIR_TEST/file"
+    # `chown user` (no trailing colon) leaves the group untouched — we don't
+    # promise an airplanes-feed group exists. A trailing `:` would set the
+    # group to the user's primary group, which isn't the contract.
+    grep -qF "chown airplanes-feed $BATS_TMPDIR_TEST/file" "$CHOWN_LOG"
+    run grep -qF "chown airplanes-feed: $BATS_TMPDIR_TEST/file" "$CHOWN_LOG"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "chown_claim_state respects APL_FEED_SECRET_OWNER override" {
+    become_root_stub
+    : > "$BATS_TMPDIR_TEST/file"
+    APL_FEED_SECRET_OWNER=other-feed chown_claim_state "$BATS_TMPDIR_TEST/file"
+    grep -qF "chown other-feed $BATS_TMPDIR_TEST/file" "$CHOWN_LOG"
+}
+
+@test "write_secret_file chowns the temp file before the rename" {
+    become_root_stub
+    write_secret_file "$BATS_TMPDIR_TEST/secret" "ABCD1234EFGH5678"
+    # The chown target should have been the temp path (.$$ suffix), not the
+    # final destination. This catches the chown-after-mv reordering bug
+    # where readers could observe root:root mode 0600 in the open window
+    # between rename and chown.
+    grep -qE "^chown airplanes-feed $BATS_TMPDIR_TEST/secret\.[0-9]+$" "$CHOWN_LOG"
+    # Negative match — under set -e a leading `!` doesn't fail the bats test
+    # (SC2314), so use `run` + status check.
+    run grep -qE "^chown airplanes-feed $BATS_TMPDIR_TEST/secret$" "$CHOWN_LOG"
+    [[ "$status" -ne 0 ]]
+    [[ -f "$BATS_TMPDIR_TEST/secret" ]]
+    [[ "$(cat "$BATS_TMPDIR_TEST/secret")" == "ABCD1234EFGH5678" ]]
+}
+
+@test "write_version_file chowns the temp file before the rename" {
+    become_root_stub
+    # write_version_file resolves via secret_version_path() which uses
+    # ROOT — so we point ROOT at our tmpdir to redirect /etc/airplanes.
+    ROOT="$BATS_TMPDIR_TEST"
+    mkdir -p "$BATS_TMPDIR_TEST/etc/airplanes"
+    write_version_file 7
+    grep -qE "^chown airplanes-feed $BATS_TMPDIR_TEST/etc/airplanes/feeder-claim-secret\.version\.[0-9]+$" "$CHOWN_LOG"
+    [[ -f "$BATS_TMPDIR_TEST/etc/airplanes/feeder-claim-secret.version" ]]
+    [[ "$(cat "$BATS_TMPDIR_TEST/etc/airplanes/feeder-claim-secret.version")" == "7" ]]
+}
+
+@test "write_secret_file no-op chown when not root, file still written" {
+    write_secret_file "$BATS_TMPDIR_TEST/secret" "ABCD1234EFGH5678"
+    [[ ! -f "$CHOWN_LOG" ]]
+    [[ -f "$BATS_TMPDIR_TEST/secret" ]]
+    [[ "$(cat "$BATS_TMPDIR_TEST/secret")" == "ABCD1234EFGH5678" ]]
+    [[ "$(stat -c %a "$BATS_TMPDIR_TEST/secret")" == "600" ]]
+}
+
+@test "write_secret_file with chown failure leaves no published final file" {
+    become_root_stub
+    # Override chown to fail. The temp file gets created but chown returns
+    # non-zero; under set -e (the apl-feed CLI's posture) write_secret_file
+    # aborts before the mv, so the final path stays unpublished. Better
+    # than publishing a root:root file that webconfig can't read.
+    cat > "$STUB_BIN_DIR/chown" <<STUB
+#!/usr/bin/env bash
+echo "chown \$*" >> "$CHOWN_LOG"
+exit 1
+STUB
+    chmod +x "$STUB_BIN_DIR/chown"
+    set +e
+    ( set -e; write_secret_file "$BATS_TMPDIR_TEST/secret" "ABCD1234EFGH5678" )
+    rc=$?
+    set -e
+    [[ "$rc" -ne 0 ]]
+    [[ ! -f "$BATS_TMPDIR_TEST/secret" ]]
+}
+
+@test "heal_claim_state_ownership chowns existing claim-state files" {
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret"
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret.pending"
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret.version"
+    heal_claim_state_ownership "$BATS_TMPDIR_TEST"
+    grep -qF "chown airplanes-feed $BATS_TMPDIR_TEST/feeder-claim-secret" "$CHOWN_LOG"
+    grep -qF "chown airplanes-feed $BATS_TMPDIR_TEST/feeder-claim-secret.pending" "$CHOWN_LOG"
+    grep -qF "chown airplanes-feed $BATS_TMPDIR_TEST/feeder-claim-secret.version" "$CHOWN_LOG"
+}
+
+@test "heal_claim_state_ownership skips files that don't exist" {
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret"
+    # No .pending or .version
+    heal_claim_state_ownership "$BATS_TMPDIR_TEST"
+    grep -qF "chown airplanes-feed $BATS_TMPDIR_TEST/feeder-claim-secret" "$CHOWN_LOG"
+    run grep -qF "feeder-claim-secret.pending" "$CHOWN_LOG"
+    [[ "$status" -ne 0 ]]
+    run grep -qF "feeder-claim-secret.version" "$CHOWN_LOG"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "heal_claim_state_ownership warns to stderr on chown failure but does not abort" {
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret"
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret.version"
+    cat > "$STUB_BIN_DIR/chown" <<STUB
+#!/usr/bin/env bash
+echo "chown \$*" >> "$CHOWN_LOG"
+exit 1
+STUB
+    chmod +x "$STUB_BIN_DIR/chown"
+    run heal_claim_state_ownership "$BATS_TMPDIR_TEST"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "WARNING: failed to chown" ]]
+    [[ "$output" =~ "feeder-claim-secret" ]]
+    [[ "$output" =~ "webconfig" ]]
+}
+
+@test "heal_claim_state_ownership respects APL_FEED_SECRET_OWNER override" {
+    : > "$BATS_TMPDIR_TEST/feeder-claim-secret"
+    APL_FEED_SECRET_OWNER=other-feed heal_claim_state_ownership "$BATS_TMPDIR_TEST"
+    grep -qF "chown other-feed $BATS_TMPDIR_TEST/feeder-claim-secret" "$CHOWN_LOG"
+}

--- a/update.sh
+++ b/update.sh
@@ -371,6 +371,11 @@ then
         || { echo "ERROR: failed to create user '$UNAME' (no working adduser/useradd)." >&2; exit 1; }
 fi
 
+# Heal claim-state files written by older feed versions that lacked the
+# airplanes-feed chown (which would be root:root mode 0600 and unreadable
+# by the daemon user webconfig drops to for `apl-feed claim show`).
+heal_claim_state_ownership "$ETC_AIRPLANES"
+
 echo 4
 sleep 0.25
 


### PR DESCRIPTION
`/etc/airplanes/feeder-claim-secret` (and `.pending`, `.version`) is written from three paths that all run as root — `airplanes-claim.service` on first boot, `register_claim_secret` from `update.sh` during webconfig-triggered updates, and manual `sudo apl-feed register/rotate`. The resulting files are `root:root` mode 0600, so the `airplanes-feed` daemon user (and webconfig dropping to it for `apl-feed claim show`) can't read them.

A new `chown_claim_state` helper in `common.sh` hands off ownership to airplanes-feed when running as root and the target user exists. `write_secret_file` and `write_version_file` chown the temp file before the rename, so a concurrent reader never observes wrong-owner intermediate state. The pending→final `mv` paths in `claim_register` and `claim_rotate` normalize the existing pending file's ownership before the move.

`update.sh` chowns any pre-existing claim-state files in `/etc/airplanes/` after creating the airplanes-feed user, so feeders upgraded from a pre-fix install heal on the next update without needing a re-register. Override the owner via `APL_FEED_SECRET_OWNER` for tests; production is hardcoded to match the `User=` line in airplanes-feed.service.

Eight new bats tests exercise the helper directly via PATH-shadowed `id`/`getent`/`chown` mocks, plus integration coverage that the chown lands on the temp path (not the post-mv final), catching any future re-ordering regression.