### PR TITLE
Recognize USER=disable in apl-feed status MLAT check

### DIFF
--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -131,11 +131,15 @@ service_status_line() {
 }
 
 mlat_disabled_by_config() {
+    # Mirror the disable conditions in airplanes-mlat.sh and update.sh:
+    #   USER=0|disable, LATITUDE=0, or LONGITUDE=0
+    # so the dashboard reports "disabled by config" instead of falsely
+    # flagging the inactive unit as a fix-it item.
     local user latitude longitude
     user="$(feed_env_get USER || true)"
     latitude="$(feed_env_get LATITUDE || true)"
     longitude="$(feed_env_get LONGITUDE || true)"
-    [[ "$user" == "0" || "$latitude" == "0" || "$longitude" == "0" ]]
+    [[ "$user" == "0" || "$user" == "disable" || "$latitude" == "0" || "$longitude" == "0" ]]
 }
 
 receiver_status_line() {

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -239,18 +239,17 @@ STUB
     [ "$status" -eq 0 ]
 }
 
-# Documents drift: airplanes-mlat.sh disables on USER=disable
-# (and historically USER=changeme), but this status helper only
-# checks USER=0 / LATITUDE=0 / LONGITUDE=0. Setting USER=disable
-# at the daemon level skips MLAT, but `apl-feed status` reports
-# "MLAT service: not running" (fail) instead of "disabled by config" (ok).
-@test "mlat_disabled_by_config: USER=disable does NOT trigger (drift with airplanes-mlat.sh)" {
+@test "mlat_disabled_by_config: USER=disable returns 0 (matches runtime daemon)" {
     printf 'USER="disable"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
     run mlat_disabled_by_config
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
 }
 
-@test "mlat_disabled_by_config: USER=changeme does NOT trigger (drift)" {
+# `changeme` is the template default for an unconfigured feeder.
+# Neither airplanes-mlat.sh nor update.sh recognize it as an explicit
+# disable signal — they only honor USER=0 / USER=disable. This helper
+# matches that.
+@test "mlat_disabled_by_config: USER=changeme does NOT trigger" {
     printf 'USER="changeme"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
     run mlat_disabled_by_config
     [ "$status" -eq 1 ]


### PR DESCRIPTION
`airplanes-mlat.sh` and `update.sh` both treat `USER=disable` as a deliberate disable signal alongside `USER=0`/`LATITUDE=0`/`LONGITUDE=0`. `apl-feed status` was missing the `USER=disable` case, so a feeder configured that way showed "MLAT service: not running" (fail) instead of "disabled by config" (ok) — the dashboard nagged about a service the user had explicitly turned off.

One-line fix in `mlat_disabled_by_config`. The drift-documenting test from the per-module bats slice is flipped to assert the new behavior; the `USER=changeme` test (still not honored anywhere on the runtime side) stays as a negative case.