### PR TITLE
Add per-module bats coverage for apl-feed CLI helpers

### DIFF
--- a/test/test_apl_feed_backup.bats
+++ b/test/test_apl_feed_backup.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+
+# Per-module unit tests for scripts/apl-feed/backup.sh.
+#
+# Restore round-trips, --check, --uuid, rollback on secret-write
+# failure, and --dry-run rejection are covered end-to-end in
+# test_apl_feed_cli.bats — not duplicated here. This file isolates
+# read_backup_file (validation matrix) and config_backup (write
+# semantics + edge cases).
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    mkdir -p "$TMPDIR" \
+        "$ROOT_DIR/etc/airplanes" \
+        "$ROOT_DIR/usr/local/share/airplanes" \
+        "$ROOT_DIR/boot"
+    export TMPDIR
+    APL_FEED_SECRET_OWNER="$(id -un)"
+    APL_FEED_SECRET_GROUP="$(id -gn)"
+    export APL_FEED_SECRET_OWNER APL_FEED_SECRET_GROUP
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/backup.sh
+    source "$LIB_DIR/backup.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    # Most config_backup cases need a valid local UUID + secret.
+    UUID='11111111-2222-3333-4444-555555555555'
+    SECRET='ABCDEFGHIJKLMNOP'
+    printf '%s\n' "$UUID" > "$ROOT_DIR/etc/airplanes/feeder-id"
+    printf '%s\n' "$SECRET" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+write_backup() {
+    # write_backup <path> <feeder_uuid|null> <secret|null> <version|null>
+    local path="$1" uuid="$2" secret="$3" version="$4"
+    jq -n \
+        --arg uuid "$uuid" \
+        --arg secret "$secret" \
+        --arg version "$version" \
+        '{schema_version:1, created_at:"2026-04-28T00:00:00Z", feeder_uuid:$uuid, claim:{secret:$secret, version:($version | if . == "null" then null elif . == "" then empty else tonumber end)}}' \
+        > "$path"
+}
+
+# --- read_backup_file ---
+
+@test "read_backup_file: schema_version != 1 dies" {
+    jq -n '{schema_version:2, feeder_uuid:"11111111-2222-3333-4444-555555555555", claim:{secret:"ABCDEFGHIJKLMNOP"}}' > "$ROOT_DIR/bad.json"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        read_backup_file '$ROOT_DIR/bad.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unsupported backup schema_version'* ]]
+}
+
+@test "read_backup_file: missing schema_version dies" {
+    jq -n '{feeder_uuid:"11111111-2222-3333-4444-555555555555", claim:{secret:"ABCDEFGHIJKLMNOP"}}' > "$ROOT_DIR/bad.json"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        read_backup_file '$ROOT_DIR/bad.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unsupported backup schema_version'* ]]
+}
+
+@test "read_backup_file: malformed JSON dies under strict mode" {
+    printf 'not-json\n' > "$ROOT_DIR/bad.json"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        read_backup_file '$ROOT_DIR/bad.json'
+    "
+    [ "$status" -ne 0 ]
+}
+
+@test "read_backup_file: malformed feeder_uuid dies" {
+    write_backup "$ROOT_DIR/bad.json" 'not-a-uuid' 'ABCDEFGHIJKLMNOP' 'null'
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        read_backup_file '$ROOT_DIR/bad.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid feeder_uuid'* ]]
+}
+
+@test "read_backup_file: malformed claim.secret dies" {
+    write_backup "$ROOT_DIR/bad.json" '11111111-2222-3333-4444-555555555555' 'too-short' 'null'
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        read_backup_file '$ROOT_DIR/bad.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid claim.secret'* ]]
+}
+
+@test "read_backup_file: claim.version=null permitted, BACKUP_VERSION empty" {
+    write_backup "$ROOT_DIR/ok.json" '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP' 'null'
+    read_backup_file "$ROOT_DIR/ok.json"
+    [ "$BACKUP_UUID" = '11111111-2222-3333-4444-555555555555' ]
+    [ "$BACKUP_SECRET" = 'ABCDEFGHIJKLMNOP' ]
+    [ -z "$BACKUP_VERSION" ]
+}
+
+@test "read_backup_file: missing claim.version key permitted, BACKUP_VERSION empty" {
+    jq -n '{schema_version:1, created_at:"2026-04-28T00:00:00Z", feeder_uuid:"11111111-2222-3333-4444-555555555555", claim:{secret:"ABCDEFGHIJKLMNOP"}}' > "$ROOT_DIR/ok.json"
+    read_backup_file "$ROOT_DIR/ok.json"
+    [ "$BACKUP_UUID" = '11111111-2222-3333-4444-555555555555' ]
+    [ "$BACKUP_SECRET" = 'ABCDEFGHIJKLMNOP' ]
+    [ -z "$BACKUP_VERSION" ]
+}
+
+@test "read_backup_file: valid integer claim.version populates BACKUP_VERSION" {
+    write_backup "$ROOT_DIR/ok.json" '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP' '7'
+    read_backup_file "$ROOT_DIR/ok.json"
+    [ "$BACKUP_VERSION" = '7' ]
+}
+
+# --- config_backup ---
+
+@test "config_backup: refuses pre-existing output file" {
+    : > "$ROOT_DIR/out.json"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup '$ROOT_DIR/out.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'already exists'* ]]
+}
+
+@test "config_backup: refuses --force flag" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup --force '$ROOT_DIR/out.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unknown flag for backup: --force'* ]]
+}
+
+@test "config_backup: writes 0600 file" {
+    config_backup "$ROOT_DIR/out.json" >/dev/null
+    perms="$(stat -c '%a' "$ROOT_DIR/out.json" 2>/dev/null || stat -f '%Lp' "$ROOT_DIR/out.json")"
+    [ "$perms" = '600' ]
+}
+
+@test "config_backup: version=null when no version file present" {
+    config_backup "$ROOT_DIR/out.json" >/dev/null
+    run jq -r '.claim.version' "$ROOT_DIR/out.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = 'null' ]
+}
+
+@test "config_backup: integer version when version file present" {
+    printf '7\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+    config_backup "$ROOT_DIR/out.json" >/dev/null
+    run jq -r '.claim.version' "$ROOT_DIR/out.json"
+    [ "$output" = '7' ]
+}
+
+@test "config_backup: schema_version, feeder_uuid, secret round-trip via jq" {
+    config_backup "$ROOT_DIR/out.json" >/dev/null
+    [ "$(jq -r '.schema_version' "$ROOT_DIR/out.json")" = '1' ]
+    [ "$(jq -r '.feeder_uuid' "$ROOT_DIR/out.json")" = "$UUID" ]
+    [ "$(jq -r '.claim.secret' "$ROOT_DIR/out.json")" = "$SECRET" ]
+}
+
+@test "config_backup: created_at is ISO 8601 UTC" {
+    config_backup "$ROOT_DIR/out.json" >/dev/null
+    created="$(jq -r '.created_at' "$ROOT_DIR/out.json")"
+    [[ "$created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "config_backup: missing UUID file dies" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup '$ROOT_DIR/out.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'no Feeder ID file'* ]]
+}
+
+@test "config_backup: invalid UUID at primary path dies" {
+    printf 'not-a-uuid\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup '$ROOT_DIR/out.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid Feeder ID format'* ]]
+}
+
+@test "config_backup: missing existing secret file dies" {
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup '$ROOT_DIR/out.json'
+    "
+    [ "$status" -ne 0 ]
+}
+
+@test "config_backup: malformed existing secret dies" {
+    printf 'too-short\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup '$ROOT_DIR/out.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid secret format'* ]]
+}
+
+@test "config_backup: requires a file argument" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'backup requires a file'* ]]
+}
+
+@test "config_backup: rejects more than one file argument" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/backup.sh'
+        ROOT='$ROOT_DIR'
+        config_backup '$ROOT_DIR/a.json' '$ROOT_DIR/b.json'
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'exactly one file'* ]]
+}

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -440,9 +440,10 @@ STUB
 
 @test "restart_feeder_services: ROOT=/, no systemctl on PATH returns 0" {
     ROOT='/'
-    PATH="$ROOT_DIR/empty-bin"
-    run restart_feeder_services
-    [ "$status" -eq 0 ]
+    # Scope the PATH change to a subshell so bats's teardown still
+    # finds rm/etc. on the host PATH.
+    output="$(PATH="$ROOT_DIR/empty-bin" restart_feeder_services)"
+    [ -z "$output" ]
 }
 
 @test "restart_feeder_services: both inactive AND disabled skips silently" {

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -1,0 +1,632 @@
+#!/usr/bin/env bats
+
+# Per-module unit tests for scripts/apl-feed/common.sh.
+#
+# End-to-end coverage of the apl-feed dispatcher lives in
+# test_apl_feed_cli.bats. Claim-state ownership/permissions are tested
+# in test_claim_state_chown.bats — chown_claim_state and
+# write_secret_file are not retested here.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    mkdir -p "$TMPDIR" \
+        "$ROOT_DIR/etc/airplanes" \
+        "$ROOT_DIR/usr/local/share/airplanes" \
+        "$ROOT_DIR/usr/bin" \
+        "$ROOT_DIR/boot"
+    export TMPDIR
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$STUB_DIR"
+    APL_FEED_SECRET_OWNER="$(id -un)"
+    APL_FEED_SECRET_GROUP="$(id -gn)"
+    export APL_FEED_SECRET_OWNER APL_FEED_SECRET_GROUP
+
+    # common.sh registers `trap cleanup_tmp_files EXIT` at source time,
+    # which clobbers bats's own EXIT trap (the one that records skip /
+    # fail status). Capture bats's trap first and reinstate it after
+    # sourcing — without this, `skip` from inside a test silently
+    # marks the test "not run".
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Run a snippet under strict mode in a fresh subshell. Mirrors the
+# dispatcher's `set -euo pipefail` posture and prevents `set +e`/`set -e`
+# toggles inside sibling modules from leaking into the bats process.
+run_strict() {
+    run env \
+        APL_FEED_SECRET_OWNER="$APL_FEED_SECRET_OWNER" \
+        APL_FEED_SECRET_GROUP="$APL_FEED_SECRET_GROUP" \
+        TMPDIR="$TMPDIR" \
+        bash -c "
+            set -euo pipefail
+            source '$LIB_DIR/common.sh'
+            ROOT='$ROOT_DIR'
+            $1
+        "
+}
+
+# --- root_path ---
+
+@test "root_path: identity when ROOT='/'" {
+    ROOT='/'
+    run root_path '/etc/airplanes/feed.env'
+    [ "$status" -eq 0 ]
+    [ "$output" = '/etc/airplanes/feed.env' ]
+}
+
+@test "root_path: joins under ROOT='/foo'" {
+    ROOT='/foo'
+    run root_path '/etc/airplanes/feed.env'
+    [ "$status" -eq 0 ]
+    [ "$output" = '/foo/etc/airplanes/feed.env' ]
+}
+
+@test "root_path: trailing slash on ROOT is normalized" {
+    ROOT='/foo/'
+    run root_path '/etc/airplanes/feed.env'
+    [ "$status" -eq 0 ]
+    [ "$output" = '/foo/etc/airplanes/feed.env' ]
+}
+
+# --- feed_env_path / feed_env_paths ---
+
+@test "feed_env_path: returns rootfs feed.env when present" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_path
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "feed_env_path: returns boot config when image marker + boot config present" {
+    : > "$ROOT_DIR/boot/airplanes-config.txt"
+    install -m 755 /dev/null "$ROOT_DIR/usr/bin/airplanes-feeder"
+    run feed_env_path
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/boot/airplanes-config.txt" ]
+}
+
+@test "feed_env_path: falls back to rootfs feed.env when neither feed.env nor image present" {
+    run feed_env_path
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "feed_env_paths: single path when rootfs feed.env present" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_paths
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | wc -l | tr -d ' ')" = '1' ]
+    [ "$output" = "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "feed_env_paths: two paths when image marker + boot config present" {
+    : > "$ROOT_DIR/boot/airplanes-config.txt"
+    install -m 755 /dev/null "$ROOT_DIR/usr/bin/airplanes-feeder"
+    run feed_env_paths
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$ROOT_DIR/boot/airplanes-config.txt"* ]]
+    [[ "$output" == *"$ROOT_DIR/boot/airplanes-env"* ]]
+}
+
+# Documents drift with airplanes-feed.sh. airplanes-feed.sh treats
+# /etc/airplanes/image-install as an image marker (commit 269994c);
+# common.sh's feed_env_paths does not. With marker-only state (no
+# legacy /usr/bin/airplanes-feeder, no rootfs feed.env), feed_env_paths
+# falls through to the rootfs feed.env fallback.
+@test "feed_env_paths: image-install marker alone does NOT trigger image branch (drift)" {
+    : > "$ROOT_DIR/etc/airplanes/image-install"
+    : > "$ROOT_DIR/boot/airplanes-config.txt"
+    run feed_env_paths
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+# --- feed_env_get ---
+
+@test "feed_env_get: parses double-quoted value" {
+    printf 'INPUT="127.0.0.1:30005"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get INPUT
+    [ "$status" -eq 0 ]
+    [ "$output" = '127.0.0.1:30005' ]
+}
+
+@test "feed_env_get: parses single-quoted value" {
+    printf "INPUT='127.0.0.1:30005'\n" > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get INPUT
+    [ "$status" -eq 0 ]
+    [ "$output" = '127.0.0.1:30005' ]
+}
+
+@test "feed_env_get: parses unquoted value" {
+    printf 'INPUT=127.0.0.1:30005\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get INPUT
+    [ "$status" -eq 0 ]
+    [ "$output" = '127.0.0.1:30005' ]
+}
+
+@test "feed_env_get: strips trailing comment from unquoted value" {
+    printf 'GAIN=42 # autogain\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get GAIN
+    [ "$status" -eq 0 ]
+    [ "$output" = '42' ]
+}
+
+@test "feed_env_get: missing key returns 1" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get NOPE
+    [ "$status" -eq 1 ]
+}
+
+@test "feed_env_get: last value wins across multi-path output" {
+    : > "$ROOT_DIR/boot/airplanes-config.txt"
+    install -m 755 /dev/null "$ROOT_DIR/usr/bin/airplanes-feeder"
+    printf 'GAIN=42\n' > "$ROOT_DIR/boot/airplanes-config.txt"
+    printf 'GAIN=99\n' > "$ROOT_DIR/boot/airplanes-env"
+    run feed_env_get GAIN
+    [ "$status" -eq 0 ]
+    [ "$output" = '99' ]
+}
+
+# --- canonicalize_secret / validate_secret / display_secret ---
+
+@test "canonicalize_secret: strips whitespace and hyphens, uppercases" {
+    run canonicalize_secret '  abcd-EFGH ijkl-mnop  '
+    [ "$status" -eq 0 ]
+    [ "$output" = 'ABCDEFGHIJKLMNOP' ]
+}
+
+@test "validate_secret: accepts canonical 16-char A-Z 0-9" {
+    run validate_secret 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_secret: rejects 15 chars" {
+    run validate_secret 'ABCDEFGHIJKLMNO'
+    [ "$status" -ne 0 ]
+}
+
+@test "validate_secret: rejects 17 chars" {
+    run validate_secret 'ABCDEFGHIJKLMNOPQ'
+    [ "$status" -ne 0 ]
+}
+
+@test "validate_secret: rejects lowercase" {
+    run validate_secret 'abcdefghijklmnop'
+    [ "$status" -ne 0 ]
+}
+
+@test "validate_secret: rejects punctuation inside" {
+    run validate_secret 'ABCDEFGH-IJKLMNOP'
+    [ "$status" -ne 0 ]
+}
+
+@test "display_secret: groups 4-4-4-4" {
+    run display_secret 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 0 ]
+    [ "$output" = 'ABCD-EFGH-IJKL-MNOP' ]
+}
+
+# --- read_secret_file ---
+
+@test "read_secret_file: missing file returns 1" {
+    run read_secret_file "$ROOT_DIR/missing"
+    [ "$status" -eq 1 ]
+}
+
+@test "read_secret_file: malformed bytes die" {
+    printf 'not-a-valid-secret\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    run_strict 'read_secret_file "$(secret_final_path)"'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid secret'* ]]
+}
+
+@test "read_secret_file: valid file echoes canonical secret" {
+    printf 'ABCD-EFGH-IJKL-MNOP\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    run read_secret_file "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    [ "$status" -eq 0 ]
+    [ "$output" = 'ABCDEFGHIJKLMNOP' ]
+}
+
+# --- read_version_file / write_version_file ---
+
+@test "read_version_file: missing file returns 1" {
+    run read_version_file
+    [ "$status" -eq 1 ]
+}
+
+@test "read_version_file: non-numeric returns 1" {
+    printf 'banana\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+    run read_version_file
+    [ "$status" -eq 1 ]
+}
+
+@test "write_version_file/read_version_file: integer round-trips" {
+    write_version_file 7
+    run read_version_file
+    [ "$status" -eq 0 ]
+    [ "$output" = '7' ]
+}
+
+@test "write_version_file: writes 0640" {
+    write_version_file 7
+    perms="$(stat -c '%a' "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version" 2>/dev/null || stat -f '%Lp' "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")"
+    [ "$perms" = '640' ]
+}
+
+@test "write_version_file: 'null' is a no-op" {
+    run write_version_file 'null'
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version" ]
+}
+
+@test "write_version_file: empty is a no-op" {
+    run write_version_file ''
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version" ]
+}
+
+@test "write_version_file: non-numeric is a no-op" {
+    run write_version_file 'banana'
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version" ]
+}
+
+# --- canonicalize_uuid ---
+
+@test "canonicalize_uuid: lowercases hex" {
+    run canonicalize_uuid '11111111-2222-3333-4444-AAAAAAAAAAAA'
+    [ "$status" -eq 0 ]
+    [ "$output" = '11111111-2222-3333-4444-aaaaaaaaaaaa' ]
+}
+
+@test "canonicalize_uuid: strips braces" {
+    run canonicalize_uuid '{11111111-2222-3333-4444-555555555555}'
+    [ "$status" -eq 0 ]
+    [ "$output" = '11111111-2222-3333-4444-555555555555' ]
+}
+
+@test "canonicalize_uuid: strips surrounding whitespace" {
+    run canonicalize_uuid '  11111111-2222-3333-4444-555555555555  '
+    [ "$status" -eq 0 ]
+    [ "$output" = '11111111-2222-3333-4444-555555555555' ]
+}
+
+@test "canonicalize_uuid: strips embedded space and tab" {
+    run canonicalize_uuid $'11111111-2222 -3333\t-4444-555555555555'
+    [ "$status" -eq 0 ]
+    [ "$output" = '11111111-2222-3333-4444-555555555555' ]
+}
+
+@test "canonicalize_uuid: rejects too short" {
+    run canonicalize_uuid '11111111-2222-3333-4444'
+    [ "$status" -eq 1 ]
+}
+
+@test "canonicalize_uuid: rejects non-hex" {
+    run canonicalize_uuid 'GGGGGGGG-2222-3333-4444-555555555555'
+    [ "$status" -eq 1 ]
+}
+
+# --- read_uuid ---
+
+@test "read_uuid: prefers /etc/airplanes/feeder-id" {
+    printf '11111111-2222-3333-4444-555555555555\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    printf '99999999-2222-3333-4444-555555555555\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    run read_uuid
+    [ "$status" -eq 0 ]
+    [ "$output" = '11111111-2222-3333-4444-555555555555' ]
+}
+
+@test "read_uuid: falls back to legacy /usr/local path" {
+    printf '22222222-2222-3333-4444-555555555555\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    run read_uuid
+    [ "$status" -eq 0 ]
+    [ "$output" = '22222222-2222-3333-4444-555555555555' ]
+}
+
+@test "read_uuid: falls back to /boot path" {
+    printf '33333333-2222-3333-4444-555555555555\n' > "$ROOT_DIR/boot/airplanes-uuid"
+    run read_uuid
+    [ "$status" -eq 0 ]
+    [ "$output" = '33333333-2222-3333-4444-555555555555' ]
+}
+
+@test "read_uuid: malformed file at first hit dies" {
+    printf 'not-a-uuid\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    run_strict 'read_uuid'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid Feeder ID format'* ]]
+}
+
+@test "read_uuid: no files dies" {
+    run_strict 'read_uuid'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'no Feeder ID file'* ]]
+}
+
+# Documents drift between read_uuid and canonicalize_uuid:
+# canonicalize_uuid strips spaces/tabs; read_uuid strips only \n\r{}.
+# A leading-space file makes read_uuid die even though the embedded
+# UUID is otherwise valid.
+@test "read_uuid vs canonicalize_uuid: leading-space input handled differently (drift)" {
+    printf ' 11111111-2222-3333-4444-555555555555\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    run_strict 'read_uuid'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'invalid Feeder ID format'* ]]
+    run canonicalize_uuid ' 11111111-2222-3333-4444-555555555555'
+    [ "$status" -eq 0 ]
+    [ "$output" = '11111111-2222-3333-4444-555555555555' ]
+}
+
+# --- write_uuid ---
+
+@test "write_uuid: writes 0644 file with newline" {
+    write_uuid '11111111-2222-3333-4444-555555555555'
+    perms="$(stat -c '%a' "$ROOT_DIR/etc/airplanes/feeder-id" 2>/dev/null || stat -f '%Lp' "$ROOT_DIR/etc/airplanes/feeder-id")"
+    [ "$perms" = '644' ]
+    contents="$(cat "$ROOT_DIR/etc/airplanes/feeder-id")"
+    [ "$contents" = '11111111-2222-3333-4444-555555555555' ]
+}
+
+@test "write_uuid: rejects invalid input" {
+    run_strict "write_uuid 'not-a-uuid'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'refusing to write invalid Feeder ID'* ]]
+}
+
+# --- generate_secret ---
+
+@test "generate_secret: output passes validate_secret" {
+    secret="$(generate_secret)"
+    run validate_secret "$secret"
+    [ "$status" -eq 0 ]
+}
+
+@test "generate_secret: two consecutive calls produce different secrets" {
+    a="$(generate_secret)"
+    b="$(generate_secret)"
+    [ -n "$a" ]
+    [ -n "$b" ]
+    [ "$a" != "$b" ]
+}
+
+# --- restart_feeder_services ---
+
+setup_systemctl_stub() {
+    local active_set="$1"   # space-separated services that are is-active
+    local enabled_set="$2"  # space-separated services that are is-enabled
+    local fail_set="$3"     # space-separated services where restart fails
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  is-active)
+    target="\$3"
+    case " $active_set " in *" \$target "*) exit 0;; *) exit 3;; esac
+    ;;
+  is-enabled)
+    target="\$3"
+    case " $enabled_set " in *" \$target "*) exit 0;; *) exit 1;; esac
+    ;;
+  restart)
+    target="\$2"
+    case " $fail_set " in *" \$target "*) exit 1;; esac
+    printf 'STUB_RESTART %s\n' "\$target" >> "$ROOT_DIR/systemctl.log"
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+}
+
+@test "restart_feeder_services: ROOT != / skips and prints message" {
+    ROOT="$ROOT_DIR"
+    run restart_feeder_services
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Skipping service restart'* ]]
+}
+
+@test "restart_feeder_services: ROOT=/, no systemctl on PATH returns 0" {
+    ROOT='/'
+    PATH="$ROOT_DIR/empty-bin"
+    run restart_feeder_services
+    [ "$status" -eq 0 ]
+}
+
+@test "restart_feeder_services: both inactive AND disabled skips silently" {
+    setup_systemctl_stub '' '' ''
+    ROOT='/'
+    run restart_feeder_services
+    [ "$status" -eq 0 ]
+    [ ! -s "$ROOT_DIR/systemctl.log" ] || [ "$(wc -l < "$ROOT_DIR/systemctl.log" | tr -d ' ')" = '0' ]
+}
+
+@test "restart_feeder_services: enabled-but-inactive triggers restart" {
+    setup_systemctl_stub '' 'airplanes-feed airplanes-mlat' ''
+    ROOT='/'
+    run restart_feeder_services
+    [ "$status" -eq 0 ]
+    grep -q 'STUB_RESTART airplanes-feed' "$ROOT_DIR/systemctl.log"
+    grep -q 'STUB_RESTART airplanes-mlat' "$ROOT_DIR/systemctl.log"
+}
+
+@test "restart_feeder_services: active-but-disabled triggers restart" {
+    setup_systemctl_stub 'airplanes-feed airplanes-mlat' '' ''
+    ROOT='/'
+    run restart_feeder_services
+    [ "$status" -eq 0 ]
+    grep -q 'STUB_RESTART airplanes-feed' "$ROOT_DIR/systemctl.log"
+    grep -q 'STUB_RESTART airplanes-mlat' "$ROOT_DIR/systemctl.log"
+}
+
+@test "restart_feeder_services: mlat restart failure returns 1 with hint" {
+    setup_systemctl_stub 'airplanes-feed airplanes-mlat' 'airplanes-feed airplanes-mlat' 'airplanes-mlat'
+    ROOT='/'
+    run restart_feeder_services
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'Restart hint'* ]]
+    [[ "$output" == *'airplanes-mlat'* ]]
+}
+
+# --- parse_common_option ---
+
+@test "parse_common_option: --root consumes 2 args and sets ROOT" {
+    rc=0
+    parse_common_option --root /mnt/foo || rc=$?
+    [ "$rc" -eq 2 ]
+    [ "$ROOT" = '/mnt/foo' ]
+}
+
+@test "parse_common_option: --root without value dies" {
+    run_strict 'parse_common_option --root'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'--root requires PATH'* ]]
+}
+
+@test "parse_common_option: --server-url without value dies" {
+    run_strict 'parse_common_option --server-url'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'--server-url requires URL'* ]]
+}
+
+@test "parse_common_option: --max-retry-time consumes 2 args" {
+    rc=0
+    parse_common_option --max-retry-time 90 || rc=$?
+    [ "$rc" -eq 2 ]
+    [ "$MAX_RETRY_TIME" = '90' ]
+}
+
+@test "parse_common_option: -h prints usage and exits 0" {
+    run bash -c "
+        source '$LIB_DIR/common.sh'
+        parse_common_option -h
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Usage:'* ]]
+}
+
+@test "parse_common_option: unknown flag returns 0 without consuming" {
+    parse_common_option --frobnitz
+    rc=$?
+    [ "$rc" -eq 0 ]
+}
+
+# --- parse_field_from / json_has_key ---
+
+@test "parse_field_from: returns scalar value" {
+    printf '{"version":7}\n' > "$ROOT_DIR/x.json"
+    run parse_field_from "$ROOT_DIR/x.json" '.version'
+    [ "$status" -eq 0 ]
+    [ "$output" = '7' ]
+}
+
+@test "parse_field_from: null becomes empty" {
+    printf '{"version":null}\n' > "$ROOT_DIR/x.json"
+    run parse_field_from "$ROOT_DIR/x.json" '.version'
+    [ "$status" -eq 0 ]
+    [ "$output" = '' ]
+}
+
+@test "parse_field_from: malformed JSON yields empty (|| true)" {
+    printf 'not-json\n' > "$ROOT_DIR/x.json"
+    run parse_field_from "$ROOT_DIR/x.json" '.version'
+    [ "$status" -eq 0 ]
+}
+
+@test "json_has_key: present returns true" {
+    printf '{"a":1}\n' > "$ROOT_DIR/x.json"
+    run json_has_key "$ROOT_DIR/x.json" 'a'
+    [ "$status" -eq 0 ]
+    [ "$output" = 'true' ]
+}
+
+@test "json_has_key: absent returns false" {
+    printf '{"a":1}\n' > "$ROOT_DIR/x.json"
+    run json_has_key "$ROOT_DIR/x.json" 'b'
+    [ "$status" -eq 0 ]
+    [ "$output" = 'false' ]
+}
+
+# --- seconds_until_iso ---
+
+@test "seconds_until_iso: future ISO yields positive integer" {
+    if ! date -u -d '2025-01-01T00:00:00Z' +%s >/dev/null 2>&1; then
+        skip "GNU date -d not available"
+    fi
+    target="$(date -u -d '+1 hour' '+%Y-%m-%dT%H:%M:%SZ')"
+    run seconds_until_iso "$target"
+    [ "$status" -eq 0 ]
+    [ "$output" -gt 0 ]
+}
+
+@test "seconds_until_iso: past ISO yields 0" {
+    if ! date -u -d '2025-01-01T00:00:00Z' +%s >/dev/null 2>&1; then
+        skip "GNU date -d not available"
+    fi
+    target="$(date -u -d '-1 hour' '+%Y-%m-%dT%H:%M:%SZ')"
+    run seconds_until_iso "$target"
+    [ "$status" -eq 0 ]
+    [ "$output" = '0' ]
+}
+
+@test "seconds_until_iso: malformed yields 0" {
+    run seconds_until_iso 'not-an-iso'
+    [ "$status" -eq 0 ]
+    [ "$output" = '0' ]
+}
+
+# --- human_duration_ago ---
+
+@test "human_duration_ago: under 60s returns 'Ns ago'" {
+    run human_duration_ago 30
+    [ "$status" -eq 0 ]
+    [ "$output" = '30s ago' ]
+}
+
+@test "human_duration_ago: under 1h returns 'Nm ago'" {
+    run human_duration_ago 600
+    [ "$status" -eq 0 ]
+    [ "$output" = '10m ago' ]
+}
+
+@test "human_duration_ago: under 1d, no minutes returns 'Nh ago'" {
+    run human_duration_ago 7200
+    [ "$status" -eq 0 ]
+    [ "$output" = '2h ago' ]
+}
+
+@test "human_duration_ago: under 1d, with minutes returns 'Nh Nm ago'" {
+    run human_duration_ago 7800
+    [ "$status" -eq 0 ]
+    [ "$output" = '2h 10m ago' ]
+}
+
+@test "human_duration_ago: at 1d boundary returns 'Nd ago'" {
+    run human_duration_ago 86400
+    [ "$status" -eq 0 ]
+    [ "$output" = '1d ago' ]
+}
+
+@test "human_duration_ago: > 1d with hours returns 'Nd Nh ago'" {
+    run human_duration_ago 90000
+    [ "$status" -eq 0 ]
+    [ "$output" = '1d 1h ago' ]
+}
+
+@test "human_duration_ago: non-numeric input echoed verbatim" {
+    run human_duration_ago 'banana'
+    [ "$status" -eq 0 ]
+    [ "$output" = 'banana' ]
+}

