### PR TITLE
docs(claude): add feed-specific orientation and rule files

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+worktrees/

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,45 @@
+# feed/
+
+Installer and updater shipped to end-user feeder hardware. Bash. Target: Debian / Ubuntu / Raspberry Pi OS, runs as root via curl-pipe-bash. CI is Ubuntu (`ubuntu-24.04`); macOS dev surfaces known portability failures (see `rules/testing.md`).
+
+## Tree map
+
+| Path | Role |
+|---|---|
+| `update.sh` | Install/update orchestrator. Self-replaces, fetches the repo, runs migrations, builds mlat-client + readsb, writes systemd units, registers claim secret. |
+| `install.sh` | Standalone bootstrap. Fetches the repo and delegates to `setup.sh`. Has its own (smaller) inline-fallback block. |
+| `setup.sh` | Interactive whiptail config (lat/long, MLAT user, receiver input). |
+| `configure.sh` | Builds systemd units, applies config to running services. |
+| `uninstall.sh` | Stops/disables units, wipes state, preserves the canonical UUID. |
+| `create-uuid.sh` | Per-device UUID generation/migration. |
+| `scripts/lib/` | Shared library modules (see `rules/architecture.md` for the extraction discipline). Current set: `install-update-common.sh`, `systemd-helpers.sh`, `claim-registration.sh`, `update-migrations.sh`, `service-account.sh`, `update-builds.sh`, `state-writer.sh`, `state-reader.sh`. |
+| `scripts/` | `apl-feed.sh` (CLI dispatcher), `airplanes-feed.sh` / `airplanes-mlat.sh` (daemon scripts), unit files. |
+| `scripts/apl-feed/` | CLI command modules: `claim`, `id`, `status`, `backup`, `http`, `common`. |
+| `test/` | BATS test suite. See `rules/testing.md`. |
+
+## Where to start for common tasks
+
+| Task | Start at |
+|---|---|
+| Bug in feeder install/update | `update.sh` + add a BATS test under `test/`. |
+| Adding a new shared lib module | Mirror `scripts/lib/update-builds.sh` shape. Read `rules/architecture.md` first. |
+| Daemon-state question | `scripts/lib/state-writer.sh` + `state-reader.sh`. State files live at `/run/<service>/state`. |
+| MLAT enable/disable behavior | `airplanes-mlat.sh`'s state classifier; `MLAT_ENABLED` is checked before geo. |
+| Image-side change (rootfs build, first-run, webconfig) | Wrong repo. |
+| Cross-cutting touches feed and another repo | Read `apl-workspace/CLAUDE.md` for the polyrepo orientation. |
+
+## Rules files
+
+- `rules/architecture.md` — load-bearing structural rules (inline-fallback discipline, lib extraction conventions, daemon state-file pattern, manifest pattern, etc.). Read this before adding/extracting any lib module or modifying `update.sh`'s top-level flow.
+- `rules/testing.md` — BATS conventions, stub patterns, set-e abort testing, macOS portability inventory, CI workflow list.
+- `rules/commit-guidelines.md` — conventional-commits format. Layers on top of the workspace-wide `apl-workspace/.claude/rules/commit-and-pr.md` (which covers PR-body conventions).
+- `rules/preserved-behavior.md` — quirks pinned by regression tests; do not "tidy" without an explicit fix proposal.
+
+## Local dev
+
+```
+bats test/                  # full suite
+bats test/test_X.bats       # one file
+```
+
+For Ubuntu parity on a macOS dev box: run via the Docker image at `test/Dockerfile.apl-feed-test`, or install brew bash and use that interpreter. Don't blanket-ignore macOS test failures — only the known-portability cases listed in `rules/testing.md` are expected.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,84 @@
+# Architecture rules
+
+Patterns that look like incidental code style but are actually invariants. Violating them breaks production feeders, breaks the drift-test, opens a security boundary, or leaks stale files on already-upgraded installs. Read before refactoring `update.sh` or extracting/adding lib modules.
+
+## The inline-fallback block
+
+Both `update.sh` (long block before `airplanes_enable_build_mode_from_args "$@"`) and `install.sh` (the `else` branch of the `install-update-common.sh` source-or-fallback at the top) carry an inline copy of helpers from `scripts/lib/install-update-common.sh`.
+
+**Why duplicated:** these two scripts are downloaded standalone via curl-pipe-bash. They need to self-bootstrap *before* the repo is on disk and *before* `source scripts/lib/install-update-common.sh` is possible. The fallback defines `airplanes_path`, `airplanes_init_paths`, `getGIT`, `revision`, etc. inline so the script can run from a single-file download.
+
+**Drift contract** — `test/test_inline_fallback_drift.bats` enforces that inline copies stay in sync with the lib. The actual rule: it compares **selected function bodies** between the inline fallback and `install-update-common.sh`, not whole blocks byte-for-byte. `install.sh`'s `airplanes_init_paths` is checked as a **subset** of the lib version (the inline copy intentionally omits paths only `update.sh` needs, like `BOOT_CONFIG`). Function bodies that exist in both must match exactly.
+
+**Don't:**
+
+- Don't "deduplicate" the block by deleting the inline copy.
+- Don't extract its functions into a new lib and skip the inline fallback.
+- Don't add new fallback functions unless a new bootstrap need genuinely exists; if you do, extend the drift test to cover them.
+
+## `AIRPLANES_FEED_BRANCH` release-channel mechanism
+
+In `update.sh`'s fallback block, the variable defaults via `/etc/airplanes/release-channel`:
+
+- `update.sh` reads that file to pin the runtime-update branch on image-built feeders. Allowlist is `{main, dev}`. Invalid value aborts (intentional — silent fallback to `main` on a `dev` image is a sticky regression).
+- An **explicit `AIRPLANES_FEED_BRANCH` env var bypasses the allowlist** — the env var wins. There's a corresponding test in `test_install_update_common.bats` that pins this.
+- **`install.sh`'s standalone fallback hardcodes `AIRPLANES_FEED_BRANCH=main`** and does NOT read the release-channel file. Only `update.sh` does. (Fine in practice: `install.sh` runs once at install time on a fresh box that has no release-channel marker yet.)
+
+## `scripts/lib/` extraction discipline
+
+Five rules observed across the shipped lib files. New libs follow them.
+
+1. **Functions take paths/values as positional arguments.** Don't read or mutate `update.sh`'s config-state globals (`USER`, `MLAT_USER`, `INPUT`, `TARGET`, etc.). Helper utilities from sourced libs (`getGIT`, `revision`, `airplanes_is_build_mode`, `is_unit_masked`, `heal_claim_state_ownership`) are fair game.
+2. **Each lib documents its helper deps at the top** ("must be in scope when sourced") so the source-order in `update.sh` stays explicit.
+3. **Idempotent leaf helpers + composer entry points.** Small `migrate_X` / `install_X` / `build_X` functions do one thing. `run_X` composers wire them together for callers that need ordered phases (see `update-migrations.sh`'s six `run_*` entry points).
+4. **Never `source` legacy config files inside helpers.** Sourcing executes arbitrary user-supplied shell content. `update.sh` sources `feed.env` itself — at the orchestrator boundary where the user-content risk is already accepted. Helpers do not.
+5. **Build steps run in subshells:** `( cd "$git_dir" || exit; … )`. The `|| exit` is required by shellcheck SC2164. The subshell prevents the `cd` from leaking to the caller. (Note: `install_mlat_client` has a subshell *inside an `if`-test* where set -e is suppressed and the bare `cd` happens to work — that special case doesn't generalize. New subshells use `|| exit`.)
+
+## `set -e` semantics for execution-path functions
+
+Functions whose contract is "abort the script on failure" — for example `build_readsb_feed_client` invoking `make` — must be invoked as plain commands from `update.sh`. Never `if fn; then …` and never `fn || …`. Bash suppresses `set -e` in the dynamic scope of any tested context (the test of an `if`, a `while`, the left side of `&&`/`||`, after `!`), and that suppression propagates into the called function. If the call sits in a tested context, the `set -e` abort never fires inside the function, even with `set -e` re-enabled there.
+
+This rule applies to **fail-loud build/install helpers**, not to predicate helpers (functions that intentionally return a boolean for use in conditionals — those are designed for tested contexts and work fine there).
+
+## Image vs non-image install branches
+
+`IMAGE_INSTALL` is set by `airplanes_is_image_install`. The two branches diverge on:
+
+- **Config source.** Image: `/boot/airplanes-config.txt` + `/boot/airplanes-env`. Manual install: `/etc/airplanes/feed.env`.
+- **Feed binary location.** Image ships a baked-in feed binary; manual installs build readsb from source.
+
+Build mode (`AIRPLANES_BUILD_MODE`) is **orthogonal** — it's "produce a rootfs" mode used by image-builder pipelines. In build mode there's no live systemd to call, no host processes to kill, no live network probes. Helpers that gate on systemd or host state must check `airplanes_is_build_mode` first.
+
+## Daemon runtime state files
+
+Daemons (`airplanes-feed`, `airplanes-mlat`) publish their config decision to `/run/<service>/state` at every activation. The state-writer side lives in `scripts/lib/state-writer.sh`; the reader side in `state-reader.sh`. Both libs are installed to `$IPATH/lib/` for daemon use.
+
+Format: `schema_version=1`, env-style `KEY=value` lines, atomic mktemp+rename so partial writes are never visible. Unit files declare `RuntimeDirectory=` + `RuntimeDirectoryPreserve=restart` so the file survives `Restart=always` cycles.
+
+**`MLAT_ENABLED` is checked before geo** in `airplanes-mlat.sh`'s state classifier — explicit disable wins over a 0/0 (unset coords) misconfiguration. The classifier produces `enabled` / `disabled` / `misconfigured`.
+
+**`update.sh` does NOT disable `airplanes-mlat` at the systemd level** based on config-derived disable. The unit stays enabled; the daemon self-disables via `sleep`+`exit`. User-visible: a `MLAT_ENABLED=false` feeder shows the unit as `enabled+active(sleeping)` rather than `disabled+inactive`. This keeps the daemon-owned state-file pattern coherent — future state consumers don't need to re-derive the predicate from `feed.env`.
+
+Daemons use a **defensive `source`** of the state-writer so a partial install (lib missing or unreadable) can't take the daemon down at startup.
+
+## The historical-ship manifest pattern
+
+There are three manifests, all defined as bash arrays at the call site in `update.sh`:
+
+- `historical_top_level_scripts` — names ever shipped from `scripts/` to `$IPATH`.
+- `historical_apl_feed_modules` — names ever shipped from `scripts/apl-feed/` to `$IPATH/apl-feed/`.
+- `historical_daemon_libs` — names ever shipped from `scripts/lib/` to `$IPATH/lib/` (i.e. libs that daemons source at runtime).
+
+The matching prune step in `update-migrations.sh:prune_installed_script_artifacts` removes any installed file whose source counterpart is now gone. Symmetric to the wildcard `cp` install (which only ADDs files, never removes).
+
+**Manifests are append-only by convention, not by enforcement.** `test/test_update_manifest.bats` verifies all currently-shipped files are listed AND has explicit retention tests for known-historical names (e.g. `second-mlat.sh`).
+
+**When deleting a shipped file:** keep its name in the manifest array AND add a new retention test in the same shape as the existing ones. Without that, future contributors might "tidy" the array and leak the stale file on already-upgraded feeders.
+
+## Daemon account
+
+User and group are both `airplanes-feed`. Renamed from the historical `airplanes` to avoid collisions with what users typically pick as their console/SSH login on a fresh image flash. The original `airplanes` user is intentionally **not** removed on upgrade — it may be referenced by user-supplied drop-ins or orphan units.
+
+The private `airplanes-feed` group exists so other service accounts can read claim-state files (mode 0640) without escalating to root. Membership grants read access to `/etc/airplanes/feeder-claim-secret`; only add service accounts that legitimately need to reveal claim secrets.
+
+`heal_claim_state_ownership` (in `claim-registration.sh`) fixes ownership on installs that pre-date the group-pivot; runs idempotently on every update.

--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -4,7 +4,7 @@ Feed commits follow the conventional-commits format. The workspace-wide `apl-wor
 
 ## Structure
 
-A commit message is structured as follows:
+A commit message shall be structured as follows:
 
 ```
 <type>[optional scope]: description
@@ -14,30 +14,23 @@ A commit message is structured as follows:
 [optional footer(s)]
 ```
 
-## Types
+## Structural elements
 
-A commit contains one of:
+A commit contains the following structural elements:
 
-1. **`fix:`** — patches a bug in the codebase (correlates with PATCH in semantic versioning).
-2. **`feat:`** — introduces a new feature to the codebase (correlates with MINOR).
-3. **Breaking change** — a commit that has a `BREAKING CHANGE:` footer, OR appends `!` after the type/scope, introduces a breaking change (correlates with MAJOR). The breaking marker can be applied to any type.
-4. Other types are allowed: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, etc.
+1. **`fix:`** — a commit of type `fix` patches a bug in the codebase (this correlates with `PATCH` in Semantic Versioning).
+2. **`feat:`** — a commit of the type `feat` introduces a new feature to the codebase (this correlates with `MINOR` in Semantic Versioning).
+3. **`BREAKING CHANGE:`** — a commit that has a footer `BREAKING CHANGE:`, or appends a `!` after the type/scope, introduces a breaking change (correlating with `MAJOR` in Semantic Versioning). A `BREAKING CHANGE` can be part of commits of any type.
+4. Types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+5. Footers other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to the git trailer format.
 
 ## Scope
 
-A scope may be provided to a commit's type, in parentheses, to give additional context:
-
-```
-feat(parser): add ability to parse arrays
-```
+A scope may be provided to a commit's type, to provide additional contextual information and is contained within parentheses, e.g., `feat(parser): add ability to parse arrays`.
 
 ## Body
 
-The body of a commit is a larger summary and **shall not exceed 256 characters**. It shall not reference any plan phases, or steps, when committed as part of task-driven development — those references rot the moment the plan is closed.
-
-## Footers
-
-Footers other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to the git trailer format.
+The body of a commit is a larger summary and shall not exceed 256 characters. It shall not reference any plan phases, or steps, when committed as part of task-driven development.
 
 ## Examples
 
@@ -49,5 +42,3 @@ test: cover REINSTALL=yes and missing-artifact rebuild paths
 chore!: drop bundled tar1090 installer
 docs(claude): add feed-specific orientation and rule files
 ```
-
-The format applies going forward. Existing commit history is mixed.

--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -1,0 +1,53 @@
+# Commit message format
+
+Feed commits follow the conventional-commits format. The workspace-wide `apl-workspace/.claude/rules/commit-and-pr.md` covers PR-body conventions; this file covers the commit-message format only.
+
+## Structure
+
+A commit message is structured as follows:
+
+```
+<type>[optional scope]: description
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Types
+
+A commit contains one of:
+
+1. **`fix:`** — patches a bug in the codebase (correlates with PATCH in semantic versioning).
+2. **`feat:`** — introduces a new feature to the codebase (correlates with MINOR).
+3. **Breaking change** — a commit that has a `BREAKING CHANGE:` footer, OR appends `!` after the type/scope, introduces a breaking change (correlates with MAJOR). The breaking marker can be applied to any type.
+4. Other types are allowed: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, etc.
+
+## Scope
+
+A scope may be provided to a commit's type, in parentheses, to give additional context:
+
+```
+feat(parser): add ability to parse arrays
+```
+
+## Body
+
+The body of a commit is a larger summary and **shall not exceed 256 characters**. It shall not reference any plan phases, or steps, when committed as part of task-driven development — those references rot the moment the plan is closed.
+
+## Footers
+
+Footers other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to the git trailer format.
+
+## Examples
+
+```
+feat(mlat): publish runtime state file to /run/airplanes-mlat
+fix(update): gate connectivity probes on command -v before nc/timeout
+refactor: extract mlat/readsb builds into scripts/lib/
+test: cover REINSTALL=yes and missing-artifact rebuild paths
+chore!: drop bundled tar1090 installer
+docs(claude): add feed-specific orientation and rule files
+```
+
+The format applies going forward. Existing commit history is mixed.

--- a/.claude/rules/preserved-behavior.md
+++ b/.claude/rules/preserved-behavior.md
@@ -1,0 +1,17 @@
+# Preserved behavior
+
+Places where the code looks wrong but is preserved verbatim because changing the behavior needs a deliberate conversation. Each entry has a regression test pinning it; the test will fail if the code is "tidied", and that's the signal to think rather than rewrite.
+
+## The mlat install command chain — `install_mlat_client` in `scripts/lib/update-builds.sh`
+
+The mixed `&& / ||` chain inside the `if` ends with:
+
+```
+…
+&& revision > "$ipath/mlat_version" || rm -f "$ipath/mlat_version" \
+&& echo 48
+```
+
+Because `rm -f` always returns 0, the chain *always* exits 0 — meaning the surrounding `if/then/else` always takes the success branch and the `else` (the "Installing mlat-client failed" message + venv-backup restore) is effectively unreachable through normal failures inside the chain (e.g. a `pip install .` that returns non-zero).
+
+Pinned by `test_update_builds.bats: install_mlat_client: pip failure is masked by chain (regression — preserve verbatim)`. Don't reorder, regroup, or simplify the chain. If you want to fix the masking so failures actually trigger the rollback, propose the behavior change explicitly in its own PR — it's a real bug, just not one to fix as a side effect of a refactor.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,89 @@
+# Testing rules
+
+How to write and run tests, and which test failures to ignore on a dev laptop.
+
+## Where tests live and how to run them
+
+Tests live in `feed/test/` (note: singular `test`, not `tests`). Framework: BATS.
+
+```
+bats test/                  # full suite
+bats test/test_X.bats       # one file
+```
+
+For Ubuntu parity on a macOS dev machine: run via the Docker image at `test/Dockerfile.apl-feed-test`, or install brew bash and use that interpreter when invoking bats.
+
+## Stub pattern
+
+Tests stub external commands via PATH manipulation plus a `COMMAND_LOG` file. Each test's `setup()`:
+
+1. Creates a temp `STUB_DIR`.
+2. Writes minimal shell scripts there that echo their argv into `COMMAND_LOG`.
+3. Prepends `STUB_DIR` to `PATH`.
+
+Assertions then `grep` `COMMAND_LOG` to check what was called and in what order. Look at `test/test_update_builds.bats` and `test/test_service_account.bats` for canonical examples.
+
+## Sourcing libs in tests
+
+Source order matters. In `setup()`:
+
+1. `install-update-common.sh` first (defines `getGIT`, `revision`, `airplanes_is_build_mode`).
+2. Any other libs the function-under-test depends on (e.g. `claim-registration.sh` for `heal_claim_state_ownership`).
+3. The lib defining the function under test.
+
+Override `getGIT`, `revision`, and similar helpers as bash functions **after** sourcing — that gives the test deterministic substitutes without needing a PATH stub.
+
+## Testing `set -e` abort behavior
+
+Non-obvious. Bash suppresses `set -e` in the dynamic scope of any tested context. Both of these patterns put the captured command in a tested context and silently disable `set -e` inside it:
+
+```
+run my_function …                    # bats's run captures into a tested context
+( set -e; my_function … ) || st=$?   # the `||` wraps the subshell as tested
+```
+
+Even with `set -e` re-enabled inside, the suppression propagates from the outer scope. To genuinely test "function X aborts under set -e when Y fails", run the function inside a fresh `bash -c` invocation:
+
+```
+run bash -c '
+set -e
+source "'"$COMMON_LIB"'"
+source "'"$LIB"'"
+getGIT() { return 1; }
+my_function …
+'
+[ "$status" -ne 0 ]
+```
+
+The fresh shell has its own dynamic scope; `set -e` there is genuinely active. Canonical pattern: see the `getGIT failure aborts` cases in `test/test_update_builds.bats`.
+
+## Test seams
+
+`update-builds.sh` exposes `${AIRPLANES_PYTHON_BIN:-/usr/bin/python3}` so the venv-creation step can be intercepted by a single python stub without needing PATH manipulation to override an absolute path. Apply the same shape to any new helper that hardcodes an absolute interpreter path — production behavior is unchanged when the env var isn't set.
+
+## macOS dev parity
+
+CI runs on `ubuntu-24.04`. Dev on macOS surfaces a recurring set of expected failures from GNU/Bash version differences. They are NOT regressions — but only ignore the categories listed below. A CI-green / macOS-red discrepancy in newly-written code outside these categories might still be a real bug.
+
+Known portability cases:
+
+- **GNU-only flags.** `stat -c '%a'` (BSD wants `stat -f '%A'`), `mv -fT` (BSD `mv` has no `-T`).
+- **Bash 4.3+ namerefs.** `local -n` / `declare -n`. macOS ships Bash 3.2; brew Bash 5.x works.
+- **`[[ … ]]` inside `#!/bin/sh` shebangs.** Works on macOS (sh is bash) but fails on Ubuntu (sh is dash). Use POSIX `[ … = … ]` in any test stub that uses a `#!/bin/sh` shebang, or switch the shebang to `#!/bin/bash`.
+- **Network-flaky paths.** `getGIT`'s wget archive fallback may fail on macOS depending on local DNS / ICMP behavior.
+
+Don't blanket-ignore. Default mental model: if a failing test on macOS doesn't fall into one of the above, treat it as a real signal until proven otherwise.
+
+## CI workflows
+
+All run on `ubuntu-24.04` host:
+
+- `bats` — full BATS suite.
+- `shellcheck + bash -n` — shellcheck at warning severity, plus bash syntax check.
+- `update-regression smoke` — `update.sh` regression run.
+- `installer smoke` × 4 — debian:13-slim and ubuntu:24.04, each in bundled (`install.sh`) and standalone (`update.sh` direct) modes.
+- `image rootfs smoke` and `image release rootfs smoke` — Docker rootfs builds.
+
+## The drift test
+
+`test_inline_fallback_drift.bats` is a contract — see `architecture.md` for the actual function-body comparison rules. It must always pass; CI will block any PR that lets the inline fallback drift from the lib version.


### PR DESCRIPTION
Adds project memory under feed/.claude/ so the repo's load-bearing conventions don't have to be re-derived every time someone opens an editor at this directory.

Six files: an orientation entry-point (CLAUDE.md), four rule files (architecture, testing, commit-guidelines, preserved-behavior), and a .gitignore that keeps .claude/worktrees/ out of accidental commits. The orientation covers the tree map and where to start for common tasks. The architecture rule documents the inline-fallback discipline, the release-channel mechanism, the scripts/lib extraction conventions, the daemon runtime state-file pattern, the historical-ship manifest pattern, and the airplanes-feed account history. The testing rule documents the BATS stub pattern, the set-e abort testing trick using bash -c, the AIRPLANES_PYTHON_BIN test seam, and the macOS portability inventory. commit-guidelines codifies conventional-commits format. preserved-behavior pins the one regression-tested verbatim quirk in the mlat install chain.

Pure documentation. No code changes.