### PR TITLE
Add daemon runtime state-file foundation and lifecycle handover

### DIFF
--- a/scripts/airplanes-feed.service
+++ b/scripts/airplanes-feed.service
@@ -6,6 +6,8 @@ After=network.target airplanes-first-run.service
 
 [Service]
 User=airplanes-feed
+RuntimeDirectory=airplanes-feed
+RuntimeDirectoryPreserve=restart
 ExecStart=/usr/local/share/airplanes/airplanes-feed.sh
 Type=simple
 Restart=always

--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -70,6 +70,33 @@ else
     FEED_IMAGE_OPTIONS=""
 fi
 
+# State writer (defensive: a partial install where this script is in
+# place but the lib isn't yet must not take down the daemon).
+STATE_WRITER="$(airplanes_path /usr/local/share/airplanes/lib/state-writer.sh)"
+if [[ -r "$STATE_WRITER" ]]; then
+    # shellcheck source=lib/state-writer.sh
+    source "$STATE_WRITER"
+else
+    airplanes_write_state() { return 0; }
+fi
+
+# Feed has no MLAT-style disable predicate; it's essentially always-on
+# once the daemon reaches this point. State file is mostly diagnostic
+# (effective config + binary path) for consumers. Forward-compatible
+# with future signals (e.g. an explicit FEED_ENABLED=false toggle
+# would add a reason token without bumping schema_version).
+STATE_FILE="$(airplanes_path /run/airplanes-feed/state)"
+mkdir -p "$(dirname "$STATE_FILE")"
+airplanes_write_state "$STATE_FILE" \
+    "service=airplanes-feed" \
+    "state=enabled" \
+    "reason=ok" \
+    "decided_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "latitude=${LATITUDE:-}" \
+    "longitude=${LONGITUDE:-}" \
+    "input=${INPUT:-}" \
+    "feed_bin=$FEED_BIN" || true
+
 exec "$FEED_BIN" --net --net-only --quiet \
     "--uuid-file=$FEEDER_ID_FILE" \
     $FEED_IMAGE_OPTIONS \

--- a/scripts/airplanes-mlat.service
+++ b/scripts/airplanes-mlat.service
@@ -7,6 +7,7 @@ After=network.target airplanes-first-run.service
 [Service]
 User=airplanes-feed
 RuntimeDirectory=airplanes-mlat
+RuntimeDirectoryPreserve=restart
 ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh
 Type=simple
 Restart=always

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -65,18 +65,58 @@ fi
 
 UUID_FILE="--uuid-file $FEEDER_ID_FILE"
 
-if [[ "$LATITUDE" == 0 ]] || [[ "$LONGITUDE" == 0 ]] || [[ "$MLAT_ENABLED" != "true" ]]; then
-    echo MLAT DISABLED
-    sleep 3600
-    exit
+# State writer (defensive: a partial install where this script is in
+# place but the lib isn't yet must not take down the daemon).
+STATE_WRITER="$(airplanes_path /usr/local/share/airplanes/lib/state-writer.sh)"
+if [[ -r "$STATE_WRITER" ]]; then
+    # shellcheck source=lib/state-writer.sh
+    source "$STATE_WRITER"
+else
+    airplanes_write_state() { return 0; }
 fi
 