--- a/test/test_apl_feed_http.bats
+++ b/test/test_apl_feed_http.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+
+# Per-module unit tests for scripts/apl-feed/http.sh.
+#
+# `post_json` is the only network primitive — uses a Python http.server
+# fixture mirroring the pattern in test_apl_feed_cli.bats.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    mkdir -p "$TMPDIR" "$ROOT_DIR/etc/airplanes"
+    export TMPDIR
+    MOCK_PORT_FILE="$(mktemp)"
+    MOCK_PID_FILE="$(mktemp)"
+    MOCK_REQUEST_LOG="$(mktemp)"
+    MOCK_REQUEST_BODY="$(mktemp)"
+
+    # Save bats's EXIT trap before common.sh overrides it (see
+    # test_apl_feed_common.bats for the explanation).
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/http.sh
+    source "$LIB_DIR/http.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+    SERVER_URL='http://127.0.0.1:0'
+}
+
+teardown() {
+    stop_mock_server || true
+    rm -rf "$ROOT_DIR"
+    rm -f "$MOCK_PORT_FILE" "$MOCK_PID_FILE" "$MOCK_REQUEST_LOG" "$MOCK_REQUEST_BODY"
+}
+
+stop_mock_server() {
+    [[ -f "$MOCK_PID_FILE" ]] || return 0
+    local pid
+    pid="$(cat "$MOCK_PID_FILE" 2>/dev/null || true)"
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+}
+
+start_mock_server() {
+    # start_mock_server <status> <body>
+    # Records the POST path and body to the request logs.
+    local status="$1"
+    local body="$2"
+    python3 - "$MOCK_PORT_FILE" "$status" "$body" "$MOCK_REQUEST_LOG" "$MOCK_REQUEST_BODY" <<'PY' &
+import http.server, sys
+port_file = sys.argv[1]
+status = int(sys.argv[2])
+body = sys.argv[3]
+req_log = sys.argv[4]
+req_body_file = sys.argv[5]
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        with open(req_log, "a") as f:
+            f.write(f"POST {self.path} ct={self.headers.get('Content-Type','')}\n")
+        with open(req_body_file, "wb") as f:
+            f.write(raw)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, *a, **kw): pass
+s = http.server.HTTPServer(("127.0.0.1", 0), H)
+with open(port_file, "w") as f:
+    f.write(str(s.server_address[1]))
+s.serve_forever()
+PY
+    echo $! > "$MOCK_PID_FILE"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [[ -s "$MOCK_PORT_FILE" ]] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+mock_url() {
+    echo "http://127.0.0.1:$(cat "$MOCK_PORT_FILE")"
+}
+
+# --- post_json ---
+
+@test "post_json: returns HTTP code on stdout, writes body to file" {
+    start_mock_server 201 '{"version":1}'
+    SERVER_URL="$(mock_url)"
+    response_file="$TMPDIR/resp"
+    body='{"uuid":"11111111-2222-3333-4444-555555555555","new_secret":"ABCDEFGHIJKLMNOP"}'
+    run post_json '/api/feeders/secret' "$body" "$response_file"
+    [ "$status" -eq 0 ]
+    [ "$output" = '201' ]
+    [ "$(cat "$response_file")" = '{"version":1}' ]
+}
+
+@test "post_json: sends body verbatim with Content-Type: application/json" {
+    start_mock_server 200 '{}'
+    SERVER_URL="$(mock_url)"
+    response_file="$TMPDIR/resp"
+    body='{"uuid":"11111111-2222-3333-4444-555555555555"}'
+    post_json '/api/feeders/status' "$body" "$response_file" >/dev/null
+    [ "$(cat "$MOCK_REQUEST_BODY")" = "$body" ]
+    grep -q 'POST /api/feeders/status ct=application/json' "$MOCK_REQUEST_LOG"
+}
+
+# --- body_preview ---
+
+@test "body_preview: caps at 200 chars" {
+    long="$(printf 'A%.0s' {1..500})"
+    printf '%s' "$long" > "$ROOT_DIR/big"
+    run body_preview "$ROOT_DIR/big"
+    [ "$status" -eq 0 ]
+    [ "${#output}" -eq 200 ]
+}
+
+@test "body_preview: missing file produces empty stdout" {
+    # head writes the open-failure message to stderr; redirect to keep
+    # `run` from capturing it as output.
+    run bash -c "source '$LIB_DIR/common.sh' && source '$LIB_DIR/http.sh' && body_preview '$ROOT_DIR/missing' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- status_probe_version ---
+
+@test "status_probe_version: 200 with .version echoes integer version" {
+    start_mock_server 200 '{"version":7}'
+    SERVER_URL="$(mock_url)"
+    run status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 0 ]
+    [ "$output" = '7' ]
+}
+
+@test "status_probe_version: 200 without .version returns 1" {
+    start_mock_server 200 '{"registered":true}'
+    SERVER_URL="$(mock_url)"
+    run status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 1 ]
+}
+
+@test "status_probe_version: 200 with .version=null returns 1" {
+    start_mock_server 200 '{"version":null}'
+    SERVER_URL="$(mock_url)"
+    run status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 1 ]
+}
+
+@test "status_probe_version: non-200 returns 1" {
+    start_mock_server 423 '{"error":"feeder_blocked"}'
+    SERVER_URL="$(mock_url)"
+    run status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 1 ]
+}
+
+@test "status_probe_version: network failure (unbound port) returns 1" {
+    SERVER_URL='http://127.0.0.1:1'   # port 1 — should refuse connection
+    run status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 1 ]
+}
+
+@test "status_probe_version: cleans up its tempfile" {
+    start_mock_server 200 '{"version":7}'
+    SERVER_URL="$(mock_url)"
+    before="$(find "$TMPDIR" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP' >/dev/null || true
+    after="$(find "$TMPDIR" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$before" = "$after" ]
+}

