### PR TITLE
feat(mlat)!: finish MLAT_USER/MLAT_ENABLED migration

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -34,8 +34,15 @@ renice 10 $$ &>/dev/null || true
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/install-update-common.sh
 source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
+# shellcheck source=scripts/lib/configure-validators.sh
+source "$SCRIPT_DIR/scripts/lib/configure-validators.sh"
 airplanes_enable_build_mode_from_args "$@"
 airplanes_init_paths
+
+# Fallback name used when the operator doesn't supply one (empty or unset
+# AIRPLANES_MLAT_USER, or blank input in the interactive prompt). Multiple
+# feeders sharing this name on the MLAT map is the expected outcome.
+DEFAULT_MLAT_NAME="Anonymous"
 
 function abort() {
     echo ------------
@@ -49,35 +56,6 @@ function abort() {
 
 BACKTITLETEXT="airplanes.live Setup Script"
 
-sanitize_mlat_user() {
-    printf '%s' "$1" | tr -c '[a-zA-Z0-9]_\- ' '_'
-}
-
-valid_latitude() {
-    [[ "$1" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]] \
-        && awk -v LAT="$1" 'BEGIN { exit !(LAT < 90 && LAT > -90) }'
-}
-
-valid_longitude() {
-    [[ "$1" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]] \
-        && awk -v LON="$1" 'BEGIN { exit !(LON < 180 && LON > -180) }'
-}
-
-valid_altitude() {
-    [[ "$1" =~ ^-?[0-9]+(ft|m)?$ ]]
-}
-
-normalize_altitude() {
-    local alt="$1"
-    if [[ $alt =~ ^-([0-9]+)ft$ ]]; then
-        awk -v NUM="${BASH_REMATCH[1]}" 'BEGIN { printf "-%0.2f", NUM / 3.28 }'
-    elif [[ $alt =~ ^-([0-9]+)m$ ]]; then
-        printf -- '-%s' "${BASH_REMATCH[1]}"
-    else
-        printf '%s' "$alt"
-    fi
-}
-
 detect_receiver_input() {
     INPUT="127.0.0.1:30005"
     INPUT_TYPE="dump1090"
@@ -90,22 +68,17 @@ detect_receiver_input() {
     fi
 }
 
-# Derive MLAT_USER and MLAT_ENABLED from $NOSPACENAME (the sanitized
-# user-supplied feeder name, or one of the legacy disable sentinels). The
-# sentinel-based disable UX is preserved for interactive users — entering
-# "0" or "disable" turns MLAT off — while the on-disk schema is the new
-# explicit shape.
+# Derive MLAT_USER from the sanitized user-supplied feeder name. Empty
+# input falls back to DEFAULT_MLAT_NAME. This function does not set
+# MLAT_ENABLED — that's the caller's job (set explicitly from
+# AIRPLANES_MLAT_ENABLED in non-interactive mode, defaulted to "true"
+# in the interactive flow).
 derive_mlat_keys() {
-    case "$NOSPACENAME" in
-        0|disable)
-            MLAT_USER=""
-            MLAT_ENABLED="false"
-            ;;
-        *)
-            MLAT_USER="$NOSPACENAME"
-            MLAT_ENABLED="true"
-            ;;
-    esac
+    if [[ -z "$NOSPACENAME" ]]; then
+        MLAT_USER="$DEFAULT_MLAT_NAME"
+    else
+        MLAT_USER="$NOSPACENAME"
+    fi
 }
 
 write_feed_env() {
@@ -146,12 +119,13 @@ EOF
 }
 
 has_noninteractive_config_env() {
-    [[ -v AIRPLANES_MLAT_USER || -v AIRPLANES_LATITUDE || -v AIRPLANES_LONGITUDE || -v AIRPLANES_ALTITUDE ]]
+    [[ -v AIRPLANES_MLAT_USER || -v AIRPLANES_MLAT_ENABLED \
+       || -v AIRPLANES_LATITUDE || -v AIRPLANES_LONGITUDE || -v AIRPLANES_ALTITUDE ]]
 }
 
 configure_noninteractive() {
     local missing=0 name
-    for name in AIRPLANES_MLAT_USER AIRPLANES_LATITUDE AIRPLANES_LONGITUDE AIRPLANES_ALTITUDE; do
+    for name in AIRPLANES_LATITUDE AIRPLANES_LONGITUDE AIRPLANES_ALTITUDE; do
         if [[ ! -v "$name" ]]; then
             echo "Missing required non-interactive configure value: $name" >&2
             missing=1
@@ -159,8 +133,22 @@ configure_noninteractive() {
     done
     [[ "$missing" == "0" ]] || exit 1
 
-    ADSBFIUSERNAME="$AIRPLANES_MLAT_USER"
+    # MLAT_USER is optional. Empty / unset falls back to DEFAULT_MLAT_NAME
+    # via derive_mlat_keys (which write_feed_env calls).
+    ADSBFIUSERNAME="${AIRPLANES_MLAT_USER:-}"
     NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
+
+    # MLAT_ENABLED is optional and defaults to "true". Only "true" or
+    # "false" are accepted; silently coercing other values would mask
+    # operator typos.
+    case "${AIRPLANES_MLAT_ENABLED:-true}" in
+        true|false) MLAT_ENABLED="${AIRPLANES_MLAT_ENABLED:-true}" ;;
+        *)
+            echo "AIRPLANES_MLAT_ENABLED must be 'true' or 'false' (got: '${AIRPLANES_MLAT_ENABLED:-}')" >&2
+            exit 1
+            ;;
+    esac
+
     RECEIVERLATITUDE="$AIRPLANES_LATITUDE"
     RECEIVERLONGITUDE="$AIRPLANES_LONGITUDE"
     ALT="$AIRPLANES_ALTITUDE"
@@ -181,20 +169,14 @@ fi
 
 whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "Thanks for choosing to share your data with airplanes.live!\n\nairplanes.live is a co-op of ADS-B/Mode S/MLAT feeders from around the world. This script will configure your current ADS-B receiver to feed data to airplanes.live.\n\nWould you like to continue setup?" 13 78 || abort
 
-ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy)\n\nExample: \"william34-london\", \"william34-jersey\", etc.\nDisable MLAT: enter a zero: 0" 12 78 3>&1 1>&2 2>&3) || abort
+ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy).\n\nExample: \"william34-london\", \"william34-jersey\", etc.\n\nLeave blank to use the default name \"$DEFAULT_MLAT_NAME\".\n\n(To disable MLAT after setup, run: sudo apl-feed mlat disable)" 14 78 3>&1 1>&2 2>&3) || abort
 
 NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
 
