### PR TITLE
ci: add legacy script upgrade regression smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,59 @@ jobs:
         with:
           name: update-regression-artifacts
           path: ${{ runner.temp }}/update-regression
+
+  legacy-upgrade-smoke:
+    name: legacy script upgrade smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout legacy (origin/main HEAD)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          path: legacy
+          persist-credentials: false
+
+      - name: Pin legacy branch label to main
+        run: |
+          current="$(git -C legacy rev-parse --abbrev-ref HEAD)"
+          if [[ "$current" != "main" ]]; then
+            git -C legacy branch -f main HEAD
+          fi
+
+      - name: Checkout candidate (PR / branch HEAD)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: candidate
+          persist-credentials: false
+
+      - name: Pin candidate branch label to dev
+        run: |
+          # Force-label the candidate as "dev" so update.sh's release-channel
+          # allowlist accepts it without env-var bypass — same trick the
+          # update-regression job uses.
+          current="$(git -C candidate rev-parse --abbrev-ref HEAD)"
+          if [[ "$current" != "dev" ]]; then
+            git -C candidate branch -f dev HEAD
+          fi
+
+      - name: Prepare diagnostics directory
+        run: mkdir -p "${{ runner.temp }}/legacy-upgrade-smoke"
+
+      - name: Run legacy upgrade smoke
+        run: |
+          docker run --rm \
+            -e AIRPLANES_LEGACY_REPO=file:///legacy \
+            -e AIRPLANES_CANDIDATE_REPO=file:///candidate \
+            -v "$PWD/legacy:/legacy:ro" \
+            -v "$PWD/candidate:/candidate:ro" \
+            -v "${{ runner.temp }}/legacy-upgrade-smoke:/tmp/legacy-upgrade-diag" \
+            debian:13-slim \
+            bash /candidate/test/legacy-upgrade-smoke.sh
+
+      - name: Upload diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: legacy-upgrade-smoke-diagnostics
+          path: ${{ runner.temp }}/legacy-upgrade-smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,14 +204,28 @@ jobs:
           path: ${{ runner.temp }}/update-regression
 
   legacy-upgrade-smoke:
-    name: legacy script upgrade smoke
+    name: legacy script upgrade smoke (${{ matrix.legacy.label }})
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        legacy:
+          # Tracking-main axis: catches regressions in the "current main →
+          # candidate" upgrade path as main moves. Becomes near-identity
+          # to the candidate after a dev→main merge.
+          - label: tracking main
+            ref: main
+          # Pinned pre-schema-split axis: hard regression coverage for
+          # feeders installed before MLAT_USER / MLAT_ENABLED split landed.
+          # Update this SHA only when retiring legacy coverage deliberately.
+          - label: pinned pre-schema-split
+            ref: 9318d02efd70488f831cbcb84ca3ec4cb9cc9ece
     steps:
-      - name: Checkout legacy (origin/main HEAD)
+      - name: Checkout legacy (${{ matrix.legacy.label }})
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: ${{ matrix.legacy.ref }}
           path: legacy
           persist-credentials: false
 

--- a/test/legacy-upgrade-smoke.sh
+++ b/test/legacy-upgrade-smoke.sh
@@ -34,7 +34,10 @@ trap on_exit EXIT
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y --no-install-recommends bash ca-certificates git python3
+# pkg-config is pre-installed on Raspberry Pi OS but absent from debian:13-slim;
+# legacy main's update.sh package list doesn't include it (dev's does), so
+# without this the readsb build fails to link ncurses on the legacy install.
+apt-get install -y --no-install-recommends bash ca-certificates git pkg-config python3
 git config --global --add safe.directory '*'
 
 install -d -m 0755 /usr/local/sbin
@@ -170,13 +173,18 @@ sed -i \
 } >> "$LEGACY_ENV"
 
 # ---- Phase 3: upgrade via candidate ----
