### PR TITLE
Extract mlat/readsb builds and service account into scripts/lib/

### DIFF
--- a/scripts/lib/service-account.sh
+++ b/scripts/lib/service-account.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Service-account creation for the airplanes-feed daemon. Sourced by
+# update.sh after the cloned tree is available at $GIT.
+#
+# Helper deps (must be in scope when sourced):
+#   heal_claim_state_ownership   from scripts/lib/claim-registration.sh
+#
+# This function is intentionally airplanes-feed-specific despite taking the
+# user/group names as arguments: heal_claim_state_ownership defaults its
+# owner to airplanes-feed and the warning message references the webconfig
+# 'claim show' surface, both of which are tied to the one daemon account
+# this project creates. The arg shape is for testability, not reuse.
+
+# Create or repair the airplanes-feed system account so the daemon and any
+# other service that needs the airplanes-feed group (for claim-secret read)
+# end up in a consistent state. After the account is in place, heal any
+# claim-state files left behind by older feed versions that wrote them as
+# root:root mode 0600.
+#
+# Args:
+#   $1  uname           — daemon user name (production: airplanes-feed)
+#   $2  gname           — daemon group name (production: airplanes-feed)
+#   $3  home_dir        — passwd home dir for the user (production: $IPATH)
+#   $4  etc_airplanes   — directory containing claim-state files to heal
+#
+# Aborts (exit 1) only when group creation fails completely. User creation
+# falls back through adduser → useradd → final id -u recheck before
+# aborting. Supplementary-group repair on existing users is non-fatal:
+# usermod → gpasswd → warning, function returns 0.
+ensure_airplanes_feed_account() {
+    local uname="$1"
+    local gname="$2"
+    local home_dir="$3"
+    local etc_airplanes="$4"
+
+    if ! getent group "$gname" >/dev/null 2>&1
+    then
+        # Trailing recheck handles the case where a concurrent update
+        # created the group between our guard and the addgroup call.
+        addgroup --system "$gname" \
+            || groupadd --system "$gname" \
+            || getent group "$gname" >/dev/null 2>&1 \
+            || { echo "ERROR: failed to create group '$gname' (no working addgroup/groupadd)." >&2; exit 1; }
+    fi
+
+    if ! id -u "$uname" &>/dev/null
+    then
+        # Fresh user creation: primary group is the daemon group so
+        # processes started under User=$uname pick the group up without
+        # a supplementary lookup. `||` chains are set -e safe.
+        adduser --system --ingroup "$gname" --home "$home_dir" --no-create-home --quiet "$uname" \
+            || adduser --system --gid "$(getent group "$gname" | cut -d: -f3)" --home-dir "$home_dir" --no-create-home "$uname" \
+            || useradd --system --gid "$(getent group "$gname" | cut -d: -f3)" --home-dir "$home_dir" --no-create-home "$uname" \
+            || id -u "$uname" &>/dev/null \
+            || { echo "ERROR: failed to create user '$uname' (no working adduser/useradd)." >&2; exit 1; }
+    else
+        # Existing user from a pre-pivot install: primary group is likely
+        # `nogroup`. Add the daemon group as supplementary so the running
+        # daemon picks it up after the post-install service restart.
+        if ! id -nG "$uname" 2>/dev/null | tr ' ' '\n' | grep -qx "$gname"
+        then
+            usermod -aG "$gname" "$uname" 2>/dev/null \
+                || gpasswd -a "$uname" "$gname" 2>/dev/null \
+                || echo "WARNING: could not add $uname to $gname group; webconfig 'claim show' may stay broken until manually fixed" >&2
+        fi
+    fi
+
+    # heal_claim_state_ownership runs after account setup so its chown
+    # target group exists. Defaults to airplanes-feed:airplanes-feed; the
+    # uname/gname args here are not threaded through because the heal
+    # surface is intentionally tied to the production account.
+    heal_claim_state_ownership "$etc_airplanes"
+}