-if [[ "$NOSPACENAME" != 0 ]]; then
-    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
-        --msgbox "For MLAT the precise location of your antenna is required.\
-        \n\nA small error of 15m/45ft will cause issues with MLAT!\
-        \n\nTo get your location, use any online map service or this website: https://www.mapcoordinates.net/en" 12 78 || abort
-else
-    whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
-        --msgbox "MLAT DISABLED!.\
-        \n\n For some local functions the approximate location is still useful, it won't be sent to the server." 12 78 || abort
-fi
+whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" \
+    --msgbox "For MLAT the precise location of your antenna is required.\
+    \n\nA small error of 15m/45ft will cause issues with MLAT!\
+    \n\nTo get your location, use any online map service or this website: https://www.mapcoordinates.net/en" 12 78 || abort
 
 #((-90 <= RECEIVERLATITUDE <= 90))
 LAT_OK=0
@@ -226,7 +208,7 @@ until [ "$LON_OK" -eq 1 ]; do
 done
 
 ALT=0
-until [[ "$NOSPACENAME" == 0 ]] || [[ $ALT =~ ^-?[0-9]+ft$ ]] || [[ $ALT =~ ^-?[0-9]+m$ ]]; do
+until [[ $ALT =~ ^-?[0-9]+ft$ ]] || [[ $ALT =~ ^-?[0-9]+m$ ]]; do
     ALT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Altitude above sea level (at the antenna):" \
         --nocancel --inputbox \
 "\nEnter the altitude of your antenna, above sea level, including the unit with no spaces:\n\n\
@@ -241,6 +223,9 @@ RECEIVERALTITUDE="$ALT"
 
 #RECEIVERPORT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Receiver Feed Port" --nocancel --inputbox "\nChange only if you were assigned a custom feed port.\nFor most all users it is required this port remain set to port 30005." 10 78 "30005" 3>&1 1>&2 2>&3)
 
+# Interactive setup always enables MLAT. Operators who want it off run
+# `sudo apl-feed mlat disable` after setup completes.
+MLAT_ENABLED="true"
 
 detect_receiver_input
 write_feed_env

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -37,10 +37,8 @@ fi
 #
 # Test "set vs unset" rather than "non-empty" — an explicit MLAT_USER=""
 # written by a future-aware writer is respected as "user opted in but left
-# the name blank" and triggers the strict-fail below. The `${VAR+x}` form
-# is portable to bash 3.2 (macOS); `[[ -v VAR ]]` would be cleaner but
-# is bash 4+.
-if [[ -z "${MLAT_USER+x}" && -z "${MLAT_ENABLED+x}" && -n "${USER+x}" ]]; then
+# the name blank" and triggers the strict-fail below.
+if [[ ! -v MLAT_USER && ! -v MLAT_ENABLED && -v USER ]]; then
     case "$USER" in
         0|disable)
             MLAT_USER=""

--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -27,6 +27,8 @@ source "$APL_FEED_LIB_DIR/id.sh"
 source "$APL_FEED_LIB_DIR/status.sh"
 # shellcheck source=scripts/apl-feed/backup.sh
 source "$APL_FEED_LIB_DIR/backup.sh"
