### PR TITLE
Add bats coverage for uninstall.sh

### DIFF
--- a/test/test_uninstall_script.bats
+++ b/test/test_uninstall_script.bats
@@ -1,0 +1,287 @@
+#!/usr/bin/env bats
+
+setup() {
+    UNINSTALL="$BATS_TEST_DIRNAME/../uninstall.sh"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    TAR1090_LOG="$ROOT_DIR/tar1090.log"
+    mkdir -p "$STUB_DIR"
+
+    # systemctl stub: log every invocation to a file path passed in via env.
+    # Using an env-var file path (not stdout/stderr) is required because the
+    # script invokes `systemctl disable --now airplanes-mlat2 &>/dev/null`,
+    # which would silence any stdio-based capture.
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+run_uninstall() {
+    run env -i \
+        PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR" \
+        SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+        TAR1090_LOG="$TAR1090_LOG" \
+        bash "$UNINSTALL"
+}
+
+# Drop a sandboxed tar1090 uninstall stub at $ROOT/usr/local/share/tar1090/uninstall.sh.
+# The stub appends its argv to TAR1090_LOG so callers can detect whether the
+# real script invoked it.
+write_tar1090_stub() {
+    local dir="$ROOT_DIR/usr/local/share/tar1090"
+    mkdir -p "$dir"
+    cat > "$dir/uninstall.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$TAR1090_LOG"
+exit 0
+SH
+    chmod +x "$dir/uninstall.sh"
+}
+
+@test "uninstall.sh runs idempotently with no prior install" {
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -d "$ROOT_DIR/usr/local/share/airplanes" ]
+    [ -z "$(ls -A "$ROOT_DIR/usr/local/share/airplanes")" ]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feeder-id" ]
+    [ -f "$SYSTEMCTL_LOG" ]
+}
+
+@test "uninstall.sh disables services in mlat -> mlat2 -> feed order, then daemon-reloads, exactly four calls" {
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+
+    local first second third fourth count
+    first="$(sed -n '1p' "$SYSTEMCTL_LOG")"
+    second="$(sed -n '2p' "$SYSTEMCTL_LOG")"
+    third="$(sed -n '3p' "$SYSTEMCTL_LOG")"
+    fourth="$(sed -n '4p' "$SYSTEMCTL_LOG")"
+    count="$(wc -l < "$SYSTEMCTL_LOG" | tr -d '[:space:]')"
+    [ "$first" = "disable --now airplanes-mlat" ]
+    [ "$second" = "disable --now airplanes-mlat2" ]
+    [ "$third" = "disable --now airplanes-feed" ]
+    [ "$fourth" = "daemon-reload" ]
+    [ "$count" = "4" ]
+}
+
+@test "uninstall.sh removes the three airplanes systemd unit files and leaves others alone" {
+    mkdir -p "$ROOT_DIR/lib/systemd/system"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-mlat.service"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-mlat2.service"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-feed.service"
+    : > "$ROOT_DIR/lib/systemd/system/keep-this.service"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-mlat.service" ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-mlat2.service" ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-feed.service" ]
+    [ -e "$ROOT_DIR/lib/systemd/system/keep-this.service" ]
+}
+
+@test "uninstall.sh wipes IPATH contents and recreates the directory" {
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git/sub"
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/.cache"
+    : > "$ROOT_DIR/usr/local/share/airplanes/marker"
+    : > "$ROOT_DIR/usr/local/share/airplanes/git/sub/file"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -d "$ROOT_DIR/usr/local/share/airplanes" ]
+    [ -z "$(ls -A "$ROOT_DIR/usr/local/share/airplanes")" ]
+}
+
+@test "canonical feeder-id is preserved across wipe and the legacy symlink is recreated" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    printf 'canonical-uuid-content\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git"
+    : > "$ROOT_DIR/usr/local/share/airplanes/git/marker"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/git/marker" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "canonical-uuid-content" ]
+    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+    [ "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+}
+
+@test "legacy fallback is materialized to canonical when canonical is absent" {
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    printf 'legacy-uuid-content\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/etc/airplanes/feeder-id" ]
+
+    # Byte-exact comparison: legacy was UUID + single newline; output should match exactly.
+    local expected="$ROOT_DIR/expected.bin"
+    printf 'legacy-uuid-content\n' > "$expected"
+    cmp "$expected" "$ROOT_DIR/etc/airplanes/feeder-id"
+
+    # Materialized canonical must be 0644.
+    [ "$(stat -c '%a' "$ROOT_DIR/etc/airplanes/feeder-id")" = "644" ]
+
+    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+    [ "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+}
+
+@test "legacy without a trailing newline is normalized to one trailing newline (UUID-format contract)" {
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    printf 'legacy-no-newline' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/etc/airplanes/feeder-id" ]
+
+    local expected="$ROOT_DIR/expected.bin"
+    printf 'legacy-no-newline\n' > "$expected"
+    cmp "$expected" "$ROOT_DIR/etc/airplanes/feeder-id"
+}
+
+@test "empty legacy file still triggers materialization and symlink restoration" {
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    : > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    # Canonical materialized as a one-newline file (matches the contract).
+    [ -f "$ROOT_DIR/etc/airplanes/feeder-id" ]
+    local expected="$ROOT_DIR/expected.bin"
+    printf '\n' > "$expected"
+    cmp "$expected" "$ROOT_DIR/etc/airplanes/feeder-id"
+    # Legacy symlink restored on top of the wiped IPATH.
+    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+}
+
+@test "legacy UUID content is not leaked into trace output by set -x" {
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    local secret_marker="LEGACY-LEAK-CANARY-9F3B7A"
+    printf '%s\n' "$secret_marker" > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    # The materialized file must contain the legacy content...
+    grep -q "$secret_marker" "$ROOT_DIR/etc/airplanes/feeder-id"
+    # ...but the bash trace must not.
+    if printf '%s' "$output" | grep -q "$secret_marker"; then
+        echo "secret marker leaked into trace output: $output" >&2
+        return 1
+    fi
+}
+
+@test "canonical wins over legacy when both exist with different values" {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    printf 'CANONICAL-UUID\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    printf 'legacy-different\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "CANONICAL-UUID" ]
+    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+    [ "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+}
+
+@test "no feeder-id is created when neither canonical nor legacy existed" {
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feeder-id" ]
+    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+}
+
+@test "tar1090 uninstall hook fires when html-airplanes/ exists, with sandboxed gate AND invocation" {
+    write_tar1090_stub
+    mkdir -p "$ROOT_DIR/usr/local/share/tar1090/html-airplanes"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$TAR1090_LOG" ]
+    [ "$(cat "$TAR1090_LOG")" = "airplanes" ]
+}
+
+@test "tar1090 uninstall hook is skipped when html-airplanes/ is absent" {
+    write_tar1090_stub
+    # Note: html-airplanes/ deliberately not created.
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$TAR1090_LOG" ]
+}
+
+@test "tar1090 hook with html-airplanes/ but missing uninstall.sh does not abort the rest of the script" {
+    # html-airplanes/ exists but the tar1090 uninstall script is absent.
+    # The script must keep going (it has no set -e) and still wipe IPATH +
+    # daemon-reload + report success.
+    mkdir -p "$ROOT_DIR/usr/local/share/tar1090/html-airplanes"
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git"
+    : > "$ROOT_DIR/usr/local/share/airplanes/git/marker"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/git/marker" ]
+    grep -q "daemon-reload" "$SYSTEMCTL_LOG"
+}
+
+@test "tar1090 hook is best-effort: nonzero exit does not abort the script" {
+    mkdir -p "$ROOT_DIR/usr/local/share/tar1090/html-airplanes"
+    cat > "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh" <<'SH'
+#!/usr/bin/env bash
+exit 7
+SH
+    chmod +x "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh"
+
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git"
+    : > "$ROOT_DIR/usr/local/share/airplanes/git/marker"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/git/marker" ]
+    grep -q "daemon-reload" "$SYSTEMCTL_LOG"
+}
+
+@test "tar1090 hook runs before IPATH is wiped (ordering guard for tar1090 dependencies on IPATH)" {
+    mkdir -p "$ROOT_DIR/usr/local/share/tar1090/html-airplanes"
+    cat > "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh" <<'SH'
+#!/usr/bin/env bash
+if [[ -f "$AIRPLANES_ROOT/usr/local/share/airplanes/marker-during-hook" ]]; then
+    printf 'IPATH-INTACT\n' >> "$TAR1090_LOG"
+else
+    printf 'IPATH-WIPED\n' >> "$TAR1090_LOG"
+fi
+exit 0
+SH
+    chmod +x "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh"
+
+    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    : > "$ROOT_DIR/usr/local/share/airplanes/marker-during-hook"
+
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$TAR1090_LOG" ]
+    [ "$(cat "$TAR1090_LOG")" = "IPATH-INTACT" ]
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 set -x
 
-IPATH=/usr/local/share/airplanes
-FEEDER_ID=/etc/airplanes/feeder-id
+AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
+
+airplanes_path() {
+    local path="$1"
+    if [[ "$AIRPLANES_ROOT" == "/" ]]; then
+        printf '%s' "$path"
+    else
+        printf '%s%s' "${AIRPLANES_ROOT%/}" "$path"
+    fi
+}
+
+IPATH="$(airplanes_path /usr/local/share/airplanes)"
+FEEDER_ID="$(airplanes_path /etc/airplanes/feeder-id)"
 LEGACY_UUID="$IPATH/airplanes-uuid"
+SYSTEMD_DIR="$(airplanes_path /lib/systemd/system)"
+TAR1090_DIR="$(airplanes_path /usr/local/share/tar1090)"
 
 systemctl disable --now airplanes-mlat
 systemctl disable --now airplanes-mlat2 &>/dev/null
@@ -12,24 +25,49 @@ systemctl disable --now airplanes-feed
 # Legacy cleanup: earlier releases shipped install-or-update-interface.sh, which
 # installed wiedehopf/tar1090 with the "airplanes" URL prefix. The installer is
 # gone, but existing systems may still have it set up — keep removing it here.
-if [[ -d /usr/local/share/tar1090/html-airplanes ]]; then
-    bash /usr/local/share/tar1090/uninstall.sh airplanes
+if [[ -d "$TAR1090_DIR/html-airplanes" ]]; then
+    bash "$TAR1090_DIR/uninstall.sh" airplanes
 fi
 
-rm -f /lib/systemd/system/airplanes-mlat.service
-rm -f /lib/systemd/system/airplanes-mlat2.service
-rm -f /lib/systemd/system/airplanes-feed.service
+rm -f "$SYSTEMD_DIR/airplanes-mlat.service"
+rm -f "$SYSTEMD_DIR/airplanes-mlat2.service"
+rm -f "$SYSTEMD_DIR/airplanes-feed.service"
+systemctl daemon-reload || true
 
-if [[ -f "$FEEDER_ID" ]]; then
-    cp -f "$FEEDER_ID" /tmp/airplanes-feeder-id
-elif [[ -f "$LEGACY_UUID" ]]; then
-    cp -f "$LEGACY_UUID" /tmp/airplanes-feeder-id
+# Preserve the legacy fallback in memory before wiping IPATH so the canonical
+# feeder-id can be materialized from it if no canonical copy exists. The
+# canonical feeder-id lives at /etc/airplanes/feeder-id (outside IPATH) and
+# survives the wipe untouched, so it does not need shuttling.
+#
+# Bytes are not preserved verbatim: command substitution strips trailing
+# newlines and the materialize step re-adds exactly one. This is intentional
+# and acceptable because feeder-id is always a UUID followed by a single
+# newline (see create-uuid.sh).
+#
+# xtrace is disabled around the read and write so the UUID does not appear in
+# stderr trace output (the original cp-based shuttle did not print contents).
+LEGACY_FALLBACK_VALID=0
+LEGACY_UUID_CONTENT=""
+if [[ ! -f "$FEEDER_ID" && -f "$LEGACY_UUID" ]]; then
+    { set +x; } 2>/dev/null
+    if LEGACY_UUID_CONTENT="$(cat "$LEGACY_UUID")"; then
+        LEGACY_FALLBACK_VALID=1
+    fi
+    set -x
 fi
+
 rm -rf "$IPATH"
 mkdir -p "$IPATH"
-if [[ -f /tmp/airplanes-feeder-id ]]; then
+
+if [[ ! -f "$FEEDER_ID" && "$LEGACY_FALLBACK_VALID" -eq 1 ]]; then
     mkdir -p "$(dirname "$FEEDER_ID")"
-    mv -f /tmp/airplanes-feeder-id "$FEEDER_ID"
+    { set +x; } 2>/dev/null
+    printf '%s\n' "$LEGACY_UUID_CONTENT" > "$FEEDER_ID"
+    set -x
+    chmod 644 "$FEEDER_ID"
+fi
+
+if [[ -f "$FEEDER_ID" ]]; then
     ln -sfn '../../../../etc/airplanes/feeder-id' "$LEGACY_UUID"
 fi
 


### PR DESCRIPTION
Closes a coverage gap: `uninstall.sh` had zero tests. Refactored to honour `AIRPLANES_ROOT` (matching install.sh's pattern) so the destructive paths can run inside a sandboxed root. Dropped the redundant `/tmp` shuttle for the canonical feeder-id (it lives outside IPATH and survives the wipe untouched, and the shuttle exposed a stale-temp resurrection bug); the legacy fallback is now preserved via an in-memory variable, normalized to the UUID-on-a-line format on materialize. Added a `systemctl daemon-reload` after unit removal so stale unit references don't linger across reinstalls. The new bats file locks down idempotency, service-disable order, unit file removal, the IPATH wipe, both feeder-id preservation paths and their precedence, the tar1090 hook across present/missing/failing/ordering states, and a guard against the UUID leaking through `set -x`.