-# The on-disk legacy update.sh self-fetches from the candidate repo, replaces
-# itself with the candidate version, and runs the new migration code. This is
-# the realistic upgrade path that real feeders take.
+# Realistic upgrade path. Legacy main's `update.sh` has no working in-place
+# self-replace (its condition `if diff "$GIT/update.sh" "$IPATH/update.sh"`
+# is satisfied only when files are *identical*, which is a no-op). Real
+# feeders upgrade by re-bootstrapping from the latest tree, so we invoke the
+# candidate's update.sh directly. The candidate's first action is to fetch
+# AIRPLANES_FEED_REPO/AIRPLANES_FEED_BRANCH into $IPATH/git and self-replace
+# $IPATH/update.sh — exercising candidate's full install path against the
+# legacy state Phases 1-2 left in place.
 echo "=== Phase 3: upgrade via candidate from $AIRPLANES_CANDIDATE_REPO ==="
 AIRPLANES_FEED_REPO="$AIRPLANES_CANDIDATE_REPO" \
 AIRPLANES_FEED_BRANCH=dev \
-    bash /usr/local/share/airplanes/git/update.sh
+    bash /candidate/update.sh
 
 # ---- Phase 4: enabled-USER assertions ----
 echo "=== Phase 4: assertions (enabled-USER migration) ==="
@@ -272,7 +280,12 @@ sed -i \
     /etc/airplanes/feed.env
 echo 'USER=0' >> /etc/airplanes/feed.env
 
-bash /usr/local/share/airplanes/git/update.sh
+# After Phase 3 self-replace, $IPATH/update.sh is the candidate version.
+# Pass the env vars explicitly so it doesn't fall back to the public main
+# branch (which would self-replace away from candidate).
+AIRPLANES_FEED_REPO="$AIRPLANES_CANDIDATE_REPO" \
+AIRPLANES_FEED_BRANCH=dev \
+    bash /usr/local/share/airplanes/git/update.sh
 
 env -i bash -c '
     set -euo pipefail

