### PR TITLE
Make install_mlat_client's failure branch reachable

### DIFF
--- a/.claude/rules/preserved-behavior.md
+++ b/.claude/rules/preserved-behavior.md
@@ -1,17 +1,5 @@
 # Preserved behavior
 
-Places where the code looks wrong but is preserved verbatim because changing the behavior needs a deliberate conversation. Each entry has a regression test pinning it; the test will fail if the code is "tidied", and that's the signal to think rather than rewrite.
+No current entries.
 
-## The mlat install command chain — `install_mlat_client` in `scripts/lib/update-builds.sh`
-
-The mixed `&& / ||` chain inside the `if` ends with:
-
-```
-…
-&& revision > "$ipath/mlat_version" || rm -f "$ipath/mlat_version" \
-&& echo 48
-```
-
-Because `rm -f` always returns 0, the chain *always* exits 0 — meaning the surrounding `if/then/else` always takes the success branch and the `else` (the "Installing mlat-client failed" message + venv-backup restore) is effectively unreachable through normal failures inside the chain (e.g. a `pip install .` that returns non-zero).
-
-Pinned by `test_update_builds.bats: install_mlat_client: pip failure is masked by chain (regression — preserve verbatim)`. Don't reorder, regroup, or simplify the chain. If you want to fix the masking so failures actually trigger the rollback, propose the behavior change explicitly in its own PR — it's a real bug, just not one to fix as a side effect of a refactor.
+When adding one, document the preserved behavior and the regression test pinning it. The previous entry — the mlat install command chain in `install_mlat_client` — was retired when the chain was restructured to make the failure-handling `else` branch reachable; build failures now propagate as originally intended.

--- a/scripts/lib/update-builds.sh
+++ b/scripts/lib/update-builds.sh
@@ -10,10 +10,19 @@
 # read or mutate update.sh's config-state globals (USER, TARGET, MLAT_*).
 #
 # Test seam: the mlat-client venv creation honors AIRPLANES_PYTHON_BIN so
-# tests can intercept the python binary without a PATH stub. This is the
-# only intentional diff from the original inline form; the rest of the
-# install command chain (mixed && / || ordering of setuptools/pyasyncore
-# fallbacks) is preserved verbatim.
+# tests can intercept the python binary without a PATH stub.
+#
+# The mlat install chain is structured as a strict `&&` sequence with
+# intentional fallbacks (`{ a || b; }`) braced into local groups. This
+# replaces an earlier free-form `&&`/`||` cascade whose precedence quirk
+# (`A && B || C && D` parses as `((A && B) || C) && D`) silently masked
+# build failures: any unintentional `||` could reset the chain accumulator
+# to success, so a `pip install` failure routed through later success
+# steps (`rm -f` always succeeds, `echo` always succeeds) and the
+# if-test's else branch — which restores the venv from backup and prints
+# a "build failed" warning — never fired. The braced groups confine each
+# fallback's scope so the chain ultimately fails when any required step
+# does, making the else branch reachable.
 
 # Compute the upstream HEAD SHA for $branch on $repo. Returns a random
 # sentinel when the lookup produces no output (network failure, DNS miss,