--- a/scripts/lib/update-builds.sh
+++ b/scripts/lib/update-builds.sh
@@ -192,7 +192,7 @@ build_readsb_feed_client() {
     # any failure aborts the script, matching the original inline form
     # where `make` failure was a hard stop for the updater.
     (
-        cd "$readsb_git"
+        cd "$readsb_git" || exit
         make clean
         make -j2 AIRCRAFT_HASH_BITS=12 >> "$logfile"
         echo 80

--- a/scripts/lib/update-builds.sh
+++ b/scripts/lib/update-builds.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Build phases for the airplanes.live feed scripts: compile + install the
+# mlat-client venv and the readsb-based feed client. Sourced by update.sh
+# after the cloned tree is available at $GIT.
+#
+# Helper deps (must be in scope when sourced):
+#   getGIT, revision, airplanes_is_build_mode   from install-update-common.sh
+#
+# Each function takes paths and values as positional arguments and does not
+# read or mutate update.sh's config-state globals (USER, TARGET, MLAT_*).
+#
+# Test seam: the mlat-client venv creation honors AIRPLANES_PYTHON_BIN so
+# tests can intercept the python binary without a PATH stub. This is the
+# only intentional diff from the original inline form; the rest of the
+# install command chain (mixed && / || ordering of setuptools/pyasyncore
+# fallbacks) is preserved verbatim.
+
+# Compute the upstream HEAD SHA for $branch on $repo. Returns a random
+# sentinel when the lookup produces no output (network failure, DNS miss,
+# git auth issue): the previous inline form
+#
+#     "$(git ls-remote ... | cut -f1 || echo "$RANDOM-$RANDOM")"
+#
+# was broken because the trailing `|| echo` only fires when `cut` itself
+# fails — without `set -o pipefail`, pipe failures upstream of `cut`
+# produce empty stdout, leaving the variable empty. The skip-check then
+# uses `grep -e ""` which matches any non-empty version file, falsely
+# taking the skip branch and stranding feeders on stale builds when the
+# version-check fetch flakes. The empty-guard restores the intended
+# "force a mismatch when we couldn't fetch the truth" behavior.
+_compute_remote_version() {
+    local repo="$1"
+    local branch="$2"
+    local version
+    version="$(git ls-remote "$repo" "$branch" 2>/dev/null | cut -f1)"
+    if [[ -z "$version" ]]; then
+        version="$RANDOM-$RANDOM"
+    fi
+    printf '%s' "$version"
+}
+
+# Install the mlat-client into a Python venv.
+#
+# Args:
+#   $1  mlat_repo       — git URL for the mlat-client repo
+#   $2  mlat_branch     — branch to fetch
+#   $3  venv            — venv path (e.g. $IPATH/venv)
+#   $4  ipath           — install dir (used for $ipath/mlat_version)
+#   $5  mlat_git        — local clone target
+#   $6  logfile         — append-only log path for build noise
+#   $7  reinstall       — "yes" to force rebuild even when versions match
+#   $8  mlat_disabled   — "1" allows skip-without-active-service (mlat
+#                          intentionally off via USER=0/disable)
+#
+# Skip path: when version matches, mlat-client binary exists, and at
+# least one of {build mode, active service, mlat-disabled} holds.
+#
+# Failure handling: getGIT failure aborts under set -e (preserved from the
+# inline form — different from the in-build failure path below, which
+# restores $venv-backup and continues so the readsb build can still run).
+# In-build failure (any step in the && / || install chain returns
+# non-zero and the chain ultimately fails) restores $venv from backup and
+# prints the documented warning; the function returns 0 so update.sh can
+# continue.
+install_mlat_client() {
+    local mlat_repo="$1"
+    local mlat_branch="$2"
+    local venv="$3"
+    local ipath="$4"
+    local mlat_git="$5"
+    local logfile="$6"
+    local reinstall="$7"
+    local mlat_disabled="$8"
+
+    local mlat_version
+    mlat_version="$(_compute_remote_version "$mlat_repo" "$mlat_branch")"
+
+    if [[ "$reinstall" != yes ]] && grep -e "$mlat_version" -qs "$ipath/mlat_version" \
+        && grep -qs -e '#!' "$venv/bin/mlat-client" && { airplanes_is_build_mode || systemctl is-active airplanes-mlat &>/dev/null || [[ "$mlat_disabled" == "1" ]]; }
+    then
+        echo
+        echo "mlat-client already installed, git hash:"
+        cat "$ipath/mlat_version"
+        echo
+        return 0
+    fi
+
+    echo
+    echo "Installing mlat-client to virtual environment"
+    echo
+
+    getGIT "$mlat_repo" "$mlat_branch" "$mlat_git" &> "$logfile"
+
+    echo 34
+
+    rm -rf "$venv-backup"
+    mv -f "$venv" "$venv-backup" &>/dev/null || true
+
+    # Build runs in a subshell so cd and venv activation don't leak to
+    # the caller (caller's $PWD is unchanged after this function returns).
+    # The mixed && / || chain inside the if-test is preserved verbatim;
+    # the only intentional edit is the AIRPLANES_PYTHON_BIN seam at the
+    # venv-creation step. Chain leg semantics:
+    #   `python3 -c "import setuptools" || python3 -m pip install setuptools`
+    # routes through &&/|| so missing setuptools triggers the pip install
+    # fallback, then continues with `&& echo 39 && ...`. Same shape for
+    # asyncore → pyasyncore.
+    if (
+        cd "$mlat_git"
+        "${AIRPLANES_PYTHON_BIN:-/usr/bin/python3}" -m venv "$venv" >> "$logfile" \
+            && echo 36 \
+            && source "$venv/bin/activate" >> "$logfile" \
+            && echo 37 \
+            && python3 -c "import setuptools" || python3 -m pip install setuptools \
+            && echo 39 \
+            && python3 -c "import asyncore" || python3 -m pip install pyasyncore \
+            && python3 -m pip install wheel \
+            && echo 40 \
+            && pip install . \
+            && echo 46 \
+            && revision > "$ipath/mlat_version" || rm -f "$ipath/mlat_version" \
+            && echo 48
+    ); then
+        rm -rf "$venv-backup"
+    else
+        rm -rf "$venv"
+        mv "$venv-backup" "$venv" &>/dev/null || true
+        echo "--------------------"
+        echo "Installing mlat-client failed, if there was an old version it has been restored."
+        echo "Will continue installation to try and get at least the feed client working."
+        echo "Please report this error on Discord."
+        echo "--------------------"
+    fi
+}
+
+# Compile the readsb-based feed client.
+#
+# Args:
+#   $1  readsb_repo     — git URL for the readsb fork
+#   $2  readsb_branch   — branch to build (caller picks: dev/jessie/etc.)
+#   $3  readsb_git      — local clone target
+#   $4  readsb_bin      — output binary path (e.g. $IPATH/feed-airplanes)
+#   $5  ipath           — install dir (used for $ipath/readsb_version)
+#   $6  logfile         — append-only log path for compile noise
+#   $7  reinstall       — "yes" to force rebuild even when versions match
+#
+# Skip path: when version matches, the existing binary responds to `-V`,
+# and at least one of {build mode, active airplanes-feed.service} holds.
+#
+# Failure handling: getGIT and `make` are plain commands; under set -e
+# their failure aborts the script. This is the intended behavior — a
+# broken feed client is fatal for an updater run, in contrast to mlat
+# (which can be intentionally disabled).
+build_readsb_feed_client() {
+    local readsb_repo="$1"
+    local readsb_branch="$2"
+    local readsb_git="$3"
+    local readsb_bin="$4"
+    local ipath="$5"
+    local logfile="$6"
+    local reinstall="$7"
+
+    local readsb_version
+    readsb_version="$(_compute_remote_version "$readsb_repo" "$readsb_branch")"
+
+    if [[ "$reinstall" != yes ]] && grep -e "$readsb_version" -qs "$ipath/readsb_version" \
+        && "$readsb_bin" -V && { airplanes_is_build_mode || systemctl is-active airplanes-feed &>/dev/null; }
+    then
+        echo
+        echo "Feed client already installed, git hash:"
+        cat "$ipath/readsb_version"
+        echo
+        return 0
+    fi
+
+    echo
+    echo "Compiling / installing the readsb based feed client"
+    echo
+
+    echo 72
+
+    getGIT "$readsb_repo" "$readsb_branch" "$readsb_git" &> "$logfile"
+
+    echo "-----------------------------------------------"
+    echo "Now compiling code can take a few minutes"
+    echo "-----------------------------------------------"
+
+    echo 74
+
+    # Build runs in a subshell so the cd doesn't leak. The subshell is
+    # called as a plain statement (not inside an if), so set -e propagates:
+    # any failure aborts the script, matching the original inline form
+    # where `make` failure was a hard stop for the updater.
+    (
+        cd "$readsb_git"
+        make clean
+        make -j2 AIRCRAFT_HASH_BITS=12 >> "$logfile"
+        echo 80
+        rm -f "$readsb_bin"
+        cp readsb "$readsb_bin"
+        revision > "$ipath/readsb_version" || rm -f "$ipath/readsb_version"
+    )
+
+    echo
+}

--- a/test/test_service_account.bats
+++ b/test/test_service_account.bats
@@ -98,6 +98,74 @@ SH
     [[ "$output" == *"failed to create group 'airplanes-feed'"* ]]
 }
 
+@test "user cascade: adduser --ingroup fails, --gid form succeeds (no useradd)" {
+    # Group exists; user does not. adduser --ingroup is rejected by some
+    # distros (e.g. busybox adduser), so the cascade falls back to the
+    # --gid form which derives the GID via `getent group | cut -d: -f3`.
+    _stub getent 'case "$*" in
+    "group airplanes-feed") echo "airplanes-feed:x:999:" ;;
+    *) exit 0 ;;
+esac'
+    _stub id 'printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub adduser '
+printf "adduser %s\n" "$*" >> "$COMMAND_LOG"
+case "$*" in
+    *--ingroup*) exit 1 ;;
+    *--gid*)     exit 0 ;;
+esac
+exit 1'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    grep -q "^adduser --system --ingroup airplanes-feed " "$COMMAND_LOG"
+    grep -q "^adduser --system --gid 999 --home-dir $HOME_DIR --no-create-home airplanes-feed$" "$COMMAND_LOG"
+    ! grep -q "^useradd " "$COMMAND_LOG"
+}
+
+@test "user cascade: both adduser forms fail, useradd succeeds" {
+    _stub getent 'case "$*" in
+    "group airplanes-feed") echo "airplanes-feed:x:999:" ;;
+    *) exit 0 ;;
+esac'
+    _stub id 'printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub adduser 'printf "adduser %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub useradd 'printf "useradd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    # Both adduser variants tried first, then useradd as the final tool.
+    grep -q "^adduser --system --ingroup airplanes-feed " "$COMMAND_LOG"
+    grep -q "^adduser --system --gid 999 " "$COMMAND_LOG"
+    grep -q "^useradd --system --gid 999 --home-dir $HOME_DIR --no-create-home airplanes-feed$" "$COMMAND_LOG"
+    # Cascade order: adduser-ingroup → adduser-gid → useradd. Pin via line numbers.
+    local ingroup_line gid_line useradd_line
+    ingroup_line="$(grep -n 'adduser --system --ingroup' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    gid_line="$(grep -n 'adduser --system --gid' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    useradd_line="$(grep -n '^useradd ' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    [ "$ingroup_line" -lt "$gid_line" ]
+    [ "$gid_line" -lt "$useradd_line" ]
+}
+
+@test "user creation total failure: aborts with documented error message" {
+    # Group exists; every create-tool fails; the final id -u recheck also
+    # confirms the user still doesn't exist (no concurrent creation).
+    _stub getent 'case "$*" in
+    "group airplanes-feed") echo "airplanes-feed:x:999:" ;;
+    *) exit 0 ;;
+esac'
+    _stub id 'printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub adduser 'printf "adduser %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub useradd 'printf "useradd %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+
+    set -e
+    run ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to create user 'airplanes-feed'"* ]]
+}
+
 @test "existing user, missing supplementary group: usermod succeeds, no gpasswd" {
     # Group exists, user exists, but `id -nG` doesn't list the group.
     _stub getent 'exit 0'

--- a/test/test_service_account.bats
+++ b/test/test_service_account.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# Tests for ensure_airplanes_feed_account, defined in
+# scripts/lib/service-account.sh. Stubs the user/group management tools
+# (getent, addgroup, groupadd, adduser, useradd, id, usermod, gpasswd)
+# via PATH manipulation so the function exercises its full
+# create/repair cascade against deterministic synthetic state.
+#
+# heal_claim_state_ownership is sourced from claim-registration.sh and
+# runs against a tmp directory containing claim-state files; the chown
+# stub records the call without actually changing ownership.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    LIB="$REPO_ROOT/scripts/lib/service-account.sh"
+    CLAIM_LIB="$REPO_ROOT/scripts/lib/claim-registration.sh"
+
+    TMP="$(mktemp -d)"
+    STUB_DIR="$TMP/bin"
+    COMMAND_LOG="$TMP/commands.log"
+    HOME_DIR="$TMP/home"
+    ETC_AIRPLANES="$TMP/etc/airplanes"
+    mkdir -p "$STUB_DIR" "$HOME_DIR" "$ETC_AIRPLANES"
+    : > "$COMMAND_LOG"
+
+    # Default stubs: every tool exists and reports success. Individual
+    # tests override stubs via _stub helper to inject failures or shape
+    # responses.
+    _stub getent 'exit 0'
+    _stub addgroup 'printf "addgroup %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub groupadd 'printf "groupadd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub adduser 'printf "adduser %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub useradd 'printf "useradd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub id 'printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub usermod 'printf "usermod %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub gpasswd 'printf "gpasswd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub chown 'printf "chown %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub chmod 'printf "chmod %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+
+    PATH="$STUB_DIR:$PATH"
+    export PATH COMMAND_LOG
+
+    # shellcheck source=/dev/null
+    source "$CLAIM_LIB"
+    # shellcheck source=/dev/null
+    source "$LIB"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+_stub() {
+    local name="$1"
+    local body="$2"
+    cat > "$STUB_DIR/$name" <<SH
+#!/usr/bin/env bash
+$body
+SH
+    chmod +x "$STUB_DIR/$name"
+}
+
+@test "fresh install: addgroup + adduser called when neither exists" {
+    # getent group → fail (group missing), id -u → fail (user missing)
+    _stub getent 'exit 2'
+    _stub id 'printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    grep -q "^addgroup --system airplanes-feed$" "$COMMAND_LOG"
+    grep -q "^adduser --system --ingroup airplanes-feed --home $HOME_DIR --no-create-home --quiet airplanes-feed$" "$COMMAND_LOG"
+    # No supplementary-group repair on the fresh-create path.
+    ! grep -q "^usermod " "$COMMAND_LOG"
+    ! grep -q "^gpasswd " "$COMMAND_LOG"
+}
+
+@test "addgroup fallback: groupadd is called when addgroup is absent" {
+    rm -f "$STUB_DIR/addgroup"
+    _stub getent 'exit 2'
+    _stub id 'printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    grep -q "^groupadd --system airplanes-feed$" "$COMMAND_LOG"
+}
+
+@test "group creation total failure: aborts under set -e with documented message" {
+    # Neither addgroup, groupadd, nor the trailing getent recheck succeed.
+    rm -f "$STUB_DIR/addgroup" "$STUB_DIR/groupadd"
+    _stub getent 'exit 2'
+    _stub id 'exit 1'
+
+    set -e
+    run ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to create group 'airplanes-feed'"* ]]
+}
+
+@test "existing user, missing supplementary group: usermod succeeds, no gpasswd" {
+    # Group exists, user exists, but `id -nG` doesn't list the group.
+    _stub getent 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    grep -q "^usermod -aG airplanes-feed airplanes-feed$" "$COMMAND_LOG"
+    ! grep -q "^gpasswd " "$COMMAND_LOG"
+    # No fresh-user creation paths fired.
+    ! grep -q "^adduser " "$COMMAND_LOG"
+    ! grep -q "^useradd " "$COMMAND_LOG"
+}
+
+@test "existing user, usermod fails, gpasswd succeeds: both called in order, no warning" {
+    _stub getent 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+    _stub usermod 'printf "usermod %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub gpasswd 'printf "gpasswd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+
+    set -e
+    run ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WARNING:"* ]]
+    grep -q "^usermod -aG airplanes-feed airplanes-feed$" "$COMMAND_LOG"
+    grep -q "^gpasswd -a airplanes-feed airplanes-feed$" "$COMMAND_LOG"
+    # Ordering: usermod before gpasswd.
+    [ "$(grep -n '^usermod\|^gpasswd' "$COMMAND_LOG" | head -1 | cut -d: -f2-)" = "usermod -aG airplanes-feed airplanes-feed" ]
+}
+
+@test "existing user, both usermod AND gpasswd fail: warning printed, function returns 0" {
+    _stub getent 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+    _stub usermod 'printf "usermod %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub gpasswd 'printf "gpasswd %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+
+    set -e
+    run ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING: could not add airplanes-feed to airplanes-feed group"* ]]
+}
+
+@test "existing user, group already supplementary: no usermod or gpasswd call" {
+    _stub getent 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup airplanes-feed"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    ! grep -q "^usermod " "$COMMAND_LOG"
+    ! grep -q "^gpasswd " "$COMMAND_LOG"
+}
+
+@test "heal_claim_state_ownership runs after account setup" {
+    # Override heal so it appends a marker to COMMAND_LOG and skips the
+    # real chown logic. The marker's position in the log relative to
+    # adduser/usermod proves call ordering.
+    _stub getent 'exit 2'
+    _stub id 'exit 1'
+    heal_claim_state_ownership() {
+        printf "heal %s\n" "$*" >> "$COMMAND_LOG"
+    }
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    # Heal entry exists and comes after the adduser entry.
+    local heal_line adduser_line
+    heal_line="$(grep -n '^heal ' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    adduser_line="$(grep -n '^adduser ' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    [ -n "$heal_line" ]
+    [ -n "$adduser_line" ]
+    [ "$heal_line" -gt "$adduser_line" ]
+    grep -q "^heal $ETC_AIRPLANES$" "$COMMAND_LOG"
+}

--- a/test/test_update_builds.bats
+++ b/test/test_update_builds.bats
@@ -318,7 +318,7 @@ exit 0'
     echo deadbeef > "$IPATH/readsb_version"
     cat > "$READSB_BIN" <<'SH'
 #!/bin/sh
-[[ "$1" == "-V" ]] && exit 0
+[ "$1" = "-V" ] && exit 0
 exit 0
 SH
     chmod +x "$READSB_BIN"
@@ -335,7 +335,8 @@ SH
     echo deadbeef > "$IPATH/readsb_version"
     cat > "$READSB_BIN" <<'SH'
 #!/bin/sh
-[[ "$1" == "-V" ]] && exit 0
+[ "$1" = "-V" ] && exit 0
+exit 0
 SH
     chmod +x "$READSB_BIN"
     AIRPLANES_BUILD_MODE=1
@@ -352,7 +353,8 @@ SH
     echo "real-version-sha" > "$IPATH/readsb_version"
     cat > "$READSB_BIN" <<'SH'
 #!/bin/sh
-[[ "$1" == "-V" ]] && exit 0
+[ "$1" = "-V" ] && exit 0
+exit 0
 SH
     chmod +x "$READSB_BIN"
     _stub git '

--- a/test/test_update_builds.bats
+++ b/test/test_update_builds.bats
@@ -1,0 +1,420 @@
+#!/usr/bin/env bats
+# Tests for install_mlat_client and build_readsb_feed_client, defined in
+# scripts/lib/update-builds.sh. Stubs git, systemctl, python3, pip, make
+# via PATH manipulation. The AIRPLANES_PYTHON_BIN seam routes the venv
+# creation step through the same stubbed python3 so a single shim covers
+# both the bare invocation and `python3 -c` / `python3 -m pip` calls.
+#
+# Helper deps: install-update-common.sh provides getGIT, revision, and
+# airplanes_is_build_mode. Tests override getGIT/revision as bash
+# functions after sourcing so they don't actually clone/run-git, and
+# control airplanes_is_build_mode via the AIRPLANES_BUILD_MODE env var
+# (which is the function's real input).
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    LIB="$REPO_ROOT/scripts/lib/update-builds.sh"
+    COMMON_LIB="$REPO_ROOT/scripts/lib/install-update-common.sh"
+
+    TMP="$(mktemp -d)"
+    STUB_DIR="$TMP/bin"
+    COMMAND_LOG="$TMP/commands.log"
+    IPATH="$TMP/install"
+    VENV="$IPATH/venv"
+    MLAT_GIT="$TMP/mlat-client-git"
+    READSB_GIT="$TMP/readsb-git"
+    READSB_BIN="$IPATH/feed-airplanes"
+    LOGFILE="$TMP/lastlog"
+    mkdir -p "$STUB_DIR" "$IPATH"
+    : > "$COMMAND_LOG"
+    : > "$LOGFILE"
+
+    AIRPLANES_BUILD_MODE=
+    export AIRPLANES_BUILD_MODE COMMAND_LOG
+
+    # Default git stub returns a deterministic SHA for ls-remote so the
+    # version-skip-check has a stable target. Tests override per-case.
+    _stub git '
+case "$1" in
+    ls-remote)
+        printf "git ls-remote %s\n" "$*" >> "$COMMAND_LOG"
+        printf "deadbeef\trefs/heads/%s\n" "${3:-master}"
+        exit 0
+        ;;
+    *)
+        printf "git %s\n" "$*" >> "$COMMAND_LOG"
+        exit 0
+        ;;
+esac'
+
+    _stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub make 'printf "make %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+    _stub cp 'printf "cp %s\n" "$*" >> "$COMMAND_LOG"; /bin/cp "$@"'
+    _stub pip '
+printf "pip %s\n" "$*" >> "$COMMAND_LOG"
+exit "${PIP_EXIT:-0}"'
+    _stub python3 '
+printf "python3 %s\n" "$*" >> "$COMMAND_LOG"
+case "$1" in
+    -m)
+        case "$2" in
+            venv)
+                # Mirror real python3 -m venv: create the dir tree and
+                # stub binaries the chain expects to find afterward.
+                mkdir -p "$3/bin"
+                : > "$3/bin/activate"
+                printf "#!/bin/sh\nexit 0\n" > "$3/bin/mlat-client"
+                chmod +x "$3/bin/mlat-client"
+                exit "${PYTHON_VENV_EXIT:-0}"
+                ;;
+            pip)
+                # `python3 -m pip install <X>` — succeed unless overridden.
+                exit "${PYTHON_PIP_EXIT:-0}"
+                ;;
+        esac
+        ;;
+    -c)
+        case "$2" in
+            "import setuptools") exit "${PYTHON_IMPORT_SETUPTOOLS_EXIT:-0}" ;;
+            "import asyncore")   exit "${PYTHON_IMPORT_ASYNCORE_EXIT:-0}"   ;;
+        esac
+        ;;
+esac
+exit 0'
+
+    AIRPLANES_PYTHON_BIN="$STUB_DIR/python3"
+    PATH="$STUB_DIR:$PATH"
+    export PATH AIRPLANES_PYTHON_BIN
+
+    # shellcheck source=/dev/null
+    source "$COMMON_LIB"
+    # shellcheck source=/dev/null
+    source "$LIB"
+
+    # Override real getGIT (which would actually clone) with a stub that
+    # creates the target dir as a usable git repo so subsequent `cd
+    # $target` and `revision` calls succeed naturally.
+    getGIT() {
+        local target="$3"
+        printf "getGIT %s %s %s\n" "$1" "$2" "$3" >> "$COMMAND_LOG"
+        if [[ "${GETGIT_EXIT:-0}" != 0 ]]; then
+            return "$GETGIT_EXIT"
+        fi
+        mkdir -p "$target"
+        ( cd "$target" && git init -q && git config user.email t@e.invalid \
+            && git config user.name t && git commit --allow-empty -q -m fixture )
+    }
+
+    # revision normally runs `git rev-parse HEAD` in cwd. Override to a
+    # deterministic value so tests can assert on the version file content.
+    revision() {
+        printf "deadbeef"
+    }
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+_stub() {
+    local name="$1"
+    local body="$2"
+    cat > "$STUB_DIR/$name" <<SH
+#!/usr/bin/env bash
+$body
+SH
+    chmod +x "$STUB_DIR/$name"
+}
+
+# ---------------------------------------------------------------------------
+# install_mlat_client
+# ---------------------------------------------------------------------------
+
+@test "install_mlat_client: happy path writes mlat_version and leaves \$PWD unchanged" {
+    local before_pwd="$PWD"
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ -f "$IPATH/mlat_version" ]
+    [ "$(cat "$IPATH/mlat_version")" = "deadbeef" ]
+    [ -x "$VENV/bin/mlat-client" ]
+    [ "$PWD" = "$before_pwd" ]
+}
+
+@test "install_mlat_client: skip when version matches AND service is active" {
+    echo deadbeef > "$IPATH/mlat_version"
+    mkdir -p "$VENV/bin"
+    printf "#!/bin/sh\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+    _stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; [[ "$1" == "is-active" ]] && exit 0; exit 0'
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    # Skip path: getGIT not invoked, no rebuild attempted.
+    ! grep -q "^getGIT " "$COMMAND_LOG"
+    ! grep -q "^pip install" "$COMMAND_LOG"
+}
+
+@test "install_mlat_client: skip via MLAT_DISABLED=1 even with inactive service" {
+    echo deadbeef > "$IPATH/mlat_version"
+    mkdir -p "$VENV/bin"
+    printf "#!/bin/sh\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+    # systemctl is-active fails (service inactive)
+    _stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; [[ "$1" == "is-active" ]] && exit 1; exit 0'
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 1
+
+    ! grep -q "^getGIT " "$COMMAND_LOG"
+}
+
+@test "install_mlat_client: skip via build mode without consulting systemctl" {
+    echo deadbeef > "$IPATH/mlat_version"
+    mkdir -p "$VENV/bin"
+    printf "#!/bin/sh\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+    AIRPLANES_BUILD_MODE=1
+    export AIRPLANES_BUILD_MODE
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    ! grep -q "^getGIT " "$COMMAND_LOG"
+    # Build-mode short-circuits the conjunction; systemctl shouldn't be reached
+    ! grep -q "^systemctl is-active" "$COMMAND_LOG"
+}
+
+@test "install_mlat_client: empty git ls-remote falls back to sentinel and forces rebuild" {
+    # Pre-existing version file. Buggy old code with empty MLAT_VERSION
+    # would falsely match here via grep -e "" and skip. The empty-guard
+    # produces a $RANDOM-$RANDOM sentinel that doesn't match.
+    echo "real-version-sha" > "$IPATH/mlat_version"
+    mkdir -p "$VENV/bin"
+    printf "#!/bin/sh\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+    _stub git '
+case "$1" in
+    ls-remote)
+        printf "git ls-remote %s\n" "$*" >> "$COMMAND_LOG"
+        # Empty stdout: simulates network/auth failure
+        exit 0
+        ;;
+    *)
+        printf "git %s\n" "$*" >> "$COMMAND_LOG"
+        exit 0
+        ;;
+esac'
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    # Rebuild proceeded → getGIT was called.
+    grep -q "^getGIT https://example/mlat-client master " "$COMMAND_LOG"
+}
+
+@test "install_mlat_client: pip failure is masked by chain (regression — preserve verbatim)" {
+    # Regression pin for the chain quirk in the install command list at
+    # update.sh:472–484 (now in update-builds.sh): the trailing
+    # `... || rm -f $ipath/mlat_version && echo 48` resets the chain's
+    # failure to success because `rm -f` always returns 0, then
+    # `echo 48` succeeds, leaving the chain's final exit status at 0.
+    # That means a `pip install` failure does NOT trigger the else
+    # branch / backup-restore path — the if-success branch fires and
+    # the (broken) new venv is kept while the backup is removed.
+    #
+    # The constraint says preserve verbatim; this test pins that
+    # semantics so a future "tidy up" of the chain can't silently
+    # change failure handling without the test failing.
+    PIP_EXIT=1
+    export PIP_EXIT
+
+    run install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ "$status" -eq 0 ]
+    # Failure-message NOT printed: success branch fires.
+    [[ "$output" != *"Installing mlat-client failed"* ]]
+    # Backup removed (success branch's `rm -rf $venv-backup`).
+    [ ! -e "$VENV-backup" ]
+    # mlat_version was removed by the chain's `|| rm -f` step before
+    # echo 48 reset the chain to success.
+    [ ! -f "$IPATH/mlat_version" ]
+}
+
+@test "install_mlat_client: getGIT failure aborts under set -e" {
+    # Bash set -e is suppressed in the dynamic scope of an &&/|| chain,
+    # which means a `( ... ) || status=$?` capture pattern actually
+    # disables set -e inside the subshell despite an inner `set -e` line.
+    # `bats run` has the same problem (it disables set -e for the captured
+    # command). Use a fresh `bash -c` instead so set -e inside the
+    # captured shell is genuinely active.
+    GETGIT_EXIT=1
+    export GETGIT_EXIT VENV IPATH MLAT_GIT LOGFILE COMMAND_LOG STUB_DIR \
+        AIRPLANES_PYTHON_BIN AIRPLANES_BUILD_MODE PATH
+
+    run bash -c '
+set -e
+source "'"$COMMON_LIB"'"
+source "'"$LIB"'"
+getGIT() { return "${GETGIT_EXIT:-1}"; }
+revision() { printf "deadbeef"; }
+install_mlat_client https://example/mlat-client master \
+    "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+'
+    [ "$status" -ne 0 ]
+}
+
+@test "install_mlat_client: setuptools/asyncore fallback chain installs missing modules in order" {
+    # `python3 -c "import setuptools"` fails → triggers `python3 -m pip
+    # install setuptools` fallback. Same for asyncore → pyasyncore.
+    PYTHON_IMPORT_SETUPTOOLS_EXIT=1
+    PYTHON_IMPORT_ASYNCORE_EXIT=1
+    export PYTHON_IMPORT_SETUPTOOLS_EXIT PYTHON_IMPORT_ASYNCORE_EXIT
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    # Both fallbacks fired with the right module names.
+    grep -q "^python3 -m pip install setuptools$" "$COMMAND_LOG"
+    grep -q "^python3 -m pip install pyasyncore$" "$COMMAND_LOG"
+    # And in the right order.
+    local setuptools_line asyncore_line
+    setuptools_line="$(grep -n 'pip install setuptools' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    asyncore_line="$(grep -n 'pip install pyasyncore' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    [ -n "$setuptools_line" ]
+    [ -n "$asyncore_line" ]
+    [ "$setuptools_line" -lt "$asyncore_line" ]
+}
+
+# ---------------------------------------------------------------------------
+# build_readsb_feed_client
+# ---------------------------------------------------------------------------
+
+@test "build_readsb_feed_client: happy path builds and writes readsb_version, leaves \$PWD unchanged" {
+    # Make `cp readsb $READSB_BIN` succeed by seeding a fake binary in
+    # the build dir before make would have written it. The getGIT stub
+    # creates the dir; we add a readsb file via a make stub that drops
+    # one in cwd.
+    _stub make '
+printf "make %s\n" "$*" >> "$COMMAND_LOG"
+[[ "$1" == "clean" ]] && exit 0
+printf "#!/bin/sh\nexit 0\n" > readsb
+chmod +x readsb
+exit 0'
+
+    local before_pwd="$PWD"
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+
+    [ -x "$READSB_BIN" ]
+    [ -f "$IPATH/readsb_version" ]
+    [ "$(cat "$IPATH/readsb_version")" = "deadbeef" ]
+    [ "$PWD" = "$before_pwd" ]
+}
+
+@test "build_readsb_feed_client: skip when version matches AND binary -V succeeds AND service active" {
+    echo deadbeef > "$IPATH/readsb_version"
+    cat > "$READSB_BIN" <<'SH'
+#!/bin/sh
+[[ "$1" == "-V" ]] && exit 0
+exit 0
+SH
+    chmod +x "$READSB_BIN"
+    _stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; [[ "$1" == "is-active" ]] && exit 0; exit 0'
+
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+
+    ! grep -q "^getGIT " "$COMMAND_LOG"
+    ! grep -q "^make " "$COMMAND_LOG"
+}
+
+@test "build_readsb_feed_client: skip via build mode without consulting systemctl" {
+    echo deadbeef > "$IPATH/readsb_version"
+    cat > "$READSB_BIN" <<'SH'
+#!/bin/sh
+[[ "$1" == "-V" ]] && exit 0
+SH
+    chmod +x "$READSB_BIN"
+    AIRPLANES_BUILD_MODE=1
+    export AIRPLANES_BUILD_MODE
+
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+
+    ! grep -q "^getGIT " "$COMMAND_LOG"
+    ! grep -q "^systemctl is-active" "$COMMAND_LOG"
+}
+
+@test "build_readsb_feed_client: empty git ls-remote falls back to sentinel and forces rebuild" {
+    echo "real-version-sha" > "$IPATH/readsb_version"
+    cat > "$READSB_BIN" <<'SH'
+#!/bin/sh
+[[ "$1" == "-V" ]] && exit 0
+SH
+    chmod +x "$READSB_BIN"
+    _stub git '
+case "$1" in
+    ls-remote)
+        printf "git ls-remote %s\n" "$*" >> "$COMMAND_LOG"
+        exit 0
+        ;;
+    *)
+        printf "git %s\n" "$*" >> "$COMMAND_LOG"
+        exit 0
+        ;;
+esac'
+    _stub make '
+printf "make %s\n" "$*" >> "$COMMAND_LOG"
+[[ "$1" == "clean" ]] && exit 0
+printf "#!/bin/sh\n" > readsb
+chmod +x readsb
+exit 0'
+
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+
+    grep -q "^getGIT https://example/readsb dev " "$COMMAND_LOG"
+}
+
+@test "build_readsb_feed_client: make failure aborts under set -e" {
+    # See note on the mlat getGIT-failure test: use bash -c so set -e
+    # genuinely applies inside the captured shell.
+    _stub make '
+printf "make %s\n" "$*" >> "$COMMAND_LOG"
+[[ "$1" == "clean" ]] && exit 0
+exit 2'
+
+    export READSB_GIT READSB_BIN IPATH LOGFILE COMMAND_LOG STUB_DIR \
+        AIRPLANES_BUILD_MODE PATH
+
+    run bash -c '
+set -e
+source "'"$COMMON_LIB"'"
+source "'"$LIB"'"
+getGIT() { mkdir -p "$3"; ( cd "$3" && git init -q && git config user.email t@e.invalid && git config user.name t && git commit --allow-empty -q -m fixture ); }
+revision() { printf "deadbeef"; }
+build_readsb_feed_client https://example/readsb dev \
+    "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+'
+    [ "$status" -ne 0 ]
+}
+
+@test "build_readsb_feed_client: getGIT failure aborts under set -e" {
+    GETGIT_EXIT=1
+    export GETGIT_EXIT READSB_GIT READSB_BIN IPATH LOGFILE COMMAND_LOG \
+        STUB_DIR AIRPLANES_BUILD_MODE PATH
+
+    run bash -c '
+set -e
+source "'"$COMMON_LIB"'"
+source "'"$LIB"'"
+getGIT() { return "${GETGIT_EXIT:-1}"; }
+revision() { printf "deadbeef"; }
+build_readsb_feed_client https://example/readsb dev \
+    "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+'
+    [ "$status" -ne 0 ]
+}

