### PR TITLE
Generalize stale-script sweep with historical-ship manifest

### DIFF
--- a/test/image-rootfs-smoke.sh
+++ b/test/image-rootfs-smoke.sh
@@ -90,6 +90,11 @@ cp "$FEED_REPO/update.sh" "$IPATH/update.sh"
 # `test ! -e "$IPATH/second-mlat.sh"` below guards the sweep.
 printf '#!/bin/bash\nexit 0\n' > "$IPATH/second-mlat.sh"
 chmod +x "$IPATH/second-mlat.sh"
+# Bystander file outside the historical-ship manifest. The manifest-driven
+# prune in update.sh must not touch files it doesn't own. The post-update
+# `test -f "$IPATH/my-custom-hook.sh"` below guards that.
+printf '#!/bin/bash\necho custom\n' > "$IPATH/my-custom-hook.sh"
+chmod +x "$IPATH/my-custom-hook.sh"
 cat > "$IPATH/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -184,6 +189,9 @@ test -f "$IPATH/apl-feed/common.sh"
 test -f "$IPATH/airplanes-feed.sh"
 test -f "$IPATH/airplanes-mlat.sh"
 test ! -e "$IPATH/second-mlat.sh"
+test -f "$IPATH/my-custom-hook.sh"
+[ "$(cat "$IPATH/my-custom-hook.sh")" = '#!/bin/bash
+echo custom' ]
 test -f "$ROOT_DIR/etc/systemd/system/airplanes-feed.service"
 test -f "$ROOT_DIR/etc/systemd/system/airplanes-mlat.service"
 test ! -e "$ROOT_DIR/lib/systemd/system/airplanes-feed.service"

--- a/test/test_update_manifest.bats
+++ b/test/test_update_manifest.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Drift guards for the historical-ship manifests in update.sh. The arrays
+# `historical_top_level_scripts` and `historical_apl_feed_modules` drive the
+# prune-on-update behavior that sweeps stale copies of removed scripts off
+# upgraded feeders. CI must catch both directions of drift:
+#   - a new script in scripts/ that wasn't registered in the manifest (would
+#     leak forever once we delete it later), and
+#   - a historical entry that gets accidentally removed from the manifest
+#     (would re-leak the stale file on every still-upgrading feeder).
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    UPDATE="$REPO_ROOT/update.sh"
+}
+
+# Extracts the contents of a `name=( ... )` array from update.sh as one entry
+# per line on stdout. Tolerates leading whitespace and trailing comments on
+# array entries. Stops at the first closing `)` after the array opens.
+extract_manifest() {
+    local name="$1"
+    awk -v name="$name" '
+        $0 ~ "^"name"=\\(" { in_arr = 1; next }
+        in_arr && /^\)/ { in_arr = 0; exit }
+        in_arr {
+            sub(/#.*$/, "")
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+            if ($0 != "") print
+        }
+    ' "$UPDATE"
+}
+
+@test "historical_top_level_scripts manifest covers every currently shipped top-level script" {
+    local manifest
+    manifest="$(extract_manifest historical_top_level_scripts)"
+    [ -n "$manifest" ]
+    for path in "$REPO_ROOT"/scripts/*.sh; do
+        local name
+        name="$(basename "$path")"
+        if ! grep -Fxq "$name" <<<"$manifest"; then
+            echo "scripts/$name is shipped but missing from historical_top_level_scripts in update.sh" >&2
+            return 1
+        fi
+    done
+}
+
+@test "historical_apl_feed_modules manifest covers every currently shipped apl-feed module" {
+    local manifest
+    manifest="$(extract_manifest historical_apl_feed_modules)"
+    [ -n "$manifest" ]
+    for path in "$REPO_ROOT"/scripts/apl-feed/*.sh; do
+        local name
+        name="$(basename "$path")"
+        if ! grep -Fxq "$name" <<<"$manifest"; then
+            echo "scripts/apl-feed/$name is shipped but missing from historical_apl_feed_modules in update.sh" >&2
+            return 1
+        fi
+    done
+}
+
+@test "historical_top_level_scripts retains second-mlat.sh (deleted in PR #30, must keep pruning forever)" {
+    local manifest
+    manifest="$(extract_manifest historical_top_level_scripts)"
+    grep -Fxq "second-mlat.sh" <<<"$manifest"
+}

--- a/update.sh
+++ b/update.sh
@@ -347,13 +347,54 @@ fi
 
 cp "$GIT/uninstall.sh" "$IPATH"
 cp "$GIT"/scripts/*.sh "$IPATH"
-# Sweep the now-removed second-mlat.sh helper from upgraded installs. The
-# wildcard cp above only adds files that exist in scripts/; it does not
-# clean up files that used to ship there. See the airplanes-mlat2 cleanup
-# in uninstall.sh for the matching service-side handling.
-rm -f "$IPATH/second-mlat.sh"
 install -d -m 0755 "$IPATH/apl-feed"
 install -m 0644 "$GIT"/scripts/apl-feed/*.sh "$IPATH/apl-feed"
+
+# Historical-ship manifests for the wildcard cp/install above. Each entry is
+# a script we have ever shipped to $IPATH (top-level) or $IPATH/apl-feed/.
+# The prune loops below remove any installed file whose source counterpart
+# is gone from the current $GIT/scripts tree — symmetric to the wildcard
+# cp/install which only ADD files, never remove them.
+#
+# Maintenance rule: NEVER remove an entry from these arrays. Add a new
+# entry whenever a new script ships from scripts/ or scripts/apl-feed/.
+# Removing an entry would leak the stale file on already-upgraded feeders.
+# CI guards both directions: presence of every currently-shipped name, and
+# retention of known-historical names.
+historical_top_level_scripts=(
+    airplanes-feed.sh
+    airplanes-mlat.sh
+    apl-feed.sh
+    second-mlat.sh
+)
+historical_apl_feed_modules=(
+    backup.sh
+    claim.sh
+    common.sh
+    http.sh
+    id.sh
+    status.sh
+)
+
+# `rm -f` on a directory exits nonzero and would trip set -e; the
+# `! -d || -L` guard limits the prune to file-like targets (regular files
+# and symlinks), skipping the unlikely case where someone replaced a
+# manifest entry with a real directory.
+for name in "${historical_top_level_scripts[@]}"; do
+    target="$IPATH/$name"
+    if [[ ! -f "$GIT/scripts/$name" && ( -L "$target" || ! -d "$target" ) ]]; then
+        rm -f "$target"
+    fi
+done
+
+if [[ -d "$IPATH/apl-feed" ]]; then
+    for name in "${historical_apl_feed_modules[@]}"; do
+        target="$IPATH/apl-feed/$name"
+        if [[ ! -f "$GIT/scripts/apl-feed/$name" && ( -L "$target" || ! -d "$target" ) ]]; then
+            rm -f "$target"
+        fi
+    done
+fi
 mkdir -p "$LOCAL_BIN"
 install -m 0755 "$GIT/scripts/apl-feed.sh" "$LOCAL_BIN/apl-feed"
 


### PR DESCRIPTION
Replaces PR #30's one-off `rm -f "$IPATH/second-mlat.sh"` with a general historical-ship manifest. Two arrays in `update.sh` list every script ever shipped from `scripts/` and `scripts/apl-feed/`; after the wildcard `cp`/`install`, the prune loops remove any installed file whose source counterpart is gone from the current `$GIT/scripts` tree.

The manifest is an explicit allowlist for pruning, so user customizations in `$IPATH` are never touched — a new bystander assertion in `image-rootfs-smoke.sh` proves a custom user file survives the update. A new bats file guards drift in both directions: every currently-shipped name must appear in the manifest, and known-removed names like `second-mlat.sh` must remain (otherwise upgrading feeders would re-leak the stale file).