-# Strict misconfigure exit. Matches RestartPreventExitStatus=64 in the unit
-# file so systemd marks the unit failed instead of restart-looping.
-if [[ -z "$MLAT_USER" ]]; then
-    echo "MLAT_ENABLED=true but MLAT_USER is empty; refusing to start mlat-client." >&2
-    exit 64
-fi
+# Classify the daemon's config decision. Order matters: explicit
+# MLAT_ENABLED disable is checked before geo so a user who turns MLAT
+# off on a fresh feeder (lat/lon still 0) sees reason=mlat_enabled_false
+# rather than reason=latitude_zero. The misconfigured branch only
+# triggers when the user opted INTO MLAT but left MLAT_USER empty —
+# that's the strict-fail-with-exit-64 shape.
+_mlat_classify() {
+    if [[ "$MLAT_ENABLED" != "true" ]]; then printf 'disabled mlat_enabled_false\n'; return; fi
+    if [[ "$LATITUDE" == 0 ]]; then printf 'disabled latitude_zero\n'; return; fi
+    if [[ "$LONGITUDE" == 0 ]]; then printf 'disabled longitude_zero\n'; return; fi
+    if [[ -z "$MLAT_USER" ]]; then printf 'misconfigured mlat_user_empty\n'; return; fi
+    printf 'enabled ok\n'
+}
+
+read -r STATE REASON < <(_mlat_classify)
+STATE_FILE="$(airplanes_path /run/airplanes-mlat/state)"
+mkdir -p "$(dirname "$STATE_FILE")"
+airplanes_write_state "$STATE_FILE" \
+    "service=airplanes-mlat" \
+    "state=$STATE" \
+    "reason=$REASON" \
+    "decided_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "mlat_enabled=${MLAT_ENABLED:-}" \
+    "mlat_user=${MLAT_USER:-}" \
+    "latitude=${LATITUDE:-}" \
+    "longitude=${LONGITUDE:-}" || true
+
+case "$STATE" in
+    disabled)
+        echo MLAT DISABLED
+        sleep 3600
+        exit
+        ;;
+    misconfigured)
+        # Matches RestartPreventExitStatus=64 in the unit file so
+        # systemd marks the unit failed instead of restart-looping.
+        echo "MLAT_ENABLED=true but MLAT_USER is empty; refusing to start mlat-client." >&2
+        exit 64
+        ;;
+    enabled)
+        ;;
+esac
 
 INPUT_IP=$(echo $INPUT | cut -d: -f1)
 INPUT_PORT=$(echo $INPUT | cut -d: -f2)

--- a/scripts/lib/state-writer.sh
+++ b/scripts/lib/state-writer.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Runtime state writer. Daemons call airplanes_write_state to publish
+# their config decision to a state file consumed by apl-feed status,
+# render-status, and the webconfig dashboard.
+#
+# Format: env-style, line-based. First line is schema_version=1
+# (writer-emitted; caller MUST NOT supply this key). Subsequent lines
+# are KEY=VALUE in caller-provided order. Values are emitted verbatim
+# (no shell-quoting). Newlines and carriage returns in values are
+# rejected. Keys must match [A-Za-z_][A-Za-z0-9_]*.
+#
+# Atomic: writes a temp file in the same directory, then renames over
+# the target. Readers may see the previous file or the new file, never
+# a partial mix. Mode 0644 (state is not sensitive).
+#
+# Lifecycle: state file is written ONCE per daemon activation, before
+# any sleep/exec/exit. It represents the daemon's config decision at
+# activation time, NOT live runtime status. Mid-run updates are NOT
+# emitted; live runtime status (process alive, exec succeeded, child
+# connected) is observable via systemd liveness, journal output, and
+# external probes.
+#
+# Readers MUST NOT `source` this file — values are unquoted; arbitrary
+# string content (e.g. user-supplied MLAT_USER) could contain shell
+# metacharacters. Parse line-by-line with KEY=VALUE split on first `=`.
+#
+# Usage:
+#   airplanes_write_state /run/airplanes-mlat/state \
+#       service=airplanes-mlat \
+#       state=disabled \
+#       reason=mlat_enabled_false \
+#       decided_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+#       mlat_enabled=false \
+#       mlat_user=
+#
+# Returns 0 on success, 1 on validation failure or write error
+# (target file is left unchanged on either).
+
+airplanes_write_state() {
+    local target="$1"; shift
+    local tmp
+    tmp="$(mktemp "${target}.XXXXXX")" || return 1
+    local kv key value rc=0
+
+    {
+        printf 'schema_version=1\n'
+        for kv in "$@"; do
+            case "$kv" in
+                *=*) ;;
+                *)
+                    printf 'state-writer: arg %q is not KEY=VALUE\n' "$kv" >&2
+                    rc=1
+                    break
+                    ;;
+            esac
+            key="${kv%%=*}"
+            value="${kv#*=}"
+            if [[ "$key" == "schema_version" ]]; then
+                printf 'state-writer: caller-supplied schema_version is rejected\n' >&2
+                rc=1
+                break
+            fi
+            if ! [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+                printf 'state-writer: invalid key %q\n' "$key" >&2
+                rc=1
+                break
+            fi
+            case "$value" in
+                *$'\n'*|*$'\r'*)
+                    printf 'state-writer: value for %s contains CR/LF; refusing to write\n' "$key" >&2
+                    rc=1
+                    break
+                    ;;
+            esac
+            printf '%s=%s\n' "$key" "$value"
+        done
+    } > "$tmp" || rc=1
+
+    if (( rc != 0 )); then
+        rm -f "$tmp"
+        return 1
+    fi
+
+    chmod 0644 "$tmp" || { rm -f "$tmp"; return 1; }
+    mv -f "$tmp" "$target" || { rm -f "$tmp"; return 1; }
+    return 0
+}

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -201,6 +201,244 @@ SH
     grep -q -- '--manual-net-option' "$arg_log"
 }
 