+# shellcheck source=scripts/apl-feed/mlat.sh
+source "$APL_FEED_LIB_DIR/mlat.sh"
 
 main() {
     local cmd="${1:-}"
@@ -50,6 +52,10 @@ main() {
         restore)
             shift
             config_restore "$@"
+            ;;
+        mlat)
+            shift
+            dispatch_mlat "$@"
             ;;
         -h|--help|'')
             usage

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -35,6 +35,8 @@ Usage:
   apl-feed claim rotate --abort
   apl-feed claim set [--force]
   apl-feed id set [--force]
+  apl-feed mlat enable
+  apl-feed mlat disable
   apl-feed backup <file>
   apl-feed restore <file>
   apl-feed restore --check <file>

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# MLAT enable/disable management. Operator-facing alternative to editing
+# /etc/airplanes/feed.env by hand.
+#
+# The on-disk schema (since commit 2851612) treats MLAT_USER as a name and
+# MLAT_ENABLED as the state flag. These commands flip MLAT_ENABLED while
+# preserving MLAT_USER, so a disable→enable round-trip restores the
+# operator's previously-configured name.
+#
+# Empty MLAT_USER is filled in with "Anonymous" on enable so the runtime
+# (which strict-fails empty MLAT_USER + MLAT_ENABLED=true) never trips on
+# a name that was never set in non-interactive setup.
+
+DEFAULT_MLAT_NAME="Anonymous"
+
+# Skip the systemctl restart when running against a non-host filesystem
+# (--root /mnt/...) or under AIRPLANES_BUILD_MODE=1 (image build-time
+# invocation, no live systemd to talk to). File edits still happen.
+_mlat_should_skip_restart() {
+    if [[ "$ROOT" != "/" ]]; then
+        echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+        return 0
+    fi
+    case "${AIRPLANES_BUILD_MODE:-}" in
+        1|true|yes)
+            echo "Skipping service restart (AIRPLANES_BUILD_MODE set)" >&2
+            return 0
+            ;;
+    esac
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+_mlat_restart_service() {
+    if _mlat_should_skip_restart; then
+        return 0
+    fi
+    if ! systemctl restart airplanes-mlat 2>&1; then
+        echo "service restart failed; recent journal output:" >&2
+        journalctl -u airplanes-mlat -n 10 --no-pager 2>/dev/null >&2 || true
+        return 1
+    fi
+}
+
+# Atomic rewrite of feed.env that updates MLAT_USER and MLAT_ENABLED while
+# preserving every other key, line ordering of unrelated keys, and file
+# mode/owner. Mirrors update-migrations.sh's migrate_user_to_mlat_split
+# pattern (mktemp same-dir, drop existing keys via grep -v, append the
+# canonical pair, chmod/chown --reference, mv -f).
+_mlat_rewrite_feed_env() {
+    local feed_env="$1"
+    local new_user="$2"
+    local new_enabled="$3"
+
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+
+    # Refuse to "fix" an unmigrated install — silently inserting MLAT_USER
+    # / MLAT_ENABLED into a feed.env that still has the legacy USER= would
+    # cross update-migrations.sh's responsibility and produce a confusing
+    # mid-state.
+    if ! grep -qE '^MLAT_USER=' "$feed_env"; then
+        die "feed.env at $feed_env appears unmigrated (no MLAT_USER= line); run \`sudo /usr/local/share/airplanes/update.sh\` first"
+    fi
+
+    local tmp escaped
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    grep -vE '^(MLAT_USER|MLAT_ENABLED)=' "$feed_env" > "$tmp" || true
+    # Same escape rule as migrate_user_to_mlat_split — make sourcing the
+    # written file produce the literal username, no expansion.
+    escaped="${new_user//\\/\\\\}"
+    escaped="${escaped//\$/\\\$}"
+    escaped="${escaped//\`/\\\`}"
+    escaped="${escaped//\"/\\\"}"
+    printf 'MLAT_USER="%s"\n' "$escaped" >> "$tmp"
+    printf 'MLAT_ENABLED=%s\n' "$new_enabled" >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
+apl_feed_mlat_disable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for mlat disable: $1" ;;
+        esac
+    done
+
+    local feed_env current_user
+    feed_env="$(feed_env_path)"
+    current_user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+
+    _mlat_rewrite_feed_env "$feed_env" "$current_user" "false"
+    echo "MLAT_ENABLED set to false in $feed_env"
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done (daemon will sleep while disabled)"
+    else
+        return 1
+    fi
+}
+
+apl_feed_mlat_enable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for mlat enable: $1" ;;
+        esac
+    done
+
+    local feed_env user
+    feed_env="$(feed_env_path)"
+    user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+    if [[ -z "$user" ]]; then
+        user="$DEFAULT_MLAT_NAME"
+        echo "MLAT_USER was empty; filling in with default \"$DEFAULT_MLAT_NAME\""
+    fi
+
+    _mlat_rewrite_feed_env "$feed_env" "$user" "true"
+    echo "MLAT_ENABLED set to true in $feed_env"
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done"
+    else
+        return 1
+    fi
+}
+
+apl_feed_mlat_status() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for mlat status: $1" ;;
+        esac
+    done
+
+    local feed_env user enabled service_state
+    feed_env="$(feed_env_path)"
+    if [[ ! -f "$feed_env" ]]; then
+        echo "feed.env not found at $feed_env; run setup first" >&2
+        return 1
+    fi
+    user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+    enabled="$(feed_env_get MLAT_ENABLED 2>/dev/null || true)"
+
+    printf 'MLAT_ENABLED=%s\n' "${enabled:-(unset)}"
+    printf 'MLAT_USER="%s"\n' "$user"
+    if [[ "$ROOT" == "/" ]] && command -v systemctl >/dev/null 2>&1; then
+        service_state="$(systemctl is-active airplanes-mlat 2>/dev/null || true)"
+        printf 'airplanes-mlat.service: %s\n' "${service_state:-unknown}"
+    fi
+}
+
+dispatch_mlat() {
+    local sub="${1:-}"
+    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable|status)"
+    shift || true
+    case "$sub" in
+        enable)  apl_feed_mlat_enable  "$@" ;;
+        disable) apl_feed_mlat_disable "$@" ;;
+        status)  apl_feed_mlat_status  "$@" ;;
+        -h|--help) usage ;;
+        *) die "unknown mlat subcommand: $sub" ;;
+    esac
+}

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -133,43 +133,20 @@ apl_feed_mlat_enable() {
     fi
 }
 