--- a/test/test_update_builds.bats
+++ b/test/test_update_builds.bats
@@ -214,6 +214,50 @@ esac'
     grep -q "^getGIT https://example/mlat-client master " "$COMMAND_LOG"
 }
 
+@test "install_mlat_client: REINSTALL=yes forces rebuild even when skip-conditions match" {
+    # Skip would otherwise fire: matching version, mlat-client binary in
+    # place, active service. REINSTALL=yes is the operator's explicit
+    # override for "rebuild regardless".
+    echo deadbeef > "$IPATH/mlat_version"
+    mkdir -p "$VENV/bin"
+    printf "#!/bin/sh\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+    _stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; [[ "$1" == "is-active" ]] && exit 0; exit 0'
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" yes 0
+
+    grep -q "^getGIT https://example/mlat-client master " "$COMMAND_LOG"
+}
+
+@test "install_mlat_client: missing version file forces rebuild" {
+    # No prior $IPATH/mlat_version file at all (fresh-ish install or
+    # post-uninstall). The skip's `grep -qs ... mlat_version` fails on
+    # the missing file, forcing rebuild.
+    [ ! -f "$IPATH/mlat_version" ]
+    mkdir -p "$VENV/bin"
+    printf "#!/bin/sh\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    grep -q "^getGIT https://example/mlat-client master " "$COMMAND_LOG"
+}
+
+@test "install_mlat_client: missing mlat-client binary forces rebuild" {
+    # Version file matches but $VENV/bin/mlat-client is gone (e.g.
+    # half-broken venv from a prior interrupted update). The skip's
+    # shebang grep on the binary fails, forcing rebuild.
+    echo deadbeef > "$IPATH/mlat_version"
+    [ ! -e "$VENV/bin/mlat-client" ]
+
+    install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    grep -q "^getGIT https://example/mlat-client master " "$COMMAND_LOG"
+}
+
 @test "install_mlat_client: pip failure is masked by chain (regression — preserve verbatim)" {
     # Regression pin for the chain quirk in the install command list at
     # update.sh:472–484 (now in update-builds.sh): the trailing
@@ -372,6 +416,72 @@ esac'
 printf "make %s\n" "$*" >> "$COMMAND_LOG"
 [[ "$1" == "clean" ]] && exit 0
 printf "#!/bin/sh\n" > readsb
+chmod +x readsb
+exit 0'
+
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+
+    grep -q "^getGIT https://example/readsb dev " "$COMMAND_LOG"
+}
+
+@test "build_readsb_feed_client: REINSTALL=yes forces rebuild even when skip-conditions match" {
+    echo deadbeef > "$IPATH/readsb_version"
+    cat > "$READSB_BIN" <<'SH'
+#!/bin/sh
+[ "$1" = "-V" ] && exit 0
+exit 0
+SH
+    chmod +x "$READSB_BIN"
+    _stub systemctl 'printf "systemctl %s\n" "$*" >> "$COMMAND_LOG"; [[ "$1" == "is-active" ]] && exit 0; exit 0'
+    _stub make '
+printf "make %s\n" "$*" >> "$COMMAND_LOG"
+[[ "$1" == "clean" ]] && exit 0
+printf "#!/bin/sh\nexit 0\n" > readsb
+chmod +x readsb
+exit 0'
+
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" yes
+
+    grep -q "^getGIT https://example/readsb dev " "$COMMAND_LOG"
+}
+
+@test "build_readsb_feed_client: missing version file forces rebuild" {
+    [ ! -f "$IPATH/readsb_version" ]
+    cat > "$READSB_BIN" <<'SH'
+#!/bin/sh
+[ "$1" = "-V" ] && exit 0
+exit 0
+SH
+    chmod +x "$READSB_BIN"
+    _stub make '
+printf "make %s\n" "$*" >> "$COMMAND_LOG"
+[[ "$1" == "clean" ]] && exit 0
+printf "#!/bin/sh\nexit 0\n" > readsb
+chmod +x readsb
+exit 0'
+
+    build_readsb_feed_client \
+        https://example/readsb dev "$READSB_GIT" "$READSB_BIN" "$IPATH" "$LOGFILE" no
+
+    grep -q "^getGIT https://example/readsb dev " "$COMMAND_LOG"
+}
+
+@test "build_readsb_feed_client: binary -V failure forces rebuild" {
+    # Version file matches but the existing binary refuses -V (corrupted,
+    # ABI mismatch, partial copy from interrupted prior update). The
+    # skip's `"$readsb_bin" -V` leg fails → rebuild.
+    echo deadbeef > "$IPATH/readsb_version"
+    cat > "$READSB_BIN" <<'SH'
+#!/bin/sh
+exit 1
+SH
+    chmod +x "$READSB_BIN"
+    _stub make '
+printf "make %s\n" "$*" >> "$COMMAND_LOG"
+[[ "$1" == "clean" ]] && exit 0
+printf "#!/bin/sh\nexit 0\n" > readsb
 chmod +x readsb
 exit 0'
 

--- a/update.sh
+++ b/update.sh
@@ -291,6 +291,10 @@ run_pre_config_legacy_retirements
 source "$GIT/scripts/lib/systemd-helpers.sh"
 # shellcheck source=scripts/lib/claim-registration.sh
 source "$GIT/scripts/lib/claim-registration.sh"
+# shellcheck source=scripts/lib/service-account.sh
+source "$GIT/scripts/lib/service-account.sh"
+# shellcheck source=scripts/lib/update-builds.sh
+source "$GIT/scripts/lib/update-builds.sh"
 
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
     # Unset USER before sourcing so a process-environment $USER (e.g. the
@@ -419,53 +423,10 @@ install -m 0755 "$GIT/scripts/apl-feed.sh" "$LOCAL_BIN/apl-feed"
 # read claim-state files (mode 0640) without escalating to root. Membership
 # in this group grants read access to /etc/airplanes/feeder-claim-secret;
 # only add service accounts that legitimately need to reveal claim secrets.
-UNAME=airplanes-feed
-GNAME=airplanes-feed
-
-# Group must exist before write_secret_file (or the heal step) tries to
-# chown into it. Create idempotently — a later run on a feeder where the
-# group already exists is a no-op. Mirror the adduser/useradd cascade for
-# distro portability.
-if ! getent group "$GNAME" >/dev/null 2>&1
-then
-    # Trailing recheck handles the case where a concurrent update created
-    # the group between our guard and the addgroup call (rare, but the
-    # fatal exit would be wrong if the group now exists).
-    addgroup --system "$GNAME" \
-        || groupadd --system "$GNAME" \
-        || getent group "$GNAME" >/dev/null 2>&1 \
-        || { echo "ERROR: failed to create group '$GNAME' (no working addgroup/groupadd)." >&2; exit 1; }
-fi
-
-if ! id -u "${UNAME}" &>/dev/null
-then
-    # Fresh user creation: put the user in the airplanes-feed group as
-    # primary so processes started under User=airplanes-feed get the group
-    # in their initial credentials without needing a supplementary lookup.
-    # `||` chains are set -e safe; the trailing recheck handles concurrent
-    # creation by a parallel update; the final block makes the all-failed
-    # case explicit.
-    adduser --system --ingroup "$GNAME" --home "$IPATH" --no-create-home --quiet "$UNAME" \
-        || adduser --system --gid "$(getent group "$GNAME" | cut -d: -f3)" --home-dir "$IPATH" --no-create-home "$UNAME" \
-        || useradd --system --gid "$(getent group "$GNAME" | cut -d: -f3)" --home-dir "$IPATH" --no-create-home "$UNAME" \
-        || id -u "$UNAME" &>/dev/null \
-        || { echo "ERROR: failed to create user '$UNAME' (no working adduser/useradd)." >&2; exit 1; }
-else
-    # Existing user from a pre-pivot install: primary group is likely
-    # `nogroup`. Add airplanes-feed as a supplementary group so the daemon
-    # process picks it up after the post-install service restart.
-    if ! id -nG "$UNAME" 2>/dev/null | tr ' ' '\n' | grep -qx "$GNAME"
-    then
-        usermod -aG "$GNAME" "$UNAME" 2>/dev/null \
-            || gpasswd -a "$UNAME" "$GNAME" 2>/dev/null \
-            || echo "WARNING: could not add $UNAME to $GNAME group; webconfig 'claim show' may stay broken until manually fixed" >&2
-    fi
-fi
-
-# Heal claim-state files written by older feed versions that lacked the
-# airplanes-feed chown (which would be root:root mode 0600 and unreadable
-# by other service accounts in the airplanes-feed group).
-heal_claim_state_ownership "$ETC_AIRPLANES"
+#
+# See scripts/lib/service-account.sh for the create/repair logic and the
+# heal_claim_state_ownership chown step.
+ensure_airplanes_feed_account airplanes-feed airplanes-feed "$IPATH" "$ETC_AIRPLANES"
 
 echo 4
 sleep 0.25
@@ -483,56 +444,17 @@ fi
 
 MLAT_REPO="${AIRPLANES_MLAT_REPO:-https://github.com/airplanes-live/mlat-client}"
 MLAT_BRANCH="${AIRPLANES_MLAT_BRANCH:-master}"
-MLAT_VERSION="$(git ls-remote "$MLAT_REPO" "$MLAT_BRANCH" | cut -f1 || echo "$RANDOM-$RANDOM" )"
-if [[ $REINSTALL != yes ]] && grep -e "$MLAT_VERSION" -qs "$IPATH/mlat_version" \
-    && grep -qs -e '#!' "$VENV/bin/mlat-client" && { airplanes_is_build_mode || systemctl is-active airplanes-mlat &>/dev/null || [[ "${MLAT_DISABLED}" == "1" ]]; }
-then
-    echo
-    echo "mlat-client already installed, git hash:"
-    cat "$IPATH/mlat_version"
-    echo
-else
-    echo
-    echo "Installing mlat-client to virtual environment"
-    echo
-    # Check if the mlat-client git repository already exists.
+MLAT_GIT="$IPATH/mlat-client-git"
 
-    MLAT_GIT="$IPATH/mlat-client-git"
-
-    # getGIT REPO BRANCH TARGET-DIR
-    getGIT "$MLAT_REPO" "$MLAT_BRANCH" "$MLAT_GIT" &> "$LOGFILE"
-
-    cd "$MLAT_GIT"
-
-    echo 34
-
-    rm "$VENV-backup" -rf
-    mv "$VENV" "$VENV-backup" -f &>/dev/null || true
-    if /usr/bin/python3 -m venv "$VENV" >> "$LOGFILE" \
-        && echo 36 \
-        && source "$VENV/bin/activate" >> "$LOGFILE" \
-        && echo 37 \
-        && python3 -c "import setuptools" || python3 -m pip install setuptools \
-        && echo 39 \
-        && python3 -c "import asyncore" || python3 -m pip install pyasyncore \
-        && python3 -m pip install wheel \
-        && echo 40 \
-        && pip install . \
-        && echo 46 \
-        && revision > "$IPATH/mlat_version" || rm -f "$IPATH/mlat_version" \
-        && echo 48 \
-    ; then
-        rm "$VENV-backup" -rf
-    else
-        rm "$VENV" -rf
-        mv "$VENV-backup" "$VENV" &>/dev/null || true
-        echo "--------------------"
-        echo "Installing mlat-client failed, if there was an old version it has been restored."
-        echo "Will continue installation to try and get at least the feed client working."
-        echo "Please report this error on Discord."
-        echo "--------------------"
-    fi
-fi
+install_mlat_client \
+    "$MLAT_REPO" \
+    "$MLAT_BRANCH" \
+    "$VENV" \
+    "$IPATH" \
+    "$MLAT_GIT" \
+    "$LOGFILE" \
+    "$REINSTALL" \
+    "$MLAT_DISABLED"
 
 echo 50
 
@@ -585,44 +507,17 @@ else
     if airplanes_is_legacy_os; then
         READSB_BRANCH="jessie"
     fi
-    READSB_VERSION="$(git ls-remote "$READSB_REPO" "$READSB_BRANCH" | cut -f1 || echo "$RANDOM-$RANDOM" )"
     READSB_GIT="$IPATH/readsb-git"
     READSB_BIN="$IPATH/feed-airplanes"
-    if [[ $REINSTALL != yes ]] && grep -e "$READSB_VERSION" -qs "$IPATH/readsb_version" \
-        && "$READSB_BIN" -V && { airplanes_is_build_mode || systemctl is-active airplanes-feed &>/dev/null; }
-    then
-        echo
-        echo "Feed client already installed, git hash:"
-        cat "$IPATH/readsb_version"
-        echo
-    else
-        echo
-        echo "Compiling / installing the readsb based feed client"
-        echo
 
-        #compile readsb
-        echo 72
-
-        # getGIT REPO BRANCH TARGET-DIR
-        getGIT "$READSB_REPO" "$READSB_BRANCH" "$READSB_GIT" &> "$LOGFILE"
-
-        cd "$READSB_GIT"
-
-        echo "-----------------------------------------------"
-        echo "Now compiling code can take a few minutes"
-        echo "-----------------------------------------------"
-
-        echo 74
-
-        make clean
-        make -j2 AIRCRAFT_HASH_BITS=12 >> "$LOGFILE"
-        echo 80
-        rm -f "$READSB_BIN"
-        cp readsb "$READSB_BIN"
-        revision > "$IPATH/readsb_version" || rm -f "$IPATH/readsb_version"
-
-        echo
-    fi
+    build_readsb_feed_client \
+        "$READSB_REPO" \
+        "$READSB_BRANCH" \
+        "$READSB_GIT" \
+        "$READSB_BIN" \
+        "$IPATH" \
+        "$LOGFILE" \
+        "$REINSTALL"
 fi
 
 #end compile readsb


### PR DESCRIPTION
Mirrors the recent update-migrations.sh extraction. Two new helper modules under scripts/lib/ — update-builds.sh (install_mlat_client, build_readsb_feed_client) and service-account.sh (ensure_airplanes_feed_account) — capture the mlat-client venv build, the readsb compile, and the airplanes-feed user/group creation as named functions taking explicit positional args. Build steps run inside subshells so the cd into clone dirs stays scoped. The mlat install command chain is preserved verbatim, with AIRPLANES_PYTHON_BIN as the one test seam.

Folds in a small bug fix that surfaced during the extraction. The MLAT_VERSION/READSB_VERSION computation form `git ls-remote ... | cut -f1 || echo $RANDOM-$RANDOM` relied on the trailing OR firing when the pipe failed, but without pipefail the OR only fires on `cut`'s own exit — so a flaky ls-remote left the variable empty, and the downstream skip-check `grep -e "$VERSION"` then falsely matched any non-empty version file with the empty pattern. Feeders silently skipped mlat/readsb rebuilds whenever the version-check fetch flaked. Fixed inside the new helpers with an explicit empty-guard sentinel.