--- a/test/legacy-upgrade-smoke.sh
+++ b/test/legacy-upgrade-smoke.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AIRPLANES_LEGACY_REPO:?AIRPLANES_LEGACY_REPO is required}"
+: "${AIRPLANES_CANDIDATE_REPO:?AIRPLANES_CANDIDATE_REPO is required}"
+
+DIAG_DIR=/tmp/legacy-upgrade-diag
+mkdir -p "$DIAG_DIR"
+MOCK_PID=
+
+dump_diag() {
+    cp -a /etc/airplanes "$DIAG_DIR/etc-airplanes" 2>/dev/null || true
+    if [[ -e /etc/default/airplanes ]]; then
+        cp -a /etc/default/airplanes "$DIAG_DIR/etc-default-airplanes" 2>/dev/null || true
+    fi
+    cp /tmp/systemctl.log "$DIAG_DIR/systemctl.log" 2>/dev/null || true
+    cp /usr/local/share/airplanes/lastlog "$DIAG_DIR/lastlog" 2>/dev/null || true
+    cp -a /run/airplanes-feed "$DIAG_DIR/run-airplanes-feed" 2>/dev/null || true
+    cp -a /run/airplanes-mlat "$DIAG_DIR/run-airplanes-mlat" 2>/dev/null || true
+    git -C /usr/local/share/airplanes/git remote -v > "$DIAG_DIR/git-remote.txt" 2>&1 || true
+    git -C /usr/local/share/airplanes/git rev-parse HEAD > "$DIAG_DIR/git-head.txt" 2>&1 || true
+    ls -la /lib/systemd/system/ > "$DIAG_DIR/systemd-units.txt" 2>&1 || true
+}
+
+on_exit() {
+    local ec=$?
+    if [[ -n "$MOCK_PID" ]]; then
+        kill "$MOCK_PID" 2>/dev/null || true
+    fi
+    dump_diag
+    exit "$ec"
+}
+trap on_exit EXIT
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends bash ca-certificates git python3
+git config --global --add safe.directory '*'
+
+install -d -m 0755 /usr/local/sbin
+
+cat > /usr/local/sbin/whiptail <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+counter=/tmp/whiptail-counter
+if printf '%s\n' "$@" | grep -q -- '--inputbox'; then
+    n=0
+    [[ -f "$counter" ]] && n="$(cat "$counter")"
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$counter"
+    case "$n" in
+        1) printf '%s\n' "ci-feeder" >&2 ;;
+        2) printf '%s\n' "52.52000" >&2 ;;
+        3) printf '%s\n' "13.40500" >&2 ;;
+        *) printf '%s\n' "35m" >&2 ;;
+    esac
+fi
+exit 0
+SH
+chmod +x /usr/local/sbin/whiptail
+
+cat > /usr/local/sbin/systemctl <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'systemctl %s\n' "$*" >> /tmp/systemctl.log
+if [[ "${1:-}" == "is-enabled" ]]; then
+    printf '%s\n' disabled
+fi
+exit 0
+SH
+chmod +x /usr/local/sbin/systemctl
+
+cat > /usr/local/sbin/journalctl <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x /usr/local/sbin/journalctl
+
+cat > /usr/local/sbin/nc <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x /usr/local/sbin/nc
+
+python3 - <<'PY' &
+import http.server
+import json
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        if self.path != "/api/feeders/secret":
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"version": 1}).encode())
+
+    def log_message(self, *args):
+        pass
+
+server = http.server.HTTPServer(("127.0.0.1", 18080), Handler)
+server.serve_forever()
+PY
+MOCK_PID=$!
+
+ready=0
+for _ in $(seq 1 50); do
+    if python3 -c 'import urllib.request, sys
+try:
+    urllib.request.urlopen("http://127.0.0.1:18080/_probe", timeout=0.2)
+except urllib.error.HTTPError:
+    sys.exit(0)
+except Exception:
+    sys.exit(1)
+sys.exit(0)' 2>/dev/null; then
+        ready=1
+        break
+    fi
+    sleep 0.1
+done
+[[ "$ready" -eq 1 ]] || { echo "mock HTTP server did not become ready" >&2; exit 1; }
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export APL_FEED_SERVER_URL="http://127.0.0.1:18080"
+export APL_FEED_MAX_RETRY_TIME=5
+export AIRPLANES_PACKAGE_MANAGER=apt
+
+# ---- Phase 1: install legacy (origin/main HEAD) ----
+echo "=== Phase 1: install legacy from $AIRPLANES_LEGACY_REPO ==="
+AIRPLANES_FEED_REPO="$AIRPLANES_LEGACY_REPO" \
+AIRPLANES_FEED_BRANCH=main \
+    bash /legacy/install.sh
+
+# Post-install sanity (catch breakage in main itself).
+test -d /usr/local/share/airplanes/git
+test -x /usr/local/bin/apl-feed
+
+# ---- Phase 2: seed legacy USER= state ----
+# Force the migration code path: drop any MLAT_* keys the legacy install may
+# have written, leave a single legacy USER=. Detect whichever config file the
+# install actually produced — modern main writes /etc/airplanes/feed.env;
+# ancient main writes /etc/default/airplanes as a real file.
+detect_legacy_env() {
+    if [[ -f /etc/airplanes/feed.env && ! -L /etc/airplanes/feed.env ]]; then
+        echo /etc/airplanes/feed.env; return
+    fi
+    if [[ -f /etc/default/airplanes && ! -L /etc/default/airplanes ]]; then
+        echo /etc/default/airplanes; return
+    fi
+    echo /etc/airplanes/feed.env
+}
+LEGACY_ENV="$(detect_legacy_env)"
+echo "=== Phase 2: seed USER=ci-legacy-feeder into $LEGACY_ENV ==="
+mkdir -p "$(dirname "$LEGACY_ENV")"
+touch "$LEGACY_ENV"
+sed -i \
+    -e '/^MLAT_USER=/d' \
+    -e '/^MLAT_ENABLED=/d' \
+    -e '/^USER=/d' \
+    -e '/^LATITUDE=/d' \
+    -e '/^LONGITUDE=/d' \
+    "$LEGACY_ENV"
+{
+    echo 'USER=ci-legacy-feeder'
+    echo 'LATITUDE=52.52000'
+    echo 'LONGITUDE=13.40500'
+} >> "$LEGACY_ENV"
+
+# ---- Phase 3: upgrade via candidate ----
+# The on-disk legacy update.sh self-fetches from the candidate repo, replaces
+# itself with the candidate version, and runs the new migration code. This is
+# the realistic upgrade path that real feeders take.
+echo "=== Phase 3: upgrade via candidate from $AIRPLANES_CANDIDATE_REPO ==="
+AIRPLANES_FEED_REPO="$AIRPLANES_CANDIDATE_REPO" \
+AIRPLANES_FEED_BRANCH=dev \
+    bash /usr/local/share/airplanes/git/update.sh
+
+# ---- Phase 4: enabled-USER assertions ----
+echo "=== Phase 4: assertions (enabled-USER migration) ==="
+
+# 4A. MLAT schema migration
+test -f /etc/airplanes/feed.env
+
+env -i bash -c '
+    set -euo pipefail
+    # shellcheck disable=SC1091
+    source /etc/airplanes/feed.env
+    [[ "${MLAT_USER:-}"    == "ci-legacy-feeder" ]] || { echo "FAIL: MLAT_USER=${MLAT_USER:-<unset>}" >&2; exit 1; }
+    [[ "${MLAT_ENABLED:-}" == "true" ]]              || { echo "FAIL: MLAT_ENABLED=${MLAT_ENABLED:-<unset>}" >&2; exit 1; }
+'
+
+[[ "$(grep -c '^USER='        /etc/airplanes/feed.env || true)" -eq 0 ]] \
+    || { echo "FAIL: USER= line not removed from feed.env" >&2; exit 1; }
+[[ "$(grep -c '^MLAT_USER='     /etc/airplanes/feed.env)" -eq 1 ]] \
+    || { echo "FAIL: expected exactly one MLAT_USER= line" >&2; exit 1; }
+[[ "$(grep -c '^MLAT_ENABLED='  /etc/airplanes/feed.env)" -eq 1 ]] \
+    || { echo "FAIL: expected exactly one MLAT_ENABLED= line" >&2; exit 1; }
+
+# Modern shape: legacy file is now a symlink to feed.env
+if [[ -e /etc/default/airplanes ]]; then
+    [[ "$(readlink /etc/default/airplanes)" = "/etc/airplanes/feed.env" ]] \
+        || { echo "FAIL: /etc/default/airplanes is not a symlink to feed.env" >&2; exit 1; }
+fi
+
+# 4B. Wire-protocol contract
+env -i bash -c '
+    set -euo pipefail
+    # shellcheck disable=SC1091
+    source /etc/airplanes/feed.env
+    [[ "${TARGET:-}"     == *"feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"* ]] \
+        || { echo "FAIL: TARGET=${TARGET:-<unset>}" >&2; exit 1; }
+    [[ "${MLATSERVER:-}" == "feed.airplanes.live:31090" ]] \
+        || { echo "FAIL: MLATSERVER=${MLATSERVER:-<unset>}" >&2; exit 1; }
+'
+
+grep -q 'feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004' \
+    /usr/local/share/airplanes/airplanes-feed.sh \
+    || { echo "FAIL: image-default TARGET literal missing in installed airplanes-feed.sh" >&2; exit 1; }
+
+grep -rq '/api/feeders/secret' /usr/local/share/airplanes/ \
+    || { echo "FAIL: /api/feeders/secret reference missing" >&2; exit 1; }
+
+# 4C. Daemon state-file pattern
+# Snapshot feed.env so we can mutate it for the disabled subtest and restore.
+cp /etc/airplanes/feed.env /tmp/feed.env.snapshot
+
+# C.1 — airplanes-mlat in disabled state. Daemon does
+# `unset MLAT_ENABLED; source feed.env`, so write the value to the file rather
+# than passing inline env (which would be wiped by the unset).
+sed -i '/^MLAT_ENABLED=/d' /etc/airplanes/feed.env
+echo 'MLAT_ENABLED=false' >> /etc/airplanes/feed.env
+mkdir -p /run/airplanes-mlat
+timeout 3 bash /usr/local/share/airplanes/airplanes-mlat.sh || true
+
+[[ -f /run/airplanes-mlat/state ]] \
+    || { echo "FAIL: /run/airplanes-mlat/state not written" >&2; exit 1; }
+grep -q '^schema_version=1$'          /run/airplanes-mlat/state \
+    || { echo "FAIL: airplanes-mlat state missing schema_version=1" >&2; exit 1; }
+grep -q '^state=disabled$'            /run/airplanes-mlat/state \
+    || { echo "FAIL: airplanes-mlat state not 'disabled'" >&2; exit 1; }
+grep -q '^reason=mlat_enabled_false$' /run/airplanes-mlat/state \
+    || { echo "FAIL: airplanes-mlat reason not 'mlat_enabled_false' (classifier order regression?)" >&2; exit 1; }
+
+# Restore for C.2
+cp /tmp/feed.env.snapshot /etc/airplanes/feed.env
+
+# C.2 — airplanes-feed in enabled state. Stub the feed binary so exec succeeds
+# quickly and the script terminates (otherwise we'd block on a real binary).
+mkdir -p /run/airplanes-feed
+AIRPLANES_FEED_BIN=/bin/true \
+    timeout 3 bash /usr/local/share/airplanes/airplanes-feed.sh || true
+
+[[ -f /run/airplanes-feed/state ]] \
+    || { echo "FAIL: /run/airplanes-feed/state not written" >&2; exit 1; }
+grep -q '^schema_version=1$' /run/airplanes-feed/state \
+    || { echo "FAIL: airplanes-feed state missing schema_version=1" >&2; exit 1; }
+grep -q '^state=enabled$'    /run/airplanes-feed/state \
+    || { echo "FAIL: airplanes-feed state not 'enabled'" >&2; exit 1; }
+
+# ---- Phase 5: disabled-USER second subcase ----
+# A disabled legacy USER=0 must migrate to MLAT_USER="" + MLAT_ENABLED=false,
+# not MLAT_ENABLED=true with empty MLAT_USER (which would trip the daemon's
+# strict-fail exit-64 path).
+echo "=== Phase 5: assertions (disabled-USER migration, USER=0) ==="
+sed -i \
+    -e '/^MLAT_USER=/d' \
+    -e '/^MLAT_ENABLED=/d' \
+    -e '/^USER=/d' \
+    /etc/airplanes/feed.env
+echo 'USER=0' >> /etc/airplanes/feed.env
+
+bash /usr/local/share/airplanes/git/update.sh
+
+env -i bash -c '
+    set -euo pipefail
+    # shellcheck disable=SC1091
+    source /etc/airplanes/feed.env
+    [[ "${MLAT_ENABLED:-}" == "false" ]] \
+        || { echo "FAIL: USER=0 should yield MLAT_ENABLED=false, got ${MLAT_ENABLED:-<unset>}" >&2; exit 1; }
+    [[ -z "${MLAT_USER:-}" ]] \
+        || { echo "FAIL: USER=0 should yield empty MLAT_USER, got ${MLAT_USER}" >&2; exit 1; }
+'
+
+echo "=== Legacy upgrade smoke OK ==="