-apl_feed_mlat_status() {
-    local opt_rc
-    while [[ $# -gt 0 ]]; do
-        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
-        case "$opt_rc" in
-            1) shift ;;
-            2) shift 2 ;;
-            0) die "unknown flag for mlat status: $1" ;;
-        esac
-    done
-
-    local feed_env user enabled service_state
-    feed_env="$(feed_env_path)"
-    if [[ ! -f "$feed_env" ]]; then
-        echo "feed.env not found at $feed_env; run setup first" >&2
-        return 1
-    fi
-    user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
-    enabled="$(feed_env_get MLAT_ENABLED 2>/dev/null || true)"
-
-    printf 'MLAT_ENABLED=%s\n' "${enabled:-(unset)}"
-    printf 'MLAT_USER="%s"\n' "$user"
-    if [[ "$ROOT" == "/" ]] && command -v systemctl >/dev/null 2>&1; then
-        service_state="$(systemctl is-active airplanes-mlat 2>/dev/null || true)"
-        printf 'airplanes-mlat.service: %s\n' "${service_state:-unknown}"
-    fi
-}
-
 dispatch_mlat() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable|status)"
+    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable)"
     shift || true
     case "$sub" in
         enable)  apl_feed_mlat_enable  "$@" ;;
         disable) apl_feed_mlat_disable "$@" ;;
-        status)  apl_feed_mlat_status  "$@" ;;
         -h|--help) usage ;;
         *) die "unknown mlat subcommand: $sub" ;;
     esac
 }
+
+# Status reporting lives in `apl-feed status`, which reads the daemon's
+# runtime state file via scripts/lib/state-reader.sh. A focused
+# `apl-feed mlat status` would either duplicate that logic or violate
+# the "CLI side does not re-derive predicates from feed.env" rule —
+# neither pays back vs. just running `apl-feed status`.