@@ -55,13 +64,16 @@ _compute_remote_version() {
 # Skip path: when version matches, mlat-client binary exists, and at
 # least one of {build mode, active service, mlat-disabled} holds.
 #
-# Failure handling: getGIT failure aborts under set -e (preserved from the
-# inline form — different from the in-build failure path below, which
-# restores $venv-backup and continues so the readsb build can still run).
-# In-build failure (any step in the && / || install chain returns
-# non-zero and the chain ultimately fails) restores $venv from backup and
+# Failure handling: getGIT failure aborts under set -e (different from
+# the in-build failure path, which restores $venv-backup and continues so
+# the readsb build can still run). In-build failure (any required step in
+# the install chain returns non-zero) restores $venv from backup and
 # prints the documented warning; the function returns 0 so update.sh can
-# continue.
+# continue. Note that `revision()` always exits 0 via its own internal
+# `|| echo "$RANDOM-$RANDOM"` sentinel (see install-update-common.sh), so
+# the `revision > $ipath/mlat_version || rm -f $ipath/mlat_version` group
+# in the chain defends against a write failure on $ipath/mlat_version
+# itself (disk full, permission denied), not git-dir failure.
 install_mlat_client() {
     local mlat_repo="$1"
     local mlat_branch="$2"
@@ -98,28 +110,29 @@ install_mlat_client() {
 
     # Build runs in a subshell so cd and venv activation don't leak to
     # the caller (caller's $PWD is unchanged after this function returns).
-    # The mixed && / || chain inside the if-test is preserved verbatim;
-    # the only intentional edit is the AIRPLANES_PYTHON_BIN seam at the
-    # venv-creation step. Chain leg semantics:
-    #   `python3 -c "import setuptools" || python3 -m pip install setuptools`
-    # routes through &&/|| so missing setuptools triggers the pip install
-    # fallback, then continues with `&& echo 39 && ...`. Same shape for
-    # asyncore → pyasyncore.
+    # Strict `&&` chain with `{ a || b; }`-braced fallbacks: each required
+    # step (venv creation, source activate, wheel install, `pip install .`)
+    # is unconditionally chained, while the setuptools/asyncore "import
+    # or install" fallbacks and the `revision`/`rm -f` tail are scoped
+    # locally so a fallback succeeding doesn't reset the accumulator for
+    # an unrelated earlier failure. The braces matter — without them the
+    # `||` would extend across the chain (see the precedence note in the
+    # file header).
     if (
-        cd "$mlat_git"
-        "${AIRPLANES_PYTHON_BIN:-/usr/bin/python3}" -m venv "$venv" >> "$logfile" \
-            && echo 36 \
-            && source "$venv/bin/activate" >> "$logfile" \
-            && echo 37 \
-            && python3 -c "import setuptools" || python3 -m pip install setuptools \
-            && echo 39 \
-            && python3 -c "import asyncore" || python3 -m pip install pyasyncore \
-            && python3 -m pip install wheel \
-            && echo 40 \
-            && pip install . \
-            && echo 46 \
-            && revision > "$ipath/mlat_version" || rm -f "$ipath/mlat_version" \
-            && echo 48
+        cd "$mlat_git" &&
+        "${AIRPLANES_PYTHON_BIN:-/usr/bin/python3}" -m venv "$venv" >> "$logfile" &&
+        echo 36 &&
+        source "$venv/bin/activate" >> "$logfile" &&
+        echo 37 &&
+        { python3 -c "import setuptools" || python3 -m pip install setuptools; } &&
+        echo 39 &&
+        { python3 -c "import asyncore" || python3 -m pip install pyasyncore; } &&
+        python3 -m pip install wheel &&
+        echo 40 &&
+        pip install . &&
+        echo 46 &&
+        { revision > "$ipath/mlat_version" || rm -f "$ipath/mlat_version"; } &&
+        echo 48
     ); then
         rm -rf "$venv-backup"
     else

--- a/test/test_update_builds.bats
+++ b/test/test_update_builds.bats
@@ -92,8 +92,9 @@ exit 0'
     source "$LIB"
 
     # Override real getGIT (which would actually clone) with a stub that
-    # creates the target dir as a usable git repo so subsequent `cd
-    # $target` and `revision` calls succeed naturally.
+    # creates the target dir so subsequent `cd $target` succeeds. (`git`
+    # is stubbed and `revision` is overridden below, so the dir's git
+    # state itself isn't read by anything in the test.)
     getGIT() {
         local target="$3"
         printf "getGIT %s %s %s\n" "$1" "$2" "$3" >> "$COMMAND_LOG"
@@ -258,19 +259,18 @@ esac'
     grep -q "^getGIT https://example/mlat-client master " "$COMMAND_LOG"
 }
 
-@test "install_mlat_client: pip failure is masked by chain (regression — preserve verbatim)" {
-    # Regression pin for the chain quirk in the install command list at
-    # update.sh:472–484 (now in update-builds.sh): the trailing
-    # `... || rm -f $ipath/mlat_version && echo 48` resets the chain's
-    # failure to success because `rm -f` always returns 0, then
-    # `echo 48` succeeds, leaving the chain's final exit status at 0.
-    # That means a `pip install` failure does NOT trigger the else
-    # branch / backup-restore path — the if-success branch fires and
-    # the (broken) new venv is kept while the backup is removed.
-    #
-    # The constraint says preserve verbatim; this test pins that
-    # semantics so a future "tidy up" of the chain can't silently
-    # change failure handling without the test failing.
+@test "install_mlat_client: pip install . failure restores backup and prints warning" {
+    # The chain restructure (strict && with braced fallback groups) makes
+    # the if-test's else branch reachable. A `pip install .` failure now
+    # propagates: backup is restored to $VENV with its original content,
+    # any pre-existing mlat_version stays untouched (the revision/rm-f
+    # group is never reached), and the operator-facing warning prints.
+    # Function still returns 0 so update.sh continues to the readsb build.
+    mkdir -p "$VENV/bin"
+    printf "OLD_VERSION_MARKER\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+    printf "OLD_SHA" > "$IPATH/mlat_version"
+
     PIP_EXIT=1
     export PIP_EXIT
 
@@ -278,13 +278,160 @@ esac'
         https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
 
     [ "$status" -eq 0 ]
-    # Failure-message NOT printed: success branch fires.
-    [[ "$output" != *"Installing mlat-client failed"* ]]
-    # Backup removed (success branch's `rm -rf $venv-backup`).
+    [[ "$output" == *"Installing mlat-client failed"* ]]
+    # Backup restored to its original location with its original content.
+    [ -x "$VENV/bin/mlat-client" ]
+    grep -q OLD_VERSION_MARKER "$VENV/bin/mlat-client"
+    # Backup directory consumed by the rename.
     [ ! -e "$VENV-backup" ]
-    # mlat_version was removed by the chain's `|| rm -f` step before
-    # echo 48 reset the chain to success.
-    [ ! -f "$IPATH/mlat_version" ]
+    # Pre-existing version file is preserved — the chain failed before
+    # reaching `revision > X || rm -f X`, so neither side of that group
+    # touched the file.
+    [ "$(cat "$IPATH/mlat_version")" = "OLD_SHA" ]
+}
+
+@test "install_mlat_client: venv-creation failure restores backup and prints warning" {
+    mkdir -p "$VENV/bin"
+    printf "OLD_VERSION_MARKER\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+
+    PYTHON_VENV_EXIT=1
+    export PYTHON_VENV_EXIT
+
+    run install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing mlat-client failed"* ]]
+    [ -x "$VENV/bin/mlat-client" ]
+    grep -q OLD_VERSION_MARKER "$VENV/bin/mlat-client"
+}
+
+@test "install_mlat_client: source-activate failure restores backup and prints warning" {
+    # Override the python3 stub for venv: succeed but write an activate
+    # script that returns non-zero from the sourced context. The subtle
+    # bit: use `return 1`, NOT `exit 1`. `exit` inside a sourced file
+    # terminates the entire subshell immediately, which would also have
+    # short-circuited the OLD buggy chain — so the test wouldn't actually
+    # exercise the fix. `return` only returns from the sourced file,
+    # propagating the non-zero status through the `&&` chain. The new
+    # chain catches it; the old `||`-cascade would have masked it.
+    _stub python3 '
+printf "python3 %s\n" "$*" >> "$COMMAND_LOG"
+case "$1" in
+    -m)
+        case "$2" in
+            venv)
+                mkdir -p "$3/bin"
+                printf "return 1\n" > "$3/bin/activate"
+                printf "#!/bin/sh\nexit 0\n" > "$3/bin/mlat-client"
+                chmod +x "$3/bin/mlat-client"
+                exit 0
+                ;;
+            pip) exit 0 ;;
+        esac
+        ;;
+    -c) exit 0 ;;
+esac
+exit 0'
+
+    mkdir -p "$VENV/bin"
+    printf "OLD_VERSION_MARKER\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+
+    run install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing mlat-client failed"* ]]
+    [ -x "$VENV/bin/mlat-client" ]
+    grep -q OLD_VERSION_MARKER "$VENV/bin/mlat-client"
+}
+
+@test "install_mlat_client: setuptools double-failure restores backup and prints warning" {
+    # `python3 -c "import setuptools"` fails (setuptools missing) AND
+    # `python3 -m pip install setuptools` also fails — both legs of the
+    # `{ ... || ... }` fallback group fail, so the group exits non-zero
+    # and the chain aborts. Without the brace grouping, the second
+    # leg's `||` would extend across the rest of the chain and a later
+    # `&& <always-succeeds>` step could mask this failure.
+    mkdir -p "$VENV/bin"
+    printf "OLD_VERSION_MARKER\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+
+    PYTHON_IMPORT_SETUPTOOLS_EXIT=1
+    PYTHON_PIP_EXIT=1
+    export PYTHON_IMPORT_SETUPTOOLS_EXIT PYTHON_PIP_EXIT
+
+    run install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing mlat-client failed"* ]]
+    [ -x "$VENV/bin/mlat-client" ]
+    grep -q OLD_VERSION_MARKER "$VENV/bin/mlat-client"
+}
+
+@test "install_mlat_client: asyncore double-failure restores backup and prints warning" {
+    # Same shape as the setuptools double-failure test, one group later
+    # in the chain. Setuptools succeeds (import returns 0 by default), so
+    # PYTHON_PIP_EXIT=1 only ever bites at the asyncore-pip install
+    # invocation.
+    mkdir -p "$VENV/bin"
+    printf "OLD_VERSION_MARKER\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+
+    PYTHON_IMPORT_ASYNCORE_EXIT=1
+    PYTHON_PIP_EXIT=1
+    export PYTHON_IMPORT_ASYNCORE_EXIT PYTHON_PIP_EXIT
+
+    run install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing mlat-client failed"* ]]
+    [ -x "$VENV/bin/mlat-client" ]
+    grep -q OLD_VERSION_MARKER "$VENV/bin/mlat-client"
+}
+
+@test "install_mlat_client: pip install wheel failure restores backup and prints warning" {
+    # Wheel install is an unconditional step (no fallback). Its failure
+    # aborts the chain directly. Custom python3 stub fails only on
+    # `python3 -m pip install wheel` to avoid colliding with the
+    # setuptools/asyncore fallback paths (which use the same stub).
+    _stub python3 '
+printf "python3 %s\n" "$*" >> "$COMMAND_LOG"
+case "$1" in
+    -m)
+        case "$2" in
+            venv)
+                mkdir -p "$3/bin"
+                : > "$3/bin/activate"
+                printf "#!/bin/sh\nexit 0\n" > "$3/bin/mlat-client"
+                chmod +x "$3/bin/mlat-client"
+                exit 0
+                ;;
+            pip)
+                if [ "$3 $4" = "install wheel" ]; then exit 1; fi
+                exit 0
+                ;;
+        esac
+        ;;
+    -c) exit 0 ;;
+esac
+exit 0'
+
+    mkdir -p "$VENV/bin"
+    printf "OLD_VERSION_MARKER\n" > "$VENV/bin/mlat-client"
+    chmod +x "$VENV/bin/mlat-client"
+
+    run install_mlat_client \
+        https://example/mlat-client master "$VENV" "$IPATH" "$MLAT_GIT" "$LOGFILE" no 0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing mlat-client failed"* ]]
+    [ -x "$VENV/bin/mlat-client" ]
+    grep -q OLD_VERSION_MARKER "$VENV/bin/mlat-client"
 }
 
 @test "install_mlat_client: getGIT failure aborts under set -e" {


### PR DESCRIPTION
The mlat install command chain in install_mlat_client used a free-form mix of `&&` and `||`, and bash's left-associative same-precedence parsing turned the trailing `... && revision > X || rm -f X && echo 48` into a success-mask: any earlier failure (pip install, venv creation, source activate, setuptools/asyncore double-failure, wheel install) routed through the OR to a guaranteed-zero `rm -f`, then through && to a guaranteed-zero `echo`, leaving the chain's final exit at 0. The if-test always fired its success branch; the else branch — which restores $venv from $venv-backup and prints a 'build failed' warning — was unreachable in practice. Operators saw no warning, and the previous working venv was deleted by the success branch's `rm -rf $venv-backup` regardless of the build's actual outcome.

The chain is now a strict `&&` sequence with intentional fallbacks scoped into `{ a || b; }` brace groups. Each required step (venv creation, source activate, wheel install, `pip install .`) is unconditional; setuptools/asyncore 'import or install' fallbacks and the `revision || rm -f` tail are local. A failing required step or a both-legs-fail fallback group now propagates to the if-test, which routes to the else branch and restores the backup. Function exit code is unchanged (0 in both paths).

The previous PR's regression-pin test is replaced with a behavior-pin; five new bats cases cover the venv-creation, source-activate, setuptools double-failure, asyncore double-failure, and wheel-install failure paths — each one exercises code the old chain would have masked, so the new tests are genuine regression coverage for the fix.

After the merge from dev, this PR also retires the mlat-chain entry from `.claude/rules/preserved-behavior.md` — that rule pointed contributors to propose this change in its own PR, which this is.