--- a/test/legacy-upgrade-smoke.sh
+++ b/test/legacy-upgrade-smoke.sh
@@ -137,9 +137,11 @@ AIRPLANES_FEED_REPO="$AIRPLANES_LEGACY_REPO" \
 AIRPLANES_FEED_BRANCH=main \
     bash /legacy/install.sh
 
-# Post-install sanity (catch breakage in main itself).
+# Post-install sanity. Only assert artifacts that legacy main is guaranteed
+# to produce — apl-feed CLI, feed.env-only layout, etc. are dev-branch
+# additions that predate this test. Phase 2's detect_legacy_env picks the
+# right config file regardless of which shape legacy produced.
 test -d /usr/local/share/airplanes/git
-test -x /usr/local/bin/apl-feed
 
 # ---- Phase 2: seed legacy USER= state ----
 # Force the migration code path: drop any MLAT_* keys the legacy install may

--- a/test/legacy-upgrade-smoke.sh
+++ b/test/legacy-upgrade-smoke.sh
@@ -131,11 +131,23 @@ export APL_FEED_SERVER_URL="http://127.0.0.1:18080"
 export APL_FEED_MAX_RETRY_TIME=5
 export AIRPLANES_PACKAGE_MANAGER=apt
 
-# ---- Phase 1: install legacy (origin/main HEAD) ----
+# ---- Phase 1: install legacy ----
+# Legacy main's install.sh AND update.sh both hardcode
+# REPO="https://github.com/airplanes-live/feed.git". A literal
+# `bash /legacy/install.sh` would re-fetch *public* main into $IPATH/git,
+# silently bypassing the SHA pinning of the /legacy mount. Mimic install.sh
+# (which is just mkdir + apt + clone + setup.sh) but seed $IPATH/git from
+# the mount, then redirect the in-update.sh re-fetch at the same mount so
+# the pin holds end-to-end.
 echo "=== Phase 1: install legacy from $AIRPLANES_LEGACY_REPO ==="