--- a/scripts/lib/configure-validators.sh
+++ b/scripts/lib/configure-validators.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Pure-function validators / normalizers used by configure.sh to accept
+# operator input from whiptail prompts and AIRPLANES_* env vars. Extracted
+# to a lib so per-function tests can exercise the regex + range rules
+# directly without driving them through configure.sh's whiptail loops.
+#
+# Each function takes its inputs as positional args and produces a boolean
+# exit status (validators) or stdout (normalizer). No global-state reads
+# or writes — safe to source anywhere.
+#
+# Altitude unit policy (intentional split):
+#   `valid_altitude` accepts unitless integers (e.g. `0`, `123`) so build-mode
+#   feeders configured non-interactively with AIRPLANES_ALTITUDE=0 don't get
+#   rejected. The interactive whiptail loop in configure.sh enforces a
+#   stricter `^-?[0-9]+(ft|m)$` shape because the operator is being asked
+#   for an antenna altitude and units must be explicit. Both rules coexist
+#   on purpose.
+#
+# `sanitize_mlat_user` character set:
+#   The `tr -c '[a-zA-Z0-9]_\- ' '_'` filter replaces every character NOT
+#   in the allowlist with `_`. Allowed: A-Z, a-z, 0-9, underscore,
+#   hyphen, space, AND square brackets `[` `]` (a `tr` quirk — `[` and
+#   `]` are literal characters here, not character-class delimiters).
+#   Everything else (`$`, backtick, single/double quotes, backslash,
+#   parens, braces, shell metacharacters, etc.) gets rewritten to `_`.
+#   The contract is pinned by test_configure_validators.bats; do not
+#   change the filter without updating both.
+
+sanitize_mlat_user() {
+    printf '%s' "$1" | tr -c '[a-zA-Z0-9]_\- ' '_'
+}
+
+valid_latitude() {
+    [[ "$1" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]] \
+        && awk -v LAT="$1" 'BEGIN { exit !(LAT < 90 && LAT > -90) }'
+}
+
+valid_longitude() {
+    [[ "$1" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]] \
+        && awk -v LON="$1" 'BEGIN { exit !(LON < 180 && LON > -180) }'
+}
+
+valid_altitude() {
+    [[ "$1" =~ ^-?[0-9]+(ft|m)?$ ]]
+}
+
+normalize_altitude() {
+    local alt="$1"
+    if [[ $alt =~ ^-([0-9]+)ft$ ]]; then
+        awk -v NUM="${BASH_REMATCH[1]}" 'BEGIN { printf "-%0.2f", NUM / 3.28 }'
+    elif [[ $alt =~ ^-([0-9]+)m$ ]]; then
+        printf -- '-%s' "${BASH_REMATCH[1]}"
+    else
+        printf '%s' "$alt"
+    fi
+}

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -181,36 +181,6 @@ EOF
     [[ "$output" == *'/usr/local/share/airplanes/update.sh'* ]]
 }
 