+# --- State-file foundation: daemons publish their config decision ---
+
+# Install state-writer.sh at the daemon's expected runtime path so the
+# defensive `if [[ -r ... ]]` branch sources the real lib. Without this,
+# the daemon falls through to the stub fallback (no-op) and no state
+# file is written.
+install_state_writer_lib() {
+    local root="$1"
+    install -d -m 0755 "$root/usr/local/share/airplanes/lib"
+    install -m 0644 "$BATS_TEST_DIRNAME/../scripts/lib/state-writer.sh" \
+        "$root/usr/local/share/airplanes/lib/state-writer.sh"
+}
+
+# Set up an mlat run with stubbed nc/sleep/mlat-client so the daemon
+# proceeds through its decision and either (a) emits MLAT DISABLED +
+# sleep + exit 0, (b) exits 64, or (c) execs the mlat-client stub.
+setup_mlat_runtime() {
+    local root="$1"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+}
+
+write_feed_env() {
+    local root="$1"; shift
+    mkdir -p "$root/etc/airplanes"
+    : > "$root/etc/airplanes/feed.env"
+    local kv
+    for kv in "$@"; do
+        printf '%s\n' "$kv" >> "$root/etc/airplanes/feed.env"
+    done
+}
+
+@test "airplanes-mlat.sh writes state=enabled,reason=ok with valid config" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ -f "$root/run/airplanes-mlat/state" ]
+    grep -qx 'schema_version=1' "$root/run/airplanes-mlat/state"
+    grep -qx 'service=airplanes-mlat' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=ok' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_enabled=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=alice' "$root/run/airplanes-mlat/state"
+    grep -qx 'latitude=52' "$root/run/airplanes-mlat/state"
+    grep -qx 'longitude=13' "$root/run/airplanes-mlat/state"
+    grep -qE '^decided_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$root/run/airplanes-mlat/state"
+    # mlat-client was invoked.
+    [ -f "$arg_log" ]
+}
+
+@test "airplanes-mlat.sh writes state=disabled,reason=mlat_enabled_false when MLAT_ENABLED=false" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=false' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes-mlat/state"
+    [[ "$output" == *'MLAT DISABLED'* ]]
+    # mlat-client was NOT invoked.
+    [ ! -f "$arg_log" ]
+}
+
+@test "airplanes-mlat.sh: MLAT_ENABLED=false wins over LATITUDE=0 in reason priority" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=false' \
+        'LATITUDE=0' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh writes state=disabled,reason=latitude_zero when LATITUDE=0" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=0' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=latitude_zero' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh writes state=disabled,reason=longitude_zero when LONGITUDE=0" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=0' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'reason=longitude_zero' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh exits 64 with state=misconfigured when MLAT_USER empty + MLAT_ENABLED=true" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER=""' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 64 ]
+    grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=mlat_user_empty' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh runs without state-writer lib (defensive source falls through to stub)" {
+    # Don't install_state_writer_lib — daemon should still proceed.
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Daemon still invoked mlat-client; no state file because lib was missing.
+    [ -f "$arg_log" ]
+    [ ! -f "$root/run/airplanes-mlat/state" ]
+}
+
+@test "airplanes-feed.sh writes state=enabled,reason=ok with effective config" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/feed-args.log"
+    install_state_writer_lib "$root"
+    write_image_config "$root"
+    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$root/usr/bin/airplanes-feeder"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ -f "$root/run/airplanes-feed/state" ]
+    grep -qx 'schema_version=1' "$root/run/airplanes-feed/state"
+    grep -qx 'service=airplanes-feed' "$root/run/airplanes-feed/state"
+    grep -qx 'state=enabled' "$root/run/airplanes-feed/state"
+    grep -qx 'reason=ok' "$root/run/airplanes-feed/state"
+    grep -qx 'latitude=52.52000' "$root/run/airplanes-feed/state"
+    grep -qx 'longitude=13.40500' "$root/run/airplanes-feed/state"
+    grep -qx 'input=127.0.0.1:30005' "$root/run/airplanes-feed/state"
+    grep -q -- "feed_bin=$root/usr/bin/airplanes-feeder" "$root/run/airplanes-feed/state"
+}
+
 @test "runtime scripts prefer canonical feed.env over boot config when both exist" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/args.log"

--- a/test/test_state_writer.bats
+++ b/test/test_state_writer.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/lib/state-writer.sh. The writer is the
+# foundation for the daemon-owned runtime state-file pattern; bugs
+# here ripple into every consumer (apl-feed status, render-status,
+# webconfig).
+
+setup() {
+    LIB="$BATS_TEST_DIRNAME/../scripts/lib/state-writer.sh"
+    ROOT_DIR="$(mktemp -d)"
+    TARGET="$ROOT_DIR/state"
+    # shellcheck source=../scripts/lib/state-writer.sh
+    source "$LIB"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# --- Happy path ---
+
+@test "writes schema_version=1 as first line" {
+    airplanes_write_state "$TARGET" service=test
+    head -n 1 "$TARGET" | grep -qx 'schema_version=1'
+}
+
+@test "subsequent lines are KEY=VALUE in caller-provided order" {
+    airplanes_write_state "$TARGET" \
+        service=airplanes-mlat \
+        state=enabled \
+        reason=ok \
+        latitude=52.520
+    run cat "$TARGET"
+    [ "${lines[0]}" = 'schema_version=1' ]
+    [ "${lines[1]}" = 'service=airplanes-mlat' ]
+    [ "${lines[2]}" = 'state=enabled' ]
+    [ "${lines[3]}" = 'reason=ok' ]
+    [ "${lines[4]}" = 'latitude=52.520' ]
+}
+
+@test "empty value writes empty RHS" {
+    airplanes_write_state "$TARGET" mlat_user= state=disabled
+    grep -qx 'mlat_user=' "$TARGET"
+    grep -qx 'state=disabled' "$TARGET"
+}
+
+@test "value with internal spaces is preserved verbatim" {
+    airplanes_write_state "$TARGET" "input=127.0.0.1:30005 dump1090"
+    grep -qx 'input=127.0.0.1:30005 dump1090' "$TARGET"
+}
+
+@test "value with shell metacharacters is preserved verbatim (writer never quotes)" {
+    # readers parse by line, never source — these are safe in the file.
+    airplanes_write_state "$TARGET" 'feed_bin=/usr/bin/x$(`)"\;&|<>'
+    grep -qFx 'feed_bin=/usr/bin/x$(`)"\;&|<>' "$TARGET"
+}
+
+@test "mode of resulting file is 0644" {
+    airplanes_write_state "$TARGET" service=test
+    perms="$(stat -c '%a' "$TARGET" 2>/dev/null || stat -f '%Lp' "$TARGET")"
+    [ "$perms" = '644' ]
+}
+
+# --- Validation: target unchanged on every failure path ---
+
+@test "rejects value with newline; target unchanged" {
+    printf 'schema_version=1\nservice=previous\n' > "$TARGET"
+    chmod 0644 "$TARGET"
+    run airplanes_write_state "$TARGET" "input=foo
+bar"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'CR/LF'* ]]
+    grep -qx 'service=previous' "$TARGET"
+}
+
+@test "rejects value with carriage return; target unchanged" {
+    printf 'schema_version=1\nservice=previous\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" "input=foo"$'\r'"bar"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'CR/LF'* ]]
+    grep -qx 'service=previous' "$TARGET"
+}
+
+@test "rejects arg without =; target unchanged" {
+    printf 'schema_version=1\nservice=previous\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" 'no_equals_sign'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'not KEY=VALUE'* ]]
+    grep -qx 'service=previous' "$TARGET"
+}
+
+@test "rejects key starting with digit; target unchanged" {
+    printf 'schema_version=1\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" '1bad=value'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'invalid key'* ]]
+    [ "$(cat "$TARGET")" = 'schema_version=1' ]
+}
+
+@test "rejects key containing dash; target unchanged" {
+    printf 'schema_version=1\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" 'bad-key=value'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'invalid key'* ]]
+    [ "$(cat "$TARGET")" = 'schema_version=1' ]
+}
+
+@test "rejects empty key; target unchanged" {
+    printf 'schema_version=1\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" '=value'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'invalid key'* ]]
+}
+
+@test "rejects caller-supplied schema_version=1; target unchanged" {
+    printf 'schema_version=1\nservice=previous\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" schema_version=1
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'caller-supplied schema_version'* ]]
+    grep -qx 'service=previous' "$TARGET"
+}
+
+@test "rejects caller-supplied schema_version=2; target unchanged" {
+    printf 'schema_version=1\nservice=previous\n' > "$TARGET"
+    run airplanes_write_state "$TARGET" schema_version=2 service=test
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'caller-supplied schema_version'* ]]
+    grep -qx 'service=previous' "$TARGET"
+}
+
+# --- Filesystem error paths ---
+
+@test "fails when target's parent directory doesn't exist" {
+    run airplanes_write_state "$ROOT_DIR/nonexistent/state" service=test
+    [ "$status" -eq 1 ]
+}
+
+# --- Idempotence / overwrite ---
+
+@test "subsequent successful write replaces previous content" {
+    airplanes_write_state "$TARGET" service=first
+    airplanes_write_state "$TARGET" service=second
+    grep -qx 'service=second' "$TARGET"
+    ! grep -qx 'service=first' "$TARGET"
+}

--- a/test/test_update_manifest.bats
+++ b/test/test_update_manifest.bats
@@ -63,3 +63,37 @@ extract_manifest() {
     manifest="$(extract_manifest historical_top_level_scripts)"
     grep -Fxq "second-mlat.sh" <<<"$manifest"
 }
+
+@test "historical_daemon_libs manifest covers every currently shipped daemon-time lib" {
+    # Daemon-time libs (libs sourced by airplanes-feed.sh / airplanes-mlat.sh
+    # at runtime) are installed to $IPATH/lib and pruned via this manifest.
+    # NOT every scripts/lib/*.sh file is daemon-time — install-update-common,
+    # update-migrations, update-builds, claim-registration, service-account,
+    # and systemd-helpers are sourced ONLY by update.sh at update time, NOT
+    # by the daemons. This test asserts every lib that the daemons actually
+    # source (grep'd from the daemon scripts) is present in the manifest.
+    local manifest
+    manifest="$(extract_manifest historical_daemon_libs)"
+    [ -n "$manifest" ]
+    local daemon_lib_names
+    # Discover daemon-time libs by grepping the daemon scripts for source
+    # statements that reference $IPATH/lib/<name>.sh (or its airplanes_path
+    # equivalent /usr/local/share/airplanes/lib/<name>.sh).
+    daemon_lib_names="$(grep -hoE '/usr/local/share/airplanes/lib/[A-Za-z0-9_-]+\.sh' \
+        "$REPO_ROOT/scripts/airplanes-feed.sh" \
+        "$REPO_ROOT/scripts/airplanes-mlat.sh" \
+        2>/dev/null | sed 's|.*/||' | sort -u)"
+    [ -n "$daemon_lib_names" ]
+    while IFS= read -r name; do
+        if ! grep -Fxq "$name" <<<"$manifest"; then
+            echo "scripts/lib/$name is sourced by a daemon but missing from historical_daemon_libs in update.sh" >&2
+            return 1
+        fi
+    done <<<"$daemon_lib_names"
+}
+
+@test "historical_daemon_libs retains state-writer.sh" {
+    local manifest
+    manifest="$(extract_manifest historical_daemon_libs)"
+    grep -Fxq "state-writer.sh" <<<"$manifest"
+}

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -318,6 +318,14 @@ SH
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
     [ "$(grep -c 'systemctl daemon-reload' "$ROOT_DIR/commands.log")" = "1" ]
     grep -q 'target-at-restart=TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"' "$ROOT_DIR/commands.log"
+    # Lifecycle handover: even when MLAT is disabled by config, update.sh
+    # no longer disables/stops the unit — the daemon self-disables via
+    # sleep+exit. The state-file pattern depends on the daemon being
+    # invoked at all (so it can publish state=disabled, reason=...).
+    ! grep -q 'systemctl disable airplanes-mlat' "$ROOT_DIR/commands.log"
+    ! grep -q 'systemctl stop airplanes-mlat' "$ROOT_DIR/commands.log"
+    grep -q 'systemctl enable airplanes-mlat' "$ROOT_DIR/commands.log"
+    grep -q 'systemctl restart airplanes-mlat' "$ROOT_DIR/commands.log"
 }
 
 @test "update.sh build mode enables units without live systemd or per-device state" {

--- a/update.sh
+++ b/update.sh
@@ -378,6 +378,12 @@ cp "$GIT/uninstall.sh" "$IPATH"
 cp "$GIT"/scripts/*.sh "$IPATH"
 install -d -m 0755 "$IPATH/apl-feed"
 install -m 0644 "$GIT"/scripts/apl-feed/*.sh "$IPATH/apl-feed"
+install -d -m 0755 "$IPATH/lib"
+# Daemon-time runtime libs. Other scripts/lib/ files (install-update-common.sh,
+# update-migrations.sh, update-builds.sh, etc.) are sourced ONLY by update.sh
+# from $GIT/scripts/lib/ at update time and have no business at the daemon's
+# install path; copy selectively rather than wildcard.
+install -m 0644 "$GIT"/scripts/lib/state-writer.sh "$IPATH/lib"
 
 # Historical-ship manifests for the wildcard cp/install above. Each entry is
 # a script we have ever shipped to $IPATH (top-level) or $IPATH/apl-feed/.
@@ -404,10 +410,16 @@ historical_apl_feed_modules=(
     id.sh
     status.sh
 )
+historical_daemon_libs=(
+    state-writer.sh
+)
 
 prune_installed_script_artifacts "$IPATH" "$GIT/scripts" historical_top_level_scripts
 if [[ -d "$IPATH/apl-feed" ]]; then
     prune_installed_script_artifacts "$IPATH/apl-feed" "$GIT/scripts/apl-feed" historical_apl_feed_modules
+fi
+if [[ -d "$IPATH/lib" ]]; then
+    prune_installed_script_artifacts "$IPATH/lib" "$GIT/scripts/lib" historical_daemon_libs
 fi
 mkdir -p "$LOCAL_BIN"
 install -m 0755 "$GIT/scripts/apl-feed.sh" "$LOCAL_BIN/apl-feed"
@@ -477,15 +489,13 @@ elif is_unit_masked airplanes-mlat.service; then
     echo "--------------------"
     sleep 3
 else
-    if [[ "${MLAT_DISABLED}" == "1" ]]; then
-        systemctl disable airplanes-mlat || true
-        systemctl stop airplanes-mlat || true
-    else
-        # Enable airplanes-mlat service
-        systemctl enable airplanes-mlat >> "$LOGFILE" || true
-        # Start or restart airplanes-mlat service
-        systemctl restart airplanes-mlat || true
-    fi
+    # The daemon classifies disabled-by-config and self-disables via
+    # sleep+exit; systemd Restart=always re-runs it. This keeps the
+    # daemon-owned state-file pattern coherent: apl-feed status and the
+    # dashboards trust the daemon's published /run/airplanes-mlat/state
+    # rather than re-deriving the predicate from feed.env.
+    systemctl enable airplanes-mlat >> "$LOGFILE" || true
+    systemctl restart airplanes-mlat || true
 fi
 
 echo 70


### PR DESCRIPTION
Daemons publish their config decision to a runtime state file at every activation. New `scripts/lib/state-writer.sh` does the atomic write (schema_version=1, env-style, mktemp+rename). `airplanes-mlat.sh` classifies into `enabled`/`disabled`/`misconfigured` with MLAT_ENABLED checked before geo so an explicit disable wins over a 0/0-default reason. `airplanes-feed.sh` writes a single `enabled`/`ok` state with effective config. Defensive source in both daemons protects against a partial install. Unit files get `RuntimeDirectory` + `RuntimeDirectoryPreserve=restart` so the file survives Restart=always cycles.

`update.sh` no longer conditionally disables/stops `airplanes-mlat` on config-derived disable — the unit stays enabled at the systemd level always, and the daemon self-disables via sleep+exit. This keeps the daemon-owned state-file pattern coherent for future consumers; no reader needs to re-derive the predicate from `feed.env`. User-visible change: a feeder configured with `MLAT_ENABLED=false` now shows the unit as enabled+active(sleeping) instead of disabled+inactive.

No consumer reads the file yet; that lands in follow-up PRs against `dev`. The new daemon-time lib install path is guarded by a `historical_daemon_libs` manifest mirroring the existing prune pattern.