--- a/test/test_apl_feed_id.bats
+++ b/test/test_apl_feed_id.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+
+# Per-module unit tests for scripts/apl-feed/id.sh.
+#
+# id_set malformed-input rejection, --force semantics, and --dry-run
+# are covered end-to-end in test_apl_feed_cli.bats — not duplicated
+# here. This file isolates dispatch_id and id_set boundary cases that
+# the CLI suite skips.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$TMPDIR" "$STUB_DIR" \
+        "$ROOT_DIR/etc/airplanes" \
+        "$ROOT_DIR/usr/local/share/airplanes"
+    export TMPDIR
+    APL_FEED_SECRET_OWNER="$(id -un)"
+    APL_FEED_SECRET_GROUP="$(id -gn)"
+    export APL_FEED_SECRET_OWNER APL_FEED_SECRET_GROUP
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/id.sh
+    source "$LIB_DIR/id.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    # Track every systemctl invocation to a log so we can assert
+    # whether a restart was attempted.
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$ROOT_DIR/systemctl.log"
+case "\$1" in
+    is-active|is-enabled) exit 0 ;;
+    restart) exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# --- dispatch_id ---
+
+@test "dispatch_id: missing subcommand dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        dispatch_id
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'id requires a subcommand'* ]]
+}
+
+@test "dispatch_id: unknown subcommand dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        dispatch_id frobnitz
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unknown id subcommand: frobnitz'* ]]
+}
+
+@test "dispatch_id: -h prints usage and exits 0" {
+    run bash -c "
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        dispatch_id -h
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Usage:'* ]]
+}
+
+# --- id_set boundaries ---
+
+@test "id_set: empty stdin dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        ROOT='$ROOT_DIR'
+        printf '' | id_set
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'no input provided'* ]]
+}
+
+@test "id_set: stdin with trailing whitespace canonicalizes correctly" {
+    UUID='11111111-2222-3333-4444-555555555555'
+    run bash -c "
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        ROOT='$ROOT_DIR'
+        printf '%s\n   \n' '$UUID' | id_set --root '$ROOT_DIR'
+    "
+    [ "$status" -eq 0 ]
+    saved="$(cat "$ROOT_DIR/etc/airplanes/feeder-id")"
+    [ "$saved" = "$UUID" ]
+}
+
+@test "id_set: --root != / skips restart even when systemctl available" {
+    UUID='11111111-2222-3333-4444-555555555555'
+    run bash -c "
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        printf '%s\n' '$UUID' | id_set --root '$ROOT_DIR'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Skipping service restart'* ]]
+    if [[ -f "$ROOT_DIR/systemctl.log" ]]; then
+        ! grep -q 'systemctl restart' "$ROOT_DIR/systemctl.log"
+    fi
+}
+
+@test "id_set: existing UUID matches input — already matches, no restart" {
+    UUID='11111111-2222-3333-4444-555555555555'
+    printf '%s\n' "$UUID" > "$ROOT_DIR/etc/airplanes/feeder-id"
+    run bash -c "
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        printf '%s\n' '$UUID' | id_set --root '$ROOT_DIR'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'already matches'* ]]
+    if [[ -f "$ROOT_DIR/systemctl.log" ]]; then
+        ! grep -q 'systemctl restart' "$ROOT_DIR/systemctl.log"
+    fi
+}
+
+@test "id_set: existing UUID matches but uppercase normalizes to lowercase" {
+    UUID_LOWER='11111111-2222-3333-4444-555555555555'
+    UUID_UPPER='11111111-2222-3333-4444-AAAAAAAAAAAA'
+    UUID_NORM='11111111-2222-3333-4444-aaaaaaaaaaaa'
+    # Pre-populate uppercase; supply lowercase via stdin (different
+    # byte-form, same canonical value should hit "already matches"
+    # — but uppercase != lowercase canonical, so this is the rejection
+    # branch, not the normalize branch. Use the same canonical value
+    # to exercise the normalize-in-place branch.
+    printf '%s\n' "$UUID_UPPER" > "$ROOT_DIR/etc/airplanes/feeder-id"
+    run bash -c "
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/id.sh'
+        printf '%s\n' '$UUID_NORM' | id_set --root '$ROOT_DIR'
+    "
+    [ "$status" -eq 0 ]
+    saved="$(cat "$ROOT_DIR/etc/airplanes/feeder-id")"
+    [ "$saved" = "$UUID_NORM" ]
+}

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -1,0 +1,612 @@
+#!/usr/bin/env bats
+
+# Per-module unit tests for scripts/apl-feed/status.sh.
+#
+# Most cases stub `post_json` directly to write a prepared response
+# file and return a chosen HTTP code — avoids per-test Python server
+# startup. One claim_registration_status_line case exercises the
+# real Python mock to keep the stub honest.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    STUB_DIR="$ROOT_DIR/bin"
+    mkdir -p "$TMPDIR" "$STUB_DIR" \
+        "$ROOT_DIR/etc/airplanes" \
+        "$ROOT_DIR/usr/local/share/airplanes"
+    export TMPDIR
+    APL_FEED_SECRET_OWNER="$(id -un)"
+    APL_FEED_SECRET_GROUP="$(id -gn)"
+    export APL_FEED_SECRET_OWNER APL_FEED_SECRET_GROUP
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/http.sh
+    source "$LIB_DIR/http.sh"
+    # shellcheck source=../scripts/apl-feed/status.sh
+    source "$LIB_DIR/status.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    # Default stubs: every external command status.sh might call.
+    # Individual tests override by writing fresh stubs.
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+    is-active) exit 3 ;;     # default: not active
+    is-enabled) printf 'disabled\n'; exit 1 ;;
+esac
+exit 0
+STUB
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+exit 1                       # default: not reachable
+STUB
+    cat > "$STUB_DIR/timeout" <<'STUB'
+#!/usr/bin/env bash
+shift                        # drop seconds arg, exec rest
+exec "$@"
+STUB
+    cat > "$STUB_DIR/ss" <<'STUB'
+#!/usr/bin/env bash
+exit 0                       # default: empty output
+STUB
+    chmod +x "$STUB_DIR"/*
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+
+    UUID='11111111-2222-3333-4444-555555555555'
+    SECRET='ABCDEFGHIJKLMNOP'
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Stub `post_json` to write a prepared response and return a chosen
+# code. Defines the function in the current shell so the next call to
+# claim_registration_status_line / status_probe_version uses it.
+stub_post_json() {
+    # stub_post_json <http-status-code> <response-body-json>
+    # On rc=99 sentinel, simulates network failure (curl rc != 0).
+    local code="$1"
+    local body="$2"
+    eval "
+post_json() {
+    local response_file=\"\$3\"
+    if [[ '$code' == '99' ]]; then
+        return 7
+    fi
+    printf '%s' '$body' > \"\$response_file\"
+    printf '%s' '$code'
+    return 0
+}
+"
+}
+
+# --- status_init / status_finish / status_overall ---
+
+@test "status_init: zeroes counters" {
+    STATUS_FAIL_COUNT=5
+    STATUS_WARN_COUNT=3
+    status_init
+    [ "$STATUS_FAIL_COUNT" -eq 0 ]
+    [ "$STATUS_WARN_COUNT" -eq 0 ]
+    [ -n "$STATUS_CHECKS_FILE" ]
+    [ -f "$STATUS_CHECKS_FILE" ]
+}
+
+@test "status_overall: 'ok' when no warns/fails" {
+    STATUS_WARN_COUNT=0
+    STATUS_FAIL_COUNT=0
+    run status_overall
+    [ "$status" -eq 0 ]
+    [ "$output" = 'ok' ]
+}
+
+@test "status_overall: 'warn' when ≥1 warn and 0 fails" {
+    STATUS_WARN_COUNT=1
+    STATUS_FAIL_COUNT=0
+    run status_overall
+    [ "$output" = 'warn' ]
+}
+
+@test "status_overall: 'fail' dominates 'warn'" {
+    STATUS_WARN_COUNT=2
+    STATUS_FAIL_COUNT=1
+    run status_overall
+    [ "$output" = 'fail' ]
+}
+
+# --- status_line ---
+
+@test "status_line: ok increments neither counter, prints OK" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run status_line ok 'Test' 'detail'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'Test'* ]]
+    [[ "$output" == *'detail'* ]]
+}
+
+@test "status_line: warn increments STATUS_WARN_COUNT" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    status_line warn 'Test' 'detail' >/dev/null
+    [ "$STATUS_WARN_COUNT" -eq 1 ]
+    [ "$STATUS_FAIL_COUNT" -eq 0 ]
+}
+
+@test "status_line: fail increments STATUS_FAIL_COUNT" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    status_line fail 'Test' 'detail' >/dev/null
+    [ "$STATUS_FAIL_COUNT" -eq 1 ]
+    [ "$STATUS_WARN_COUNT" -eq 0 ]
+}
+
+@test "status_line: appends JSON line to STATUS_CHECKS_FILE" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    status_line ok 'Feeder ID' 'present' >/dev/null
+    line="$(cat "$STATUS_CHECKS_FILE")"
+    [ "$(printf '%s' "$line" | jq -r '.state')" = 'ok' ]
+    [ "$(printf '%s' "$line" | jq -r '.label')" = 'Feeder ID' ]
+    [ "$(printf '%s' "$line" | jq -r '.detail')" = 'present' ]
+}
+
+@test "status_line: JSON output mode suppresses plain text but still records JSON" {
+    status_init
+    STATUS_OUTPUT_JSON=1
+    run status_line ok 'Test' 'detail'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    line="$(cat "$STATUS_CHECKS_FILE")"
+    [ "$(printf '%s' "$line" | jq -r '.state')" = 'ok' ]
+}
+
+# --- service_status_line ---
+
+@test "service_status_line: no systemctl on PATH warns" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    output="$(PATH="$ROOT_DIR/empty" service_status_line airplanes-feed 'Feed service')"
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'systemctl unavailable'* ]]
+}
+
+@test "service_status_line: is-active --quiet 0 → ok 'running'" {
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+    is-active) exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run service_status_line airplanes-feed 'Feed service'
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'running'* ]]
+}
+
+@test "service_status_line: is-enabled = masked → fail 'masked'" {
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+    is-active) exit 3 ;;
+    is-enabled) printf 'masked\n'; exit 1 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run service_status_line airplanes-feed 'Feed service'
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'masked'* ]]
+}
+
+@test "service_status_line: default (inactive, not masked) → fail 'not running'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run service_status_line airplanes-feed 'Feed service'
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'not running'* ]]
+}
+
+# --- mlat_disabled_by_config ---
+
+@test "mlat_disabled_by_config: USER=0 returns 0" {
+    printf 'USER="0"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run mlat_disabled_by_config
+    [ "$status" -eq 0 ]
+}
+
+@test "mlat_disabled_by_config: LATITUDE=0 returns 0" {
+    printf 'USER="me"\nLATITUDE="0"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run mlat_disabled_by_config
+    [ "$status" -eq 0 ]
+}
+
+@test "mlat_disabled_by_config: LONGITUDE=0 returns 0" {
+    printf 'USER="me"\nLATITUDE="52"\nLONGITUDE="0"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run mlat_disabled_by_config
+    [ "$status" -eq 0 ]
+}
+
+# Documents drift: airplanes-mlat.sh disables on USER=disable
+# (and historically USER=changeme), but this status helper only
+# checks USER=0 / LATITUDE=0 / LONGITUDE=0. Setting USER=disable
+# at the daemon level skips MLAT, but `apl-feed status` reports
+# "MLAT service: not running" (fail) instead of "disabled by config" (ok).
+@test "mlat_disabled_by_config: USER=disable does NOT trigger (drift with airplanes-mlat.sh)" {
+    printf 'USER="disable"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run mlat_disabled_by_config
+    [ "$status" -eq 1 ]
+}
+
+@test "mlat_disabled_by_config: USER=changeme does NOT trigger (drift)" {
+    printf 'USER="changeme"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run mlat_disabled_by_config
+    [ "$status" -eq 1 ]
+}
+
+@test "mlat_disabled_by_config: configured location returns 1" {
+    printf 'USER="me"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run mlat_disabled_by_config
+    [ "$status" -eq 1 ]
+}
+
+# --- receiver_status_line ---
+
+@test "receiver_status_line: default INPUT (no env), nc fails → fail" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run receiver_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'127.0.0.1:30005'* ]]
+}
+
+@test "receiver_status_line: malformed INPUT (no colon) warns" {
+    printf 'INPUT="badvalue"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run receiver_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'could not parse INPUT'* ]]
+}
+
+@test "receiver_status_line: no nc on PATH warns" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    rm -f "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    # Restrict PATH to stubs only so the system /usr/bin/nc isn't found.
+    output="$(PATH="$STUB_DIR" receiver_status_line)"
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'nc unavailable'* ]]
+}
+
+@test "receiver_status_line: nc exit 0 → ok 'connected'" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run receiver_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'connected'* ]]
+}
+
+@test "receiver_status_line: nc exit 1 → fail 'no data source reachable'" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run receiver_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'no data source reachable'* ]]
+}
+
+# --- airplanes_link_status_line ---
+
+@test "airplanes_link_status_line: ss output shows :30004 → ok" {
+    cat > "$STUB_DIR/ss" <<'STUB'
+#!/usr/bin/env bash
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004 \n'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/ss"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run airplanes_link_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'connected'* ]]
+}
+
+@test "airplanes_link_status_line: ss output shows :31090 → ok (mlat)" {
+    cat > "$STUB_DIR/ss" <<'STUB'
+#!/usr/bin/env bash
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090 \n'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/ss"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run airplanes_link_status_line
+    [[ "$output" == *'OK'* ]]
+}
+
+@test "airplanes_link_status_line: ss output empty → warn" {
+    cat > "$STUB_DIR/ss" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/ss"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run airplanes_link_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'no connection'* ]]
+}
+
+@test "airplanes_link_status_line: neither ss nor netstat available → warn" {
+    rm -f "$STUB_DIR/ss"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    output="$(PATH="$ROOT_DIR/empty" airplanes_link_status_line)"
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'ss/netstat unavailable'* ]]
+}
+
+# --- website_feed_status_line ---
+
+@test "website_feed_status_line: STATUS_LAST_SEEN_AT empty → not_seen warn" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_LAST_SEEN_AT=''
+    run website_feed_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'not seen yet'* ]]
+}
+
+@test "website_feed_status_line: age 900 (boundary inclusive) → ok 'recent'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
+    STATUS_LAST_SEEN_AGE_SECONDS='900'
+    STATUS_WEBSITE_FEED_STATE=''
+    run website_feed_status_line
+    [[ "$output" == *'OK'* ]]
+}
+
+@test "website_feed_status_line: age 901 (boundary exclusive) → warn 'stale'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
+    STATUS_LAST_SEEN_AGE_SECONDS='901'
+    STATUS_WEBSITE_FEED_STATE=''
+    run website_feed_status_line
+    [[ "$output" == *'CHECK'* ]]
+}
+
+@test "website_feed_status_line: non-numeric age → warn 'unavailable'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
+    STATUS_LAST_SEEN_AGE_SECONDS=''
+    STATUS_WEBSITE_FEED_STATE=''
+    run website_feed_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'unavailable'* ]]
+}
+
+# --- claim_registration_status_line (post_json stubbed per case) ---
+
+setup_claim_state() {
+    # setup_claim_state <write-secret?>
+    local write_secret="${1:-1}"
+    printf '%s\n' "$UUID" > "$ROOT_DIR/etc/airplanes/feeder-id"
+    if (( write_secret )); then
+        printf '%s\n' "$SECRET" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+        chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    fi
+}
+
+@test "claim_registration_status_line: no UUID → fail 'missing or invalid'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'missing or invalid'* ]]
+}
+
+@test "claim_registration_status_line: UUID + no secret → warn 'not present'" {
+    setup_claim_state 0
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'not present'* ]]
+}
+
+@test "claim_registration_status_line: UUID + unreadable secret → warn 'not readable'" {
+    setup_claim_state 1
+    chmod 0000 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"   # restore for teardown
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'not readable'* ]]
+}
+
+@test "claim_registration_status_line: 200 + registered:true + version + owner_present:true → ok 'registered and claimed'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":true,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'registered and claimed (v5)'* ]]
+}
+
+@test "claim_registration_status_line: 200 + registered:true + version + owner_present:false → ok 'not yet claimed'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'not yet claimed (v5)'* ]]
+}
+
+@test "claim_registration_status_line: 200 + registered:true + missing version → warn 'did not authenticate'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"owner_present":true}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'did not authenticate'* ]]
+}
+
+@test "claim_registration_status_line: 200 + registered:false → warn 'not registered'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":false}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'not registered'* ]]
+}
+
+@test "claim_registration_status_line: 200 with last_seen_at key absent → no website_feed line" {
+    # When the response omits last_seen_at entirely, json_has_key
+    # returns false and the website_feed line is skipped. (When the
+    # key is present but null, the line IS emitted as warn 'not seen
+    # yet' — see status.sh:271-277.)
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":true}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" != *'Website feed'* ]]
+}
+
+@test "claim_registration_status_line: 200 with last_seen_at:null emits 'not seen yet' warn" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":true,"last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'Website feed'* ]]
+    [[ "$output" == *'not seen yet'* ]]
+}
+
+@test "claim_registration_status_line: pending rotation file present adds warn line" {
+    setup_claim_state 1
+    : > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending"
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":true,"last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'pending rotation file exists'* ]]
+}
+
+@test "claim_registration_status_line: 423 → fail 'blocked'" {
+    setup_claim_state 1
+    stub_post_json 423 '{"error":"feeder_blocked"}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'FIX'* ]]
+}
+
+@test "claim_registration_status_line: 429 → warn 'rate-limited'" {
+    setup_claim_state 1
+    stub_post_json 429 '{"error":"rate_limited"}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'rate-limited'* ]]
+}
+
+@test "claim_registration_status_line: 503 → warn 'unexpected HTTP 503'" {
+    setup_claim_state 1
+    stub_post_json 503 '{"error":"upstream_down"}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'unexpected HTTP 503'* ]]
+}
+
+@test "claim_registration_status_line: network failure → warn 'unreachable'" {
+    setup_claim_state 1
+    stub_post_json 99 ''
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'unreachable'* ]]
+}
+
+# Integration sanity check: real Python mock, stub_post_json out of
+# the way. Keeps the per-test stub honest about post_json's contract.
+start_python_mock() {
+    local code="$1" body="$2"
+    PORT_FILE="$(mktemp)"
+    PID_FILE="$(mktemp)"
+    python3 - "$PORT_FILE" "$code" "$body" <<'PY' &
+import http.server, sys
+port_file, status, body = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, *a, **kw): pass
+s = http.server.HTTPServer(("127.0.0.1", 0), H)
+with open(port_file, "w") as f:
+    f.write(str(s.server_address[1]))
+s.serve_forever()
+PY
+    echo $! > "$PID_FILE"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [[ -s "$PORT_FILE" ]] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+stop_python_mock() {
+    [[ -f "$PID_FILE" ]] || return 0
+    local pid
+    pid="$(cat "$PID_FILE")"
+    kill "$pid" 2>/dev/null || true
+    rm -f "$PORT_FILE" "$PID_FILE"
+}
+
+@test "claim_registration_status_line: integration with real Python mock (200 ok)" {
+    setup_claim_state 1
+    start_python_mock 200 '{"registered":true,"version":5,"owner_present":true,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    SERVER_URL="http://127.0.0.1:$(cat "$PORT_FILE")"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    stop_python_mock
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'registered and claimed (v5)'* ]]
+}


### PR DESCRIPTION
Adds five bats files covering `scripts/apl-feed/{common,http,backup,id,status}.sh` in isolation. End-to-end coverage stays in `test_apl_feed_cli.bats`; these new files exercise individual helpers so a regression in `canonicalize_uuid` or `feed_env_get` fails locally rather than five layers up through the dispatcher.

Test-only — no production changes. The new tests assert current behavior, including two cross-script drifts worth follow-up: `feed_env_paths` does not honor `/etc/airplanes/image-install` (which `airplanes-feed.sh` does), and `mlat_disabled_by_config` does not recognize `USER=disable` (which `airplanes-mlat.sh` does).