-# --- status ---
-
-@test "status reports MLAT_ENABLED, MLAT_USER, and service state" {
-    write_feed_env "alice" "true"
-    ROOT="/"
-    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
-    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
-
-    run apl_feed_mlat_status
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *'MLAT_ENABLED=true'* ]]
-    [[ "$output" == *'MLAT_USER="alice"'* ]]
-    [[ "$output" == *'airplanes-mlat.service: active'* ]]
-}
-
-@test "status reports (unset) when feed.env lacks MLAT_ENABLED" {
-    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
-MLAT_USER="alice"
-EOF
-    ROOT="/"
-    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
-    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
-
-    run apl_feed_mlat_status
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *'MLAT_ENABLED=(unset)'* ]]
-}
-
 # --- restart-skip semantics ---
 
 @test "AIRPLANES_BUILD_MODE=1 skips the systemctl restart (file edits still happen)" {

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -1,0 +1,243 @@
+#!/usr/bin/env bats
+
+# Per-module tests for scripts/apl-feed/mlat.sh. Mirrors test_apl_feed_id.bats
+# in shape: source common.sh + mlat.sh, stub systemctl, point ROOT at a
+# scratch tree containing /etc/airplanes/feed.env.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    mkdir -p "$TMPDIR" "$STUB_DIR" "$ROOT_DIR/etc/airplanes"
+    export TMPDIR
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/mlat.sh
+    source "$LIB_DIR/mlat.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+case "\$1" in
+    is-active) echo active ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+write_feed_env() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="$1"
+MLAT_ENABLED=$2
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+EOF
+}
+
+# --- dispatch_mlat ---
+
+@test "dispatch_mlat: missing subcommand dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/mlat.sh'
+        dispatch_mlat
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'mlat requires a subcommand'* ]]
+}
+
+@test "dispatch_mlat: unknown subcommand dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/mlat.sh'
+        dispatch_mlat frobnitz
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unknown mlat subcommand: frobnitz'* ]]
+}
+
+# --- disable / enable round-trip ---
+
+@test "disable flips MLAT_ENABLED true→false, preserves MLAT_USER, restarts service" {
+    write_feed_env "alice" "true"
+    ROOT="/"  # exercise the systemctl path; only safe because PATH-stub captures it
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+
+    # Override feed_env_path to point inside ROOT_DIR (the helper resolves
+    # off /etc/airplanes which would be the host's real path with ROOT='/').
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_disable
+
+    grep -q '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=false$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable flips MLAT_ENABLED false→true, preserves MLAT_USER, restarts service" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_enable
+
+    grep -q '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=true$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable with empty MLAT_USER fills in Anonymous default" {
+    write_feed_env "" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_enable
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'MLAT_USER was empty; filling in with default "Anonymous"'* ]]
+    grep -q '^MLAT_USER="Anonymous"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=true$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "disable preserves MLAT_USER even when empty (no Anonymous fill on disable)" {
+    write_feed_env "" "true"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_disable
+
+    # MLAT_USER stays empty on disable — only enable triggers the fallback,
+    # since the runtime doesn't strict-fail empty MLAT_USER while disabled.
+    grep -q '^MLAT_USER=""$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=false$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "round-trip disable→enable restores the original MLAT_USER" {
+    write_feed_env "william34-london" "true"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_disable
+    grep -q '^MLAT_USER="william34-london"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=false$' "$ROOT_DIR/etc/airplanes/feed.env"
+
+    apl_feed_mlat_enable
+    grep -q '^MLAT_USER="william34-london"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=true$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+# --- error paths ---
+
+@test "missing feed.env: enable dies with documented message" {
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+
+    run apl_feed_mlat_enable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'feed.env not found'* ]]
+    [[ "$output" == *'run setup first'* ]]
+}
+
+@test "unmigrated feed.env (USER= without MLAT_USER) dies with documented message" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+USER="alice"
+LATITUDE="52.52"
+EOF
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_disable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'feed.env at'* ]]
+    [[ "$output" == *'unmigrated'* ]]
+    [[ "$output" == *'/usr/local/share/airplanes/update.sh'* ]]
+}
+
+# --- status ---
+
+@test "status reports MLAT_ENABLED, MLAT_USER, and service state" {
+    write_feed_env "alice" "true"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_status
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'MLAT_ENABLED=true'* ]]
+    [[ "$output" == *'MLAT_USER="alice"'* ]]
+    [[ "$output" == *'airplanes-mlat.service: active'* ]]
+}
+
+@test "status reports (unset) when feed.env lacks MLAT_ENABLED" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+MLAT_USER="alice"
+EOF
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_status
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'MLAT_ENABLED=(unset)'* ]]
+}
+
+# --- restart-skip semantics ---
+
+@test "AIRPLANES_BUILD_MODE=1 skips the systemctl restart (file edits still happen)" {
+    write_feed_env "alice" "true"
+    ROOT="/"
+    AIRPLANES_BUILD_MODE=1
+    export AIRPLANES_BUILD_MODE
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_disable
+
+    [ "$status" -eq 0 ]
+    grep -q '^MLAT_ENABLED=false$' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ ! -f "$SYSTEMCTL_LOG" ] || ! grep -q 'restart' "$SYSTEMCTL_LOG"
+    [[ "$output" == *'AIRPLANES_BUILD_MODE'* ]]
+}
+
+@test "ROOT != / skips the systemctl restart (file edits still happen)" {
+    write_feed_env "alice" "true"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_disable
+
+    [ "$status" -eq 0 ]
+    grep -q '^MLAT_ENABLED=false$' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ ! -f "$SYSTEMCTL_LOG" ] || ! grep -q 'restart' "$SYSTEMCTL_LOG"
+    [[ "$output" == *"--root=$ROOT_DIR"* ]]
+}

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -161,3 +161,103 @@ run_configure_env() {
     [[ "$output" =~ "Latitude must be a decimal number" ]]
     [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
 }
+
+@test "configure.sh empty AIRPLANES_MLAT_USER falls back to Anonymous" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="Anonymous"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh unset AIRPLANES_MLAT_USER also falls back to Anonymous" {
+    # Triggering non-interactive via AIRPLANES_LATITUDE; MLAT_USER is unset.
+    run_configure_env \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="Anonymous"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh AIRPLANES_MLAT_ENABLED=false preserves the supplied name" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="alice" \
+        AIRPLANES_MLAT_ENABLED="false" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="alice"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh AIRPLANES_MLAT_ENABLED=false plus empty user still fills Anonymous" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="" \
+        AIRPLANES_MLAT_ENABLED="false" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="Anonymous"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh AIRPLANES_MLAT_ENABLED with bogus value rejects with documented message" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="alice" \
+        AIRPLANES_MLAT_ENABLED="probably" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "AIRPLANES_MLAT_ENABLED must be 'true' or 'false'" ]]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "configure.sh AIRPLANES_MLAT_USER=0 is now a literal username (sentinel dropped)" {
+    # Contract change: pre-migration this would have disabled MLAT.
+    # Now it's a regular name and MLAT stays enabled.
+    run_configure_env \
+        AIRPLANES_MLAT_USER="0" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="0"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh AIRPLANES_MLAT_ENABLED alone triggers non-interactive mode" {
+    # Even with no other AIRPLANES_* vars set, AIRPLANES_MLAT_ENABLED on
+    # its own should make has_noninteractive_config_env return true.
+    # Required lat/lon/alt are then missing, so this exits 1 with the
+    # standard "Missing required" error — proving has_noninteractive
+    # recognized AIRPLANES_MLAT_ENABLED.
+    run_configure_env AIRPLANES_MLAT_ENABLED="false"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Missing required non-interactive configure value: AIRPLANES_LATITUDE" ]]
+    [ ! -e "$WHIPTAIL_LOG" ]
+}
+
+@test "configure.sh interactive: empty MLAT name input writes Anonymous" {
+    # The first interactive inputbox (name) gets an empty line. The flow
+    # falls back to DEFAULT_MLAT_NAME on disk.
+    run_configure $'\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="Anonymous"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}

--- a/test/test_configure_validators.bats
+++ b/test/test_configure_validators.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+
+# Per-function tests for scripts/lib/configure-validators.sh. The same
+# rules are also exercised end-to-end via test_configure_script.bats's
+# whiptail loops and non-interactive paths; these tests pin the contract
+# at the function boundary so a future webconfig backend (or any other
+# reuser) has a stable specification.
+
+setup() {
+    LIB="$BATS_TEST_DIRNAME/../scripts/lib/configure-validators.sh"
+    # shellcheck source=/dev/null
+    source "$LIB"
+}
+
+# --- valid_latitude ---
+
+@test "valid_latitude accepts canonical decimals" {
+    valid_latitude 0
+    valid_latitude 52.52
+    valid_latitude -89.99
+    valid_latitude 0.0
+}
+
+@test "valid_latitude accepts +signed values" {
+    valid_latitude '+52.52'
+    valid_latitude '+0'
+}
+
+@test "valid_latitude rejects out-of-range" {
+    ! valid_latitude 90
+    ! valid_latitude 90.0
+    ! valid_latitude -90
+    ! valid_latitude 91
+    ! valid_latitude -91
+    ! valid_latitude 100
+}
+
+@test "valid_latitude rejects non-numeric" {
+    ! valid_latitude north
+    ! valid_latitude ''
+    ! valid_latitude '52.52N'
+    ! valid_latitude '52,52'
+}
+
+# --- valid_longitude ---
+
+@test "valid_longitude accepts canonical decimals" {
+    valid_longitude 0
+    valid_longitude 13.405
+    valid_longitude -179.99
+    valid_longitude 179.99
+}
+
+@test "valid_longitude rejects out-of-range" {
+    ! valid_longitude 180
+    ! valid_longitude -180
+    ! valid_longitude 181
+    ! valid_longitude -181
+}
+
+@test "valid_longitude rejects non-numeric" {
+    ! valid_longitude east
+    ! valid_longitude ''
+    ! valid_longitude '13.40E'
+}
+
+# --- valid_altitude ---
+
+@test "valid_altitude accepts unitless integers (build-mode contract)" {
+    # README's build-mode example uses AIRPLANES_ALTITUDE=0 — keep it valid
+    # at the lib level even though the interactive UI requires units.
+    valid_altitude 0
+    valid_altitude 35
+    valid_altitude -10
+    valid_altitude 1000
+}
+
+@test "valid_altitude accepts ft and m suffixes" {
+    valid_altitude 35m
+    valid_altitude 100ft
+    valid_altitude -5m
+    valid_altitude -200ft
+}
+
+@test "valid_altitude rejects decimals" {
+    ! valid_altitude 35.5
+    ! valid_altitude 35.5m
+    ! valid_altitude 35.5ft
+}
+
+@test "valid_altitude rejects unknown units" {
+    ! valid_altitude 35km
+    ! valid_altitude 35yd
+    ! valid_altitude 35M  # case-sensitive: only lowercase 'm' is meters
+    ! valid_altitude 35FT
+}
+
+@test "valid_altitude rejects non-numeric" {
+    ! valid_altitude high
+    ! valid_altitude ''
+    ! valid_altitude m
+    ! valid_altitude ft
+}
+
+# --- normalize_altitude ---
+
+@test "normalize_altitude passes positive values through unchanged" {
+    [ "$(normalize_altitude 35m)" = "35m" ]
+    [ "$(normalize_altitude 100ft)" = "100ft" ]
+    [ "$(normalize_altitude 0)" = "0" ]
+    [ "$(normalize_altitude 200)" = "200" ]
+}
+
+@test "normalize_altitude converts negative feet to negative meters" {
+    # Existing rule: -<n>ft -> awk "%.2f" of n/3.28
+    local out
+    out="$(normalize_altitude -100ft)"
+    [[ "$out" =~ ^-30\.[0-9]+$ ]]
+}
+
+@test "normalize_altitude strips m suffix from negative meters" {
+    [ "$(normalize_altitude -50m)" = "-50" ]
+    [ "$(normalize_altitude -1m)" = "-1" ]
+}
+
+# --- sanitize_mlat_user ---
+#
+# Contract pin (see header in configure-validators.sh): the `tr` filter
+# replaces every character NOT in [a-zA-Z0-9_- ] with `_`. These tests
+# exhaustively pin that allowlist so a future maintainer can't widen or
+# narrow it without seeing a test break.
+
+@test "sanitize_mlat_user passes alphanumerics through unchanged" {
+    [ "$(sanitize_mlat_user 'alice')" = 'alice' ]
+    [ "$(sanitize_mlat_user 'ABC123')" = 'ABC123' ]
+    [ "$(sanitize_mlat_user 'william34-london')" = 'william34-london' ]
+}
+
+@test "sanitize_mlat_user preserves underscore, hyphen, space" {
+    [ "$(sanitize_mlat_user 'alice_bob')" = 'alice_bob' ]
+    [ "$(sanitize_mlat_user 'alice-bob')" = 'alice-bob' ]
+    [ "$(sanitize_mlat_user 'alice bob')" = 'alice bob' ]
+}
+
+@test "sanitize_mlat_user replaces shell metacharacters with underscore" {
+    [ "$(sanitize_mlat_user 'al$ce')"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al`ce')"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al"ce')"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user "al'ce")"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al\ce')" = 'al_ce' ]
+}
+
+@test "sanitize_mlat_user: parens, braces are replaced with underscore" {
+    [ "$(sanitize_mlat_user 'al(ce')"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al)ce')"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al{ce')"  = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al}ce')"  = 'al_ce' ]
+}
+
+@test "sanitize_mlat_user: square brackets pass through unchanged (tr-set quirk, contract pin)" {
+    # The `tr -c '[a-zA-Z0-9]_\- '` filter treats `[` and `]` as LITERAL
+    # characters in the allowlist (BSD/GNU tr both do — POSIX `tr` does
+    # not use `[...]` as a character-class delimiter outside the
+    # `[:class:]` form). So these end up allowed alongside `a-zA-Z0-9`.
+    # Pinning this behavior so a future maintainer who tightens the
+    # filter sees the test break and decides explicitly.
+    [ "$(sanitize_mlat_user 'al[ce')" = 'al[ce' ]
+    [ "$(sanitize_mlat_user 'al]ce')" = 'al]ce' ]
+}
+
+@test "sanitize_mlat_user replaces other non-allowlist characters" {
+    [ "$(sanitize_mlat_user 'al@ce')" = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al#ce')" = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al!ce')" = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al?ce')" = 'al_ce' ]
+    [ "$(sanitize_mlat_user 'al/ce')" = 'al_ce' ]
+}
+
+@test "sanitize_mlat_user collapses tabs and newlines to underscore" {
+    [ "$(sanitize_mlat_user $'al\tce')" = 'al_ce' ]
+    [ "$(sanitize_mlat_user $'al\nce')" = 'al_ce' ]
+}
+
+@test "sanitize_mlat_user empty input produces empty output" {
+    [ "$(sanitize_mlat_user '')" = '' ]
+}
+
+@test "sanitize_mlat_user multiple bad characters each become underscore (not collapsed)" {
+    [ "$(sanitize_mlat_user 'a!@#b')" = 'a___b' ]
+}

--- a/update.sh
+++ b/update.sh
@@ -317,7 +317,7 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
     # check below sees MLAT_USER/MLAT_ENABLED. The boot config itself is
     # left alone (it's the user's edit surface and must keep working as-is
     # for users who hand-edit it).
-    if [[ -z "${MLAT_USER+x}" && -z "${MLAT_ENABLED+x}" && -n "${USER+x}" ]]; then
+    if [[ ! -v MLAT_USER && ! -v MLAT_ENABLED && -v USER ]]; then
         case "$USER" in
             0|disable)
                 MLAT_USER=""
@@ -408,6 +408,7 @@ historical_apl_feed_modules=(
     common.sh
     http.sh
     id.sh
+    mlat.sh
     status.sh
 )
 historical_daemon_libs=(


### PR DESCRIPTION
AIRPLANES_MLAT_USER is now name-only; empty/unset falls back to a new DEFAULT_MLAT_NAME="Anonymous". AIRPLANES_MLAT_ENABLED is the dedicated input flag (default true; only true|false; anything else exits 1). Interactive whiptail always enables MLAT — operators run `sudo apl-feed mlat disable` after setup, which atomically rewrites feed.env and restarts airplanes-mlat (skipping the systemctl call under AIRPLANES_BUILD_MODE=1 or non-default ROOT).

apl-feed status remains the canonical MLAT-state query surface (it reads the daemon runtime state file). A focused mlat status would re-derive predicates from feed.env — the architecture rule explicitly retires that pattern, so this PR ships only enable/disable and routes status through the existing dispatcher.

Validators (lat/lon/altitude/sanitize_mlat_user) move to scripts/lib/configure-validators.sh with per-function tests pinning their contracts, including a documented tr quirk that lets [ and ] pass through unchanged. Two `${VAR+x}` is-set checks in update.sh and airplanes-mlat.sh revert to `[[ -v VAR ]]`; production runs Linux bash 4.3+ and the airplanes-mlat.sh comment already called `[[ -v VAR ]]` the cleaner form.

BREAKING CHANGE: AIRPLANES_MLAT_USER no longer accepts 0 or disable as state sentinels. To turn MLAT off, set AIRPLANES_MLAT_ENABLED=false (non-interactive setup) or run `sudo apl-feed mlat disable` after setup.