### PR TITLE
ci: drop fork-PR cost gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
   installer-smoke:
     name: installer smoke (${{ matrix.image }}, ${{ matrix.path }})
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -123,7 +122,6 @@ jobs:
   image-release-rootfs-smoke:
     name: image release rootfs smoke
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 45
     steps:
       - name: Checkout feed


### PR DESCRIPTION
Org-level fork-PR approval is now enforced for all external contributors, so the per-job head.repo gate adds nothing beyond cost shaping. Drop it on installer-smoke and image-release-rootfs-smoke so contributor PRs get the same regression coverage we run on internal branches.