### PR TITLE
apl-feed status MLAT path reads daemon runtime state file

### DIFF
--- a/scripts/airplanes-feed.service
+++ b/scripts/airplanes-feed.service
@@ -7,7 +7,7 @@ After=network.target airplanes-first-run.service
 [Service]
 User=airplanes-feed
 RuntimeDirectory=airplanes-feed
-RuntimeDirectoryPreserve=restart
+RuntimeDirectoryPreserve=yes
 ExecStart=/usr/local/share/airplanes/airplanes-feed.sh
 Type=simple
 Restart=always

--- a/scripts/airplanes-mlat.service
+++ b/scripts/airplanes-mlat.service
@@ -7,7 +7,7 @@ After=network.target airplanes-first-run.service
 [Service]
 User=airplanes-feed
 RuntimeDirectory=airplanes-mlat
-RuntimeDirectoryPreserve=restart
+RuntimeDirectoryPreserve=yes
 ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh
 Type=simple
 Restart=always

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# State reader. Defensive — if the lib is missing (mid-update transient),
+# fall back to a stub that always returns 1 so the MLAT path degrades to
+# systemd-only rendering. The path is BASH_SOURCE-relative so it
+# resolves identically in source tree (scripts/apl-feed/.. -> scripts/lib)
+# and production install (/usr/local/share/airplanes/apl-feed/.. ->
+# /usr/local/share/airplanes/lib).
+_status_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+_state_reader="$_status_dir/../lib/state-reader.sh"
+if [[ -r "$_state_reader" ]]; then
+    # shellcheck source=../lib/state-reader.sh
+    source "$_state_reader"
+else
+    airplanes_read_state() { return 1; }
+fi
+unset _status_dir _state_reader
+
 STATUS_OUTPUT_JSON=0
 STATUS_CHECKS_FILE=''
 STATUS_FAIL_COUNT=0
@@ -130,24 +146,133 @@ service_status_line() {
     status_line fail "$label" "not running"
 }
 
-mlat_disabled_by_config() {
-    # Mirror the disable conditions in airplanes-mlat.sh and update.sh:
-    #   MLAT_ENABLED=false, LATITUDE=0, or LONGITUDE=0
-    # Falls back to legacy USER=0|disable when feed.env hasn't been migrated
-    # yet (e.g. a daemon read between a legacy webconfig write and the next
-    # update.sh run).
-    local mlat_enabled latitude longitude user
-    mlat_enabled="$(feed_env_get MLAT_ENABLED || true)"
-    latitude="$(feed_env_get LATITUDE || true)"
-    longitude="$(feed_env_get LONGITUDE || true)"
-    user="$(feed_env_get USER || true)"
-    if [[ -z "$mlat_enabled" && -n "$user" ]]; then
-        case "$user" in
-            0|disable) mlat_enabled="false" ;;
-            *)         mlat_enabled="true" ;;
-        esac
+# _render_systemd_state <unit> <label> <active_state>
+# Renders status_line output for the not-active cases (failed, inactive,
+# deactivating, masked, unrecognized). Shared between mlat_status_line
+# and any future state-file consumer that needs the same fall-through.
+# Note: ActiveState=inactive can mean either user-stopped or masked;
+# masked units report ActiveState=inactive AND is-enabled=masked, so
+# we check is-enabled separately.
+_render_systemd_state() {
+    local unit="$1" label="$2" active_state="$3"
+    local enabled
+    enabled="$(systemctl is-enabled "$unit" 2>/dev/null || true)"
+    if [[ "$enabled" == "masked" ]]; then
+        status_line fail "$label" "masked"
+        return
     fi
-    [[ "$mlat_enabled" == "false" || "$latitude" == "0" || "$longitude" == "0" ]]
+    case "$active_state" in
+        failed)
+            local exit_code
+            exit_code="$(systemctl show --property=ExecMainStatus --value "$unit" 2>/dev/null || true)"
+            status_line fail "$label" "failed${exit_code:+ (exit $exit_code)}"
+            ;;
+        inactive|deactivating|'')
+            status_line fail "$label" "not running"
+            ;;
+        *)
+            status_line fail "$label" "not running ($active_state)"
+            ;;
+    esac
+}
+
+# mlat_status_line — replaces the old mlat_disabled_by_config + the
+# matching service_status_line call in feed_status. Reads the daemon's
+# published decision from /run/airplanes-mlat/state when the unit is
+# active or transitioning; falls through to systemd-derived rendering
+# otherwise. Special-cases failed-with-exit-64 (the strict misconfig
+# fail from airplanes-mlat.sh) to surface the MLAT_USER-empty actionable
+# message via the state file's reason key.
+mlat_status_line() {
+    local label="MLAT service"
+    local unit="airplanes-mlat.service"
+    if ! command -v systemctl >/dev/null 2>&1; then
+        status_line warn "$label" "systemctl unavailable"
+        return
+    fi
+    local active_state
+    active_state="$(systemctl show --property=ActiveState --value "$unit" 2>/dev/null || true)"
+    local state_file
+    state_file="$(root_path /run/airplanes-mlat/state)"
+
+    case "$active_state" in
+        active|activating|reloading)
+            local decision reason
+            if decision="$(airplanes_read_state "$state_file" state)" \
+                && reason="$(airplanes_read_state "$state_file" reason)"; then
+                _render_mlat_decision "$active_state" "$decision" "$reason"
+                return
+            fi
+            # State file unavailable / unparseable. Daemon is alive but
+            # we can't tell what it decided.
+            if [[ "$active_state" == "active" ]]; then
+                status_line ok "$label" "running"
+            else
+                status_line warn "$label" "starting up ($active_state)"
+            fi
+            ;;
+        failed)
+            local exit_code
+            exit_code="$(systemctl show --property=ExecMainStatus --value "$unit" 2>/dev/null || true)"
+            if [[ "$exit_code" == "64" ]]; then
+                # Strict misconfig fail. State file persists across the
+                # failed terminal state via RuntimeDirectoryPreserve=yes;
+                # surface its reason as the actionable cause.
+                local reason
+                if reason="$(airplanes_read_state "$state_file" reason)" && [[ -n "$reason" ]]; then
+                    _render_mlat_misconfig_reason "$reason"
+                    return
+                fi
+                status_line fail "$label" "failed (exit 64; check feed.env MLAT config)"
+                return
+            fi
+            _render_systemd_state "$unit" "$label" "$active_state"
+            ;;
+        *)
+            _render_systemd_state "$unit" "$label" "$active_state"
+            ;;
+    esac
+}
+
+_render_mlat_decision() {
+    local active_state="$1" decision="$2" reason="$3"
+    local label="MLAT service"
+    case "$decision" in
+        enabled)
+            if [[ "$active_state" == "active" ]]; then
+                status_line ok "$label" "running"
+            else
+                status_line warn "$label" "starting up ($active_state)"
+            fi
+            ;;
+        disabled)
+            local detail
+            case "$reason" in
+                mlat_enabled_false) detail="disabled by config (MLAT_ENABLED=false)" ;;
+                latitude_zero)      detail="disabled by config (LATITUDE=0)" ;;
+                longitude_zero)     detail="disabled by config (LONGITUDE=0)" ;;
+                *)                  detail="disabled by config ($reason)" ;;
+            esac
+            status_line ok "$label" "$detail"
+            ;;
+        misconfigured)
+            _render_mlat_misconfig_reason "$reason"
+            ;;
+        *)
+            # Forward-compat: an unknown decision token from a future
+            # schema would surface as a warn rather than a crash.
+            status_line warn "$label" "decision: $decision ($reason)"
+            ;;
+    esac
+}
+
+_render_mlat_misconfig_reason() {
+    local reason="$1"
+    local label="MLAT service"
+    case "$reason" in
+        mlat_user_empty) status_line fail "$label" "MLAT_USER is empty (set MLAT_USER, or set MLAT_ENABLED=false)" ;;
+        *)               status_line fail "$label" "misconfigured ($reason)" ;;
+    esac
 }
 
 receiver_status_line() {
@@ -330,11 +455,7 @@ feed_status() {
         echo
     fi
     service_status_line airplanes-feed "Feed service"
-    if mlat_disabled_by_config; then
-        status_line ok "MLAT service" "disabled by config"
-    else
-        service_status_line airplanes-mlat "MLAT service"
-    fi
+    mlat_status_line
     receiver_status_line
     airplanes_link_status_line
     claim_registration_status_line

--- a/scripts/lib/state-reader.sh
+++ b/scripts/lib/state-reader.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Runtime state reader. Consumers (apl-feed status, render-status, the
+# webconfig snapshot endpoint) call airplanes_read_state to extract a
+# single key from a state file written by airplanes_write_state.
+#
+# Format: see scripts/lib/state-writer.sh. schema_version=1 must be
+# present on the first line; other versions return 1 (caller treats
+# as "decision unknown").
+#
+# Reader MUST NOT `source` the file — values are unquoted and may
+# contain shell metacharacters. Parse line-by-line.
+#
+# Usage:
+#   if reason="$(airplanes_read_state /run/airplanes-mlat/state reason)"; then
+#       printf 'reason=%s\n' "$reason"
+#   else
+#       printf 'state file unavailable or unparseable\n'
+#   fi
+#
+# Returns 0 with the value on stdout if the key is present.
+# Returns 1 (no stdout) if:
+#   - file doesn't exist or isn't a regular file
+#   - file is unreadable
+#   - schema_version != 1 on the first line
+#   - key not found in file
+#   - value contains \r (corrupt file — writer never emits CR)
+#   - key arg doesn't match the writer's key constraint
+#     ([A-Za-z_][A-Za-z0-9_]*)
+
+airplanes_read_state() {
+    local file="$1"
+    local key="$2"
+    [[ -f "$file" && -r "$file" ]] || return 1
+    if ! [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        return 1
+    fi
+    local first=1 line value
+    # Single-pass: one open, validate schema on first line, then scan.
+    # Avoids generation-mix if a writer renames the file between two
+    # opens. Caller still trusts the writer's mktemp+rename atomicity.
+    while IFS= read -r line; do
+        if (( first )); then
+            first=0
+            [[ "$line" == 'schema_version=1' ]] || return 1
+            continue
+        fi
+        case "$line" in
+            "${key}="*)
+                value="${line#"${key}="}"
+                case "$value" in
+                    *$'\r'*) return 1 ;;
+                esac
+                printf '%s' "$value"
+                return 0
+                ;;
+        esac
+    done < "$file"
+    return 1
+}

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -17,6 +17,8 @@ setup() {
     cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
+    "show --property=ActiveState --value "*) printf 'active\n'; exit 0 ;;
+    "show --property=ExecMainStatus --value "*) printf '0\n'; exit 0 ;;
     "is-active --quiet "*) exit 0 ;;
     "is-enabled "*) echo "enabled"; exit 0 ;;
 esac

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -219,78 +219,209 @@ STUB
     [[ "$output" == *'not running'* ]]
 }
 
-# --- mlat_disabled_by_config ---
+# --- mlat_status_line: state-file-driven (replaces old mlat_disabled_by_config) ---
 
-@test "mlat_disabled_by_config: USER=0 returns 0" {
-    printf 'USER="0"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
+# Helper: write a state file under the test root for the MLAT daemon.
+write_mlat_state() {
+    # write_mlat_state <decision> <reason>
+    local decision="$1"
+    local reason="$2"
+    mkdir -p "$ROOT_DIR/run/airplanes-mlat"
+    {
+        printf 'schema_version=1\n'
+        printf 'service=airplanes-mlat\n'
+        printf 'state=%s\n' "$decision"
+        printf 'reason=%s\n' "$reason"
+    } > "$ROOT_DIR/run/airplanes-mlat/state"
+}
+
+# Helper: stub systemctl to return a chosen ActiveState / ExecMainStatus /
+# is-enabled. Real call shapes:
+#   systemctl show --property=ActiveState --value <unit>     (4 args)
+#   systemctl show --property=ExecMainStatus --value <unit>  (4 args)
+#   systemctl is-enabled <unit>                              (2 args)
+#   systemctl is-active --quiet <unit>                       (3 args)
+stub_systemctl_active_state() {
+    local active_state="$1"
+    local exec_main_status="${2:-0}"
+    local is_enabled_value="${3:-enabled}"
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+case "\$1 \$2 \$3" in
+    "show --property=ActiveState --value") shift 3; printf '%s\n' '$active_state'; exit 0 ;;
+    "show --property=ExecMainStatus --value") shift 3; printf '%s\n' '$exec_main_status'; exit 0 ;;
+esac
+case "\$1" in
+    is-enabled) shift; printf '%s\n' '$is_enabled_value'; exit 0 ;;
+    is-active) [[ '$active_state' == 'active' ]] && exit 0 || exit 3 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+}
+
+@test "mlat_status_line: ActiveState=active + decision=enabled → OK running" {
+    write_mlat_state enabled ok
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'running'* ]]
+}
+
+@test "mlat_status_line: ActiveState=active + disabled mlat_enabled_false → 'disabled by config (MLAT_ENABLED=false)'" {
+    write_mlat_state disabled mlat_enabled_false
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
+}
+
+@test "mlat_status_line: ActiveState=active + disabled latitude_zero → 'disabled by config (LATITUDE=0)'" {
+    write_mlat_state disabled latitude_zero
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'disabled by config (LATITUDE=0)'* ]]
+}
+
+@test "mlat_status_line: ActiveState=active + disabled longitude_zero → 'disabled by config (LONGITUDE=0)'" {
+    write_mlat_state disabled longitude_zero
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'disabled by config (LONGITUDE=0)'* ]]
+}
+
+@test "mlat_status_line: ActiveState=active + misconfigured mlat_user_empty → FIX with actionable message" {
+    write_mlat_state misconfigured mlat_user_empty
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'MLAT_USER is empty'* ]]
+    [[ "$output" == *'set MLAT_ENABLED=false'* ]]
+}
+
+@test "mlat_status_line: ActiveState=activating + enabled → 'starting up'" {
+    write_mlat_state enabled ok
+    stub_systemctl_active_state activating
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'starting up (activating)'* ]]
+}
+
+# Load-bearing case: misconfig surface is visible continuously across the
+# Restart=always cycle, not just during the microsecond active window.
+@test "mlat_status_line: ActiveState=activating + misconfigured → still surfaces the actionable message" {
+    write_mlat_state misconfigured mlat_user_empty
+    stub_systemctl_active_state activating
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'MLAT_USER is empty'* ]]
+}
+
+@test "mlat_status_line: ActiveState=failed + exit 64 + state file present → surfaces misconfig reason" {
+    write_mlat_state misconfigured mlat_user_empty
+    stub_systemctl_active_state failed 64
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'MLAT_USER is empty'* ]]
+}
+
+@test "mlat_status_line: ActiveState=failed + exit 64 + no state file → generic 'check feed.env MLAT config'" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state failed 64
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'failed (exit 64'* ]]
+}
+
+@test "mlat_status_line: ActiveState=failed + exit other → 'failed (exit X)'" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state failed 1
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'failed (exit 1)'* ]]
+}
+
+@test "mlat_status_line: ActiveState=inactive + is-enabled=enabled → 'not running'" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state inactive 0 enabled
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'not running'* ]]
+}
+
+@test "mlat_status_line: ActiveState=inactive + is-enabled=masked → 'masked'" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state inactive 0 masked
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'masked'* ]]
+}
+
+@test "mlat_status_line: ActiveState=deactivating → 'not running'" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state deactivating
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'not running'* ]]
+}
+
+@test "mlat_status_line: ActiveState=active + no state file → degraded 'running' fallback" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'running'* ]]
+}
+
+@test "mlat_status_line: ActiveState=activating + no state file → 'starting up'" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    stub_systemctl_active_state activating
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'starting up (activating)'* ]]
+}
+
+# --root integration: catches source-time vs runtime path mismatches that
+# unit-testing mlat_status_line in isolation doesn't.
+@test "mlat_status_line --root: reads state file under the redirected root" {
+    write_mlat_state disabled mlat_enabled_false
+    stub_systemctl_active_state active
+    # ROOT was set in setup() to $ROOT_DIR; verify the function honors it.
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
     [ "$status" -eq 0 ]
-}
-
-@test "mlat_disabled_by_config: LATITUDE=0 returns 0" {
-    printf 'USER="me"\nLATITUDE="0"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 0 ]
-}
-
-@test "mlat_disabled_by_config: LONGITUDE=0 returns 0" {
-    printf 'USER="me"\nLATITUDE="52"\nLONGITUDE="0"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 0 ]
-}
-
-@test "mlat_disabled_by_config: USER=disable returns 0 (matches runtime daemon)" {
-    printf 'USER="disable"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 0 ]
-}
-
-# `changeme` is the template default for an unconfigured feeder.
-# Neither airplanes-mlat.sh nor update.sh recognize it as an explicit
-# disable signal — they only honor USER=0 / USER=disable. This helper
-# matches that.
-@test "mlat_disabled_by_config: USER=changeme does NOT trigger" {
-    printf 'USER="changeme"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 1 ]
-}
-
-@test "mlat_disabled_by_config: configured location returns 1" {
-    printf 'USER="me"\nLATITUDE="52"\nLONGITUDE="13"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 1 ]
-}
-
-# --- New schema: MLAT_ENABLED-driven ---
-
-@test "mlat_disabled_by_config: MLAT_ENABLED=false returns 0" {
-    printf 'MLAT_USER="alice"\nMLAT_ENABLED=false\nLATITUDE="52"\nLONGITUDE="13"\n' \
-        > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 0 ]
-}
-
-@test "mlat_disabled_by_config: MLAT_ENABLED=true with valid location returns 1" {
-    printf 'MLAT_USER="alice"\nMLAT_ENABLED=true\nLATITUDE="52"\nLONGITUDE="13"\n' \
-        > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 1 ]
-}
-
-@test "mlat_disabled_by_config: MLAT_ENABLED wins over orphan USER=0" {
-    # Legacy webconfig might write USER=0 via the symlink; the migrated
-    # schema should win until the next update.sh sweeps the orphan.
-    printf 'MLAT_USER="alice"\nMLAT_ENABLED=true\nUSER="0"\nLATITUDE="52"\nLONGITUDE="13"\n' \
-        > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 1 ]
-}
-
-@test "mlat_disabled_by_config: MLAT_ENABLED=true with LATITUDE=0 still triggers" {
-    printf 'MLAT_USER="alice"\nMLAT_ENABLED=true\nLATITUDE="0"\nLONGITUDE="13"\n' \
-        > "$ROOT_DIR/etc/airplanes/feed.env"
-    run mlat_disabled_by_config
-    [ "$status" -eq 0 ]
+    [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
 }
 
 # --- receiver_status_line ---

--- a/test/test_state_reader.bats
+++ b/test/test_state_reader.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/lib/state-reader.sh. The reader is the foundation
+# for daemon-state-driven status display; bugs here ripple into every
+# consumer (apl-feed status, render-status, webconfig snapshot endpoint).
+
+setup() {
+    READER_LIB="$BATS_TEST_DIRNAME/../scripts/lib/state-reader.sh"
+    WRITER_LIB="$BATS_TEST_DIRNAME/../scripts/lib/state-writer.sh"
+    ROOT_DIR="$(mktemp -d)"
+    TARGET="$ROOT_DIR/state"
+    # shellcheck source=../scripts/lib/state-reader.sh
+    source "$READER_LIB"
+    # shellcheck source=../scripts/lib/state-writer.sh
+    source "$WRITER_LIB"
+}
+
+teardown() {
+    chmod -R u+rwX "$ROOT_DIR" 2>/dev/null || true
+    rm -rf "$ROOT_DIR"
+}
+
+valid_state_file() {
+    cat > "$1" <<'EOF'
+schema_version=1
+service=airplanes-mlat
+state=disabled
+reason=mlat_enabled_false
+mlat_user=
+mlat_enabled=false
+latitude=52.520
+longitude=13.405
+EOF
+}
+
+# --- Happy path ---
+
+@test "reads existing key and returns its value" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" reason
+    [ "$status" -eq 0 ]
+    [ "$output" = 'mlat_enabled_false' ]
+}
+
+@test "reads first matching key (single-pass scan)" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" service
+    [ "$status" -eq 0 ]
+    [ "$output" = 'airplanes-mlat' ]
+}
+
+@test "reads empty value as empty string" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" mlat_user
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "reads value containing internal spaces verbatim" {
+    cat > "$TARGET" <<'EOF'
+schema_version=1
+input=127.0.0.1:30005 dump1090
+EOF
+    run airplanes_read_state "$TARGET" input
+    [ "$status" -eq 0 ]
+    [ "$output" = '127.0.0.1:30005 dump1090' ]
+}
+
+@test "reads value containing shell metacharacters verbatim (reader never sources)" {
+    # writer would emit the literal `$(...)` string; reader returns it as data.
+    cat > "$TARGET" <<'EOF'
+schema_version=1
+feed_bin=/usr/bin/x$(`)"\;&|<>
+EOF
+    run airplanes_read_state "$TARGET" feed_bin
+    [ "$status" -eq 0 ]
+    [ "$output" = '/usr/bin/x$(`)"\;&|<>' ]
+}
+
+# --- Failure paths: every error path returns 1 with no stdout ---
+
+@test "returns 1 for non-existent file" {
+    run airplanes_read_state "$ROOT_DIR/missing" reason
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for unreadable file" {
+    valid_state_file "$TARGET"
+    chmod 000 "$TARGET"
+    run airplanes_read_state "$TARGET" reason
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+    chmod 0644 "$TARGET"   # restore for teardown
+}
+
+@test "returns 1 for a directory at the path (rejects non-regular files)" {
+    mkdir -p "$ROOT_DIR/dir-instead-of-file"
+    run airplanes_read_state "$ROOT_DIR/dir-instead-of-file" reason
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for missing schema_version line" {
+    cat > "$TARGET" <<'EOF'
+service=airplanes-mlat
+reason=mlat_enabled_false
+EOF
+    run airplanes_read_state "$TARGET" reason
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for unknown schema_version=2" {
+    cat > "$TARGET" <<'EOF'
+schema_version=2
+reason=future_thing
+EOF
+    run airplanes_read_state "$TARGET" reason
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for key not found" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" nope
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 when value contains CR (corrupt file)" {
+    printf 'schema_version=1\nreason=foo\r\n' > "$TARGET"
+    run airplanes_read_state "$TARGET" reason
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for invalid key arg (shell metacharacter)" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" 'reason; rm -rf /'
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for empty key arg" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" ''
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "returns 1 for key starting with digit" {
+    valid_state_file "$TARGET"
+    run airplanes_read_state "$TARGET" '1bad'
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+# --- Round-trip with state-writer ---
+
+@test "round-trip: write then read recovers each key in order" {
+    airplanes_write_state "$TARGET" \
+        service=airplanes-mlat \
+        state=disabled \
+        reason=mlat_enabled_false \
+        mlat_user= \
+        mlat_enabled=false
+    [ "$(airplanes_read_state "$TARGET" service)" = 'airplanes-mlat' ]
+    [ "$(airplanes_read_state "$TARGET" state)" = 'disabled' ]
+    [ "$(airplanes_read_state "$TARGET" reason)" = 'mlat_enabled_false' ]
+    run airplanes_read_state "$TARGET" mlat_user
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ "$(airplanes_read_state "$TARGET" mlat_enabled)" = 'false' ]
+}
+
+@test "schema_version is validation-only, not retrievable as a key" {
+    # The first line is consumed by the schema check; readers don't
+    # need to retrieve schema_version (it's always 1 per the contract).
+    # Document this explicitly: schema_version returns 1 (not found)
+    # even though it's syntactically present, because it's special.
+    airplanes_write_state "$TARGET" service=test
+    run airplanes_read_state "$TARGET" schema_version
+    [ "$status" -eq 1 ]
+}
+
+@test "round-trip: shell-metacharacter values survive write+read" {
+    airplanes_write_state "$TARGET" 'feed_bin=/usr/bin/x$(`)"\;&|<>'
+    [ "$(airplanes_read_state "$TARGET" feed_bin)" = '/usr/bin/x$(`)"\;&|<>' ]
+}
+
+# --- Non-root readability (sentinel against future writer tightening) ---
+
+@test "non-root user can read state files written by non-root user (mode 0644)" {
+    # The bats test process runs as a non-root user. The writer chmods
+    # to 0644 (per state-writer.sh). Confirm the same user can read
+    # what was just written. Guards against any future regression that
+    # tightens permissions and accidentally locks out apl-feed-as-user.
+    airplanes_write_state "$TARGET" service=test state=enabled reason=ok
+    perms="$(stat -c '%a' "$TARGET" 2>/dev/null || stat -f '%Lp' "$TARGET")"
+    [ "$perms" = '644' ]
+    [ "$(airplanes_read_state "$TARGET" reason)" = 'ok' ]
+}

--- a/test/test_update_manifest.bats
+++ b/test/test_update_manifest.bats
@@ -97,3 +97,9 @@ extract_manifest() {
     manifest="$(extract_manifest historical_daemon_libs)"
     grep -Fxq "state-writer.sh" <<<"$manifest"
 }
+
+@test "historical_daemon_libs retains state-reader.sh" {
+    local manifest
+    manifest="$(extract_manifest historical_daemon_libs)"
+    grep -Fxq "state-reader.sh" <<<"$manifest"
+}

--- a/update.sh
+++ b/update.sh
@@ -379,11 +379,13 @@ cp "$GIT"/scripts/*.sh "$IPATH"
 install -d -m 0755 "$IPATH/apl-feed"
 install -m 0644 "$GIT"/scripts/apl-feed/*.sh "$IPATH/apl-feed"
 install -d -m 0755 "$IPATH/lib"
-# Daemon-time runtime libs. Other scripts/lib/ files (install-update-common.sh,
-# update-migrations.sh, update-builds.sh, etc.) are sourced ONLY by update.sh
-# from $GIT/scripts/lib/ at update time and have no business at the daemon's
-# install path; copy selectively rather than wildcard.
+# Runtime libs: sourced at runtime by daemons (state-writer) and CLI tools
+# like apl-feed status (state-reader). Distinct from update-time-only libs
+# (install-update-common.sh, update-migrations.sh, update-builds.sh, etc.)
+# which are sourced ONLY by update.sh from $GIT/scripts/lib/ at update time
+# and are NOT installed at $IPATH; copy selectively rather than wildcard.
 install -m 0644 "$GIT"/scripts/lib/state-writer.sh "$IPATH/lib"
+install -m 0644 "$GIT"/scripts/lib/state-reader.sh "$IPATH/lib"
 
 # Historical-ship manifests for the wildcard cp/install above. Each entry is
 # a script we have ever shipped to $IPATH (top-level) or $IPATH/apl-feed/.
@@ -411,6 +413,7 @@ historical_apl_feed_modules=(
     status.sh
 )
 historical_daemon_libs=(
+    state-reader.sh
     state-writer.sh
 )
 


### PR DESCRIPTION
New `scripts/lib/state-reader.sh` symmetric with state-writer: single-pass parse, validates `schema_version=1`, rejects non-regular files. `apl-feed/status.sh` retires `mlat_disabled_by_config` and adds `mlat_status_line` driven by the daemon's published state file. The MLAT predicate duplication on the CLI side is fully retired.

When `MLAT_USER` is empty + `MLAT_ENABLED=true` (the strict-fail case at exit 64), the dashboard now surfaces "MLAT_USER is empty (set MLAT_USER, or set MLAT_ENABLED=false)" rather than a generic "not running." The misconfig surface persists across the failed terminal state via `RuntimeDirectoryPreserve=yes` — folded in as a PR 1 amendment because the misconfig surface depends on the state file outliving the daemon's exit 64.

Reader policy: state file is consulted when systemctl `ActiveState` is `active`, `activating`, or `reloading`. Inactive/failed/masked render systemd-derived "not running" with last-exit reason. A shared `_render_systemd_state` helper handles the failed/inactive/masked rendering for both feed and mlat. The source path for state-reader.sh is BASH_SOURCE-relative so it resolves identically in source tree and production install.

Feed-side state file consumption is deferred to follow-up PRs.