-AIRPLANES_FEED_REPO="$AIRPLANES_LEGACY_REPO" \
-AIRPLANES_FEED_BRANCH=main \
-    bash /legacy/install.sh
+mkdir -p /usr/local/share/airplanes
+git clone --branch main "$AIRPLANES_LEGACY_REPO" /usr/local/share/airplanes/git
+
+sed -i \
+    -e 's|^REPO=".*airplanes-live/feed\.git"$|REPO="'"$AIRPLANES_LEGACY_REPO"'"|' \
+    /usr/local/share/airplanes/git/update.sh
+
+bash /usr/local/share/airplanes/git/setup.sh
 
 # Post-install sanity. Only assert artifacts that legacy main is guaranteed
 # to produce — apl-feed CLI, feed.env-only layout, etc. are dev-branch

--- a/test/test_wire_endpoints.bats
+++ b/test/test_wire_endpoints.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# Fast-feedback regression net for wire-protocol literals. These endpoints
+# are the contract between feeders and the airplanes.live infrastructure;
+# changing one silently is how production fleets quietly stop reporting.
+# An accidental edit fails this test in ~30s, long before the legacy upgrade
+# smoke job would surface it. If a literal genuinely needs to change, update
+# this test in the same PR — that's the desired friction.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+}
+
+@test "configure.sh writes TARGET=feed.airplanes.live:30004 + feed2:64004 to feed.env" {
+    grep -qE '^TARGET="--net-connector feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004"$' \
+        "$REPO_ROOT/configure.sh"
+}
+
+@test "configure.sh writes MLATSERVER=feed.airplanes.live:31090 to feed.env" {
+    grep -qE '^MLATSERVER="feed\.airplanes\.live:31090"$' "$REPO_ROOT/configure.sh"
+}
+
+@test "airplanes-feed.sh image-default TARGET embeds feed.airplanes.live:30004 + feed2:64004" {
+    grep -q 'feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004' \
+        "$REPO_ROOT/scripts/airplanes-feed.sh"
+}
+
+@test "claim CLI posts to /api/feeders/secret" {
+    grep -q "/api/feeders/secret" "$REPO_ROOT/scripts/apl-feed/claim.sh"
+}


### PR DESCRIPTION
Adds a CI job that exercises the script-installed-main → dev upgrade path inside a debian:13-slim container — install.sh from current main, then update.sh from the candidate code, with a seeded USER= forcing the migration code path. Asserts the MLAT_USER + MLAT_ENABLED split, that wire-protocol endpoints survive the upgrade, and that the daemons write the expected /run/<service>/state on startup.

Also adds a small BATS file that greps the wire-endpoint literals (TARGET, MLATSERVER, claim API URL) so accidental endpoint drift fails in ~30s rather than after the full smoke job. Migration logic itself is covered by test/test_migrations.bats; the smoke complements that with end-to-end coverage through the live container.
