### PR TITLE
test: relax image-boot-smoke After= regex for baked-in form

### DIFF
--- a/test/image-boot-smoke.sh
+++ b/test/image-boot-smoke.sh
@@ -497,6 +497,10 @@ assert_contains() {
     grep -q -- "$2" "$1" || fail "$1 does not contain $2"
 }
 
+assert_regex() {
+    grep -qE -- "$2" "$1" || fail "$1 does not match regex: $2"
+}
+
 assert_not_exists() {
     [[ ! -e "$1" ]] || fail "unexpected path exists: $1"
 }
@@ -541,9 +545,9 @@ assert_image_contracts() {
     assert_file /etc/systemd/system/airplanes-mlat.service
     assert_file /etc/systemd/system/airplanes-first-run.service
     assert_contains /etc/systemd/system/airplanes-feed.service 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh'
-    assert_contains /etc/systemd/system/airplanes-feed.service 'After=airplanes-first-run.service'
+    assert_regex /etc/systemd/system/airplanes-feed.service '^After=.*airplanes-first-run.service'
     assert_contains /etc/systemd/system/airplanes-mlat.service 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh'
-    assert_contains /etc/systemd/system/airplanes-mlat.service 'After=airplanes-first-run.service'
+    assert_regex /etc/systemd/system/airplanes-mlat.service '^After=.*airplanes-first-run.service'
     assert_contains /usr/local/share/airplanes/airplanes-feed.sh 'feed2.airplanes.live,64004'
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
         assert_not_exists /etc/airplanes/feed.env


### PR DESCRIPTION
Sibling of `674a265`, missed in that pass for the manual boot-smoke harness.

Commit `9a35cf6` baked `After=airplanes-first-run.service` into the airplanes-feed and airplanes-mlat unit templates as a space-separated continuation of `After=network.target`, so the literal substring no longer matches. Adds an `assert_regex` helper to match the file's existing style and uses it for the two After= assertions.

Latent — `image-boot-smoke.yml` is `workflow_dispatch` only, so this isn't currently red, but the next manual run would fail the same way overlay-smoke did in airplanes-live/image.