### PR TITLE
refactor(mlat): retire PRIVACY+MLAT_MARKER for canonical MLAT_PRIVATE

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -92,6 +92,11 @@ REDUCE_INTERVAL="0.5"
 MLAT_USER="$MLAT_USER"
 # Explicit on/off toggle for MLAT. When false, airplanes-mlat exits early.
 MLAT_ENABLED="$MLAT_ENABLED"
+# Hide the feed name on the public MLAT map. true|false. Position is
+# never shown accurately no matter the setting. Toggle after setup with:
+#   sudo apl-feed mlat private enable
+#   sudo apl-feed mlat private disable
+MLAT_PRIVATE=$MLAT_PRIVATE
 
 LATITUDE="$RECEIVERLATITUDE"
 LONGITUDE="$RECEIVERLONGITUDE"
@@ -106,9 +111,6 @@ RESULTS="--results beast,connect,127.0.0.1:30104"
 RESULTS2="--results basestation,listen,31015"
 RESULTS3="--results beast,listen,30157"
 RESULTS4="--results beast,connect,127.0.0.1:30187"
-# add --privacy between the quotes below to disable having the feed name shown on the mlat map
-# (position is never shown accurately no matter the settings)
-PRIVACY=""
 INPUT_TYPE="$INPUT_TYPE"
 
 MLATSERVER="feed.airplanes.live:31090"
@@ -119,7 +121,7 @@ EOF
 }
 
 has_noninteractive_config_env() {
-    [[ -v AIRPLANES_MLAT_USER || -v AIRPLANES_MLAT_ENABLED \
+    [[ -v AIRPLANES_MLAT_USER || -v AIRPLANES_MLAT_ENABLED || -v AIRPLANES_MLAT_PRIVATE \
        || -v AIRPLANES_LATITUDE || -v AIRPLANES_LONGITUDE || -v AIRPLANES_ALTITUDE ]]
 }
 
@@ -145,6 +147,16 @@ configure_noninteractive() {
         true|false) MLAT_ENABLED="${AIRPLANES_MLAT_ENABLED:-true}" ;;
         *)
             echo "AIRPLANES_MLAT_ENABLED must be 'true' or 'false' (got: '${AIRPLANES_MLAT_ENABLED:-}')" >&2
+            exit 1
+            ;;
+    esac
+
+    # MLAT_PRIVATE is optional and defaults to "false" (name shown on
+    # the MLAT map). Same strict true|false validation as MLAT_ENABLED.
+    case "${AIRPLANES_MLAT_PRIVATE:-false}" in
+        true|false) MLAT_PRIVATE="${AIRPLANES_MLAT_PRIVATE:-false}" ;;
+        *)
+            echo "AIRPLANES_MLAT_PRIVATE must be 'true' or 'false' (got: '${AIRPLANES_MLAT_PRIVATE:-}')" >&2
             exit 1
             ;;
     esac
@@ -223,9 +235,12 @@ RECEIVERALTITUDE="$ALT"
 
 #RECEIVERPORT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Receiver Feed Port" --nocancel --inputbox "\nChange only if you were assigned a custom feed port.\nFor most all users it is required this port remain set to port 30005." 10 78 "30005" 3>&1 1>&2 2>&3)
 
-# Interactive setup always enables MLAT. Operators who want it off run
-# `sudo apl-feed mlat disable` after setup completes.
+# Interactive setup always enables MLAT and shows the feeder name on the
+# map. Operators who want either off run, after setup completes:
+#   sudo apl-feed mlat disable
+#   sudo apl-feed mlat private enable
 MLAT_ENABLED="true"
+MLAT_PRIVATE="false"
 
 detect_receiver_input
 write_feed_env

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -15,10 +15,12 @@ BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
 FEED_ENV="$(airplanes_path /etc/airplanes/feed.env)"
 FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
 
-# Unset USER (and the new keys) before sourcing so the process env's $USER
-# (systemd User= sets it to airplanes-feed) can't be mistaken for a legacy
-# boot-config key.
-unset USER MLAT_USER MLAT_ENABLED
+# Unset USER (and the privacy keys) before sourcing so the process env
+# can't bleed into the legacy-USER, legacy-PRIVACY, or legacy-MLAT_MARKER
+# fallbacks below. systemd's User= sets $USER for airplanes-mlat.service;
+# an env-supplied MLAT_PRIVATE / PRIVACY / MLAT_MARKER (e.g. from a
+# Drop-In) would otherwise mask the on-disk value.
+unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
 if [[ -f "$FEED_ENV" ]]; then
     source "$FEED_ENV"
 elif [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && -f "$BOOT_CONFIG" ]]; then
@@ -41,13 +43,31 @@ fi
 MLAT_ENABLED="${MLAT_ENABLED:-true}"
 MLAT_USER="${MLAT_USER-}"
 
-if [[ "${MLAT_MARKER:-}" == "no" ]]; then
-    PRIVACY="--privacy"
-elif [[ -n "${MLAT_MARKER:-}" ]]; then
-    PRIVACY=""
-else
-    PRIVACY="${PRIVACY:-}"
+# Legacy PRIVACY read fallback. update.sh's migrate_privacy_to_mlat_private
+# converts PRIVACY=--privacy to MLAT_PRIVATE=true on every run; this in-
+# memory derivation handles a daemon restart that races ahead of the next
+# update.sh. Validation of MLAT_PRIVATE happens in the classifier below
+# so an invalid hand-edit fails loud.
+if [[ ! -v MLAT_PRIVATE && -v PRIVACY ]]; then
+    case "$PRIVACY" in
+        --privacy) MLAT_PRIVATE="true" ;;
+        *)         MLAT_PRIVATE="false" ;;
+    esac
 fi
+
+# Legacy MLAT_MARKER read fallback. PHP webconfig still writes MLAT_MARKER
+# in /boot/airplanes-config.txt via its yes/no dropdown — inverted polarity
+# where "no" means privacy ON. Without this fallback a legacy-image feeder
+# would silently lose privacy on first daemon start under the new schema,
+# even though their stored preference says "private". The webconfig-side
+# migrator translation closes the window on the next save/update.
+if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
+    case "$MLAT_MARKER" in
+        no) MLAT_PRIVATE="true" ;;
+        *)  MLAT_PRIVATE="false" ;;
+    esac
+fi
+MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 
 UUID_FILE="--uuid-file $FEEDER_ID_FILE"
 
@@ -61,13 +81,18 @@ else
     airplanes_write_state() { return 0; }
 fi
 
-# Classify the daemon's config decision. Order matters: explicit
-# MLAT_ENABLED disable is checked before geo so a user who turns MLAT
-# off on a fresh feeder (lat/lon still 0) sees reason=mlat_enabled_false
-# rather than reason=latitude_zero. The misconfigured branch only
-# triggers when the user opted INTO MLAT but left MLAT_USER empty —
-# that's the strict-fail-with-exit-64 shape.
+# Classify the daemon's config decision. Order matters: invalid
+# MLAT_PRIVATE is checked first (fail-loud rather than silently
+# defaulting), then explicit MLAT_ENABLED disable (so a user who turns
+# MLAT off on a fresh feeder with lat/lon still 0 sees reason=
+# mlat_enabled_false rather than reason=latitude_zero), then geo
+# sentinels, then the empty-MLAT_USER check. The misconfigured branch
+# is the strict-fail-with-exit-64 shape.
 _mlat_classify() {
+    case "$MLAT_PRIVATE" in
+        true|false) ;;
+        *) printf 'misconfigured mlat_private_invalid\n'; return ;;
+    esac
     if [[ "$MLAT_ENABLED" != "true" ]]; then printf 'disabled mlat_enabled_false\n'; return; fi
     if [[ "$LATITUDE" == 0 ]]; then printf 'disabled latitude_zero\n'; return; fi
     if [[ "$LONGITUDE" == 0 ]]; then printf 'disabled longitude_zero\n'; return; fi
@@ -85,6 +110,7 @@ airplanes_write_state "$STATE_FILE" \
     "decided_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     "mlat_enabled=${MLAT_ENABLED:-}" \
     "mlat_user=${MLAT_USER:-}" \
+    "mlat_private=${MLAT_PRIVATE:-}" \
     "latitude=${LATITUDE:-}" \
     "longitude=${LONGITUDE:-}" || true
 
@@ -97,12 +123,31 @@ case "$STATE" in
     misconfigured)
         # Matches RestartPreventExitStatus=64 in the unit file so
         # systemd marks the unit failed instead of restart-looping.
-        echo "MLAT_ENABLED=true but MLAT_USER is empty; refusing to start mlat-client." >&2
+        case "$REASON" in
+            mlat_private_invalid)
+                echo "MLAT_PRIVATE must be 'true' or 'false' (got: '${MLAT_PRIVATE:-}'); refusing to start mlat-client." >&2
+                ;;
+            mlat_user_empty)
+                echo "MLAT_ENABLED=true but MLAT_USER is empty; refusing to start mlat-client." >&2
+                ;;
+            *)
+                echo "Misconfigured ($REASON); refusing to start mlat-client." >&2
+                ;;
+        esac
         exit 64
         ;;
     enabled)
         ;;
 esac
+
+# Build the mlat-client privacy flag from the canonical boolean. The
+# literal --privacy flag string never appears on disk anywhere; storing
+# CLI fragments in feed.env was the legacy PRIVACY pattern this refactor
+# retired.
+PRIVACY_ARG=""
+if [[ "$MLAT_PRIVATE" == "true" ]]; then
+    PRIVACY_ARG="--privacy"
+fi
 
 INPUT_IP=$(echo $INPUT | cut -d: -f1)
 INPUT_PORT=$(echo $INPUT | cut -d: -f2)
@@ -122,6 +167,6 @@ exec "$(airplanes_path /usr/local/share/airplanes/venv/bin/mlat-client)" \
     --lat "$LATITUDE" \
     --lon "$LONGITUDE" \
     --alt "$ALTITUDE" \
-    $PRIVACY \
+    $PRIVACY_ARG \
     ${UUID_FILE:-} \
     $RESULTS $RESULTS1 $RESULTS2 $RESULTS3 $RESULTS4

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -37,6 +37,8 @@ Usage:
   apl-feed id set [--force]
   apl-feed mlat enable
   apl-feed mlat disable
+  apl-feed mlat private enable
+  apl-feed mlat private disable
   apl-feed backup <file>
   apl-feed restore <file>
   apl-feed restore --check <file>

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -133,13 +133,98 @@ apl_feed_mlat_enable() {
     fi
 }
 
+# Atomic single-key rewrite for MLAT_PRIVATE. Targeted (not generalized
+# to arbitrary keys) so the `grep -vE` pattern stays a fixed literal and
+# the boolean serializer (no shell-escape rules needed for true|false)
+# stays distinct from MLAT_USER's escape rules.
+#
+# Refuses to write into a feed.env that hasn't yet been touched by
+# update.sh's migrate_privacy_to_mlat_private — silently inserting
+# MLAT_PRIVATE alongside legacy PRIVACY would cross update-migrations.sh's
+# responsibility and produce a confusing mid-state.
+_mlat_rewrite_feed_env_private() {
+    local feed_env="$1"
+    local new_value="$2"
+
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+
+    if ! grep -qE '^MLAT_PRIVATE=' "$feed_env"; then
+        die "feed.env at $feed_env appears unmigrated (no MLAT_PRIVATE= line); run \`sudo /usr/local/share/airplanes/update.sh\` first"
+    fi
+
+    local tmp
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    grep -vE '^MLAT_PRIVATE=' "$feed_env" > "$tmp" || true
+    printf 'MLAT_PRIVATE=%s\n' "$new_value" >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
+apl_feed_mlat_private_enable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for mlat private enable: $1" ;;
+        esac
+    done
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    _mlat_rewrite_feed_env_private "$feed_env" "true"
+    echo "MLAT_PRIVATE set to true in $feed_env (feed name will be hidden on the public MLAT map)"
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done"
+    else
+        return 1
+    fi
+}
+
+apl_feed_mlat_private_disable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for mlat private disable: $1" ;;
+        esac
+    done
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    _mlat_rewrite_feed_env_private "$feed_env" "false"
+    echo "MLAT_PRIVATE set to false in $feed_env (feed name will be shown on the public MLAT map)"
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done"
+    else
+        return 1
+    fi
+}
+
+dispatch_mlat_private() {
+    local sub="${1:-}"
+    [[ -n "$sub" ]] || die "mlat private requires a subcommand (enable|disable)"
+    shift || true
+    case "$sub" in
+        enable)  apl_feed_mlat_private_enable  "$@" ;;
+        disable) apl_feed_mlat_private_disable "$@" ;;
+        -h|--help) usage ;;
+        *) die "unknown mlat private subcommand: $sub" ;;
+    esac
+}
+
 dispatch_mlat() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable)"
+    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable|private)"
     shift || true
     case "$sub" in
         enable)  apl_feed_mlat_enable  "$@" ;;
         disable) apl_feed_mlat_disable "$@" ;;
+        private) dispatch_mlat_private "$@" ;;
         -h|--help) usage ;;
         *) die "unknown mlat subcommand: $sub" ;;
     esac

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -270,8 +270,28 @@ _render_mlat_misconfig_reason() {
     local reason="$1"
     local label="MLAT service"
     case "$reason" in
-        mlat_user_empty) status_line fail "$label" "MLAT_USER is empty (set MLAT_USER, or set MLAT_ENABLED=false)" ;;
-        *)               status_line fail "$label" "misconfigured ($reason)" ;;
+        mlat_user_empty)      status_line fail "$label" "MLAT_USER is empty (set MLAT_USER, or set MLAT_ENABLED=false)" ;;
+        mlat_private_invalid) status_line fail "$label" "MLAT_PRIVATE must be 'true' or 'false' in feed.env" ;;
+        *)                    status_line fail "$label" "misconfigured ($reason)" ;;
+    esac
+}
+
+# Read the daemon's published privacy posture from /run/airplanes-mlat/state.
+# Daemon-state-file rule: never fall back to feed.env. If the state file
+# is unavailable (daemon down, partial install) we emit no privacy line
+# at all rather than re-deriving — mlat_status_line already covers the
+# "daemon down" actionable signal.
+mlat_privacy_status_line() {
+    local state_file mlat_private
+    state_file="$(root_path /run/airplanes-mlat/state)"
+    if ! mlat_private="$(airplanes_read_state "$state_file" mlat_private)"; then
+        return 0
+    fi
+    case "$mlat_private" in
+        true)  status_line ok "MLAT name privacy" "private (--privacy; name hidden on map)" ;;
+        false) status_line ok "MLAT name privacy" "public (name shown on map)" ;;
+        '')    return 0 ;;
+        *)     status_line warn "MLAT name privacy" "unknown value: $mlat_private" ;;
     esac
 }
 
@@ -456,6 +476,7 @@ feed_status() {
     fi
     service_status_line airplanes-feed "Feed service"
     mlat_status_line
+    mlat_privacy_status_line
     receiver_status_line
     airplanes_link_status_line
     claim_registration_status_line

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -252,12 +252,74 @@ _extract_env_value() {
     printf '%s' "$raw"
 }
 
+# Convert legacy PRIVACY (CLI-flag-as-storage from the upstream ADS-B
+# Exchange installer) into MLAT_PRIVATE=true|false. Idempotent.
+#
+#   PRIVACY=--privacy   →  MLAT_PRIVATE=true
+#   PRIVACY=""          →  MLAT_PRIVATE=false
+#   PRIVACY absent      →  MLAT_PRIVATE=false (defaulted, no PRIVACY to strip)
+#
+# Conflict rule: when both PRIVACY and MLAT_PRIVATE are present, canonical
+# MLAT_PRIVATE wins and PRIVACY is stripped. (Diverges from migrate_user_to_mlat_split's
+# legacy-reappearance re-derivation: there's no observed legacy PRIVACY
+# writer outside this repo today, so we don't loop a webconfig race.)
+#
+# Backup at $feed_env.pre-privacy-split is the rollback path; written
+# exactly once and never overwritten.
+migrate_privacy_to_mlat_private() {
+    local feed_env="$1"
+    [[ -f "$feed_env" ]] || return 0
+
+    local has_privacy=0 has_mlat_private=0
+    grep -qE '^PRIVACY=' "$feed_env" && has_privacy=1
+    grep -qE '^MLAT_PRIVATE=' "$feed_env" && has_mlat_private=1
+
+    if [[ "$has_privacy" == "0" && "$has_mlat_private" == "1" ]]; then
+        return 0
+    fi
+
+    local mlat_private
+    if [[ "$has_mlat_private" == "1" ]]; then
+        mlat_private="$(_extract_env_value "$feed_env" MLAT_PRIVATE)"
+    elif [[ "$has_privacy" == "1" ]]; then
+        local privacy_value
+        privacy_value="$(_extract_env_value "$feed_env" PRIVACY)"
+        # Trim leading/trailing whitespace; tolerate hand-edits like
+        # `PRIVACY=" --privacy "` and `PRIVACY=--privacy`.
+        privacy_value="${privacy_value#"${privacy_value%%[![:space:]]*}"}"
+        privacy_value="${privacy_value%"${privacy_value##*[![:space:]]}"}"
+        case "$privacy_value" in
+            --privacy) mlat_private="true" ;;
+            *)         mlat_private="false" ;;
+        esac
+    else
+        mlat_private="false"
+    fi
+
+    if [[ "$has_privacy" == "1" || "$has_mlat_private" == "0" ]]; then
+        local backup="${feed_env}.pre-privacy-split"
+        if [[ ! -f "$backup" ]]; then
+            cp -fp "$feed_env" "$backup"
+        fi
+
+        local tmp
+        tmp="$(mktemp "${feed_env}.XXXXXX")"
+        # Same `grep -v` exit-1 handling as migrate_user_to_mlat_split.
+        grep -vE '^(PRIVACY|MLAT_PRIVATE)=' "$feed_env" > "$tmp" || true
+        printf 'MLAT_PRIVATE=%s\n' "$mlat_private" >> "$tmp"
+        chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+        chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+        mv -f "$tmp" "$feed_env"
+    fi
+}
+
 run_config_file_migrations() {
     local feed_env="$1"
     migrate_net_options_beast_reduce_plus "$feed_env"
     migrate_target_fallback_host "$feed_env"
     migrate_strip_uuid_file_arg "$feed_env"
     migrate_user_to_mlat_split "$feed_env"
+    migrate_privacy_to_mlat_private "$feed_env"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -252,17 +252,23 @@ _extract_env_value() {
     printf '%s' "$raw"
 }
 
-# Convert legacy PRIVACY (CLI-flag-as-storage from the upstream ADS-B
-# Exchange installer) into MLAT_PRIVATE=true|false. Idempotent.
+# Convert legacy PRIVACY / MLAT_MARKER into canonical MLAT_PRIVATE=true|false.
+# Idempotent.
 #
 #   PRIVACY=--privacy   →  MLAT_PRIVATE=true
 #   PRIVACY=""          →  MLAT_PRIVATE=false
-#   PRIVACY absent      →  MLAT_PRIVATE=false (defaulted, no PRIVACY to strip)
+#   MLAT_MARKER=no      →  MLAT_PRIVATE=true   (inverted polarity: "no" = privacy ON)
+#   MLAT_MARKER=<else>  →  MLAT_PRIVATE=false
+#   all three absent    →  MLAT_PRIVATE=false (defaulted, no legacy keys to strip)
 #
-# Conflict rule: when both PRIVACY and MLAT_PRIVATE are present, canonical
-# MLAT_PRIVATE wins and PRIVACY is stripped. (Diverges from migrate_user_to_mlat_split's
-# legacy-reappearance re-derivation: there's no observed legacy PRIVACY
-# writer outside this repo today, so we don't loop a webconfig race.)
+# Precedence when multiple sources are present:
+#   1. canonical MLAT_PRIVATE wins
+#   2. then PRIVACY (manual-install legacy CLI fragment, the more deliberate
+#      hand-edit signal)
+#   3. then MLAT_MARKER (PHP webconfig's still-shipping yes/no dropdown)
+#
+# Both PRIVACY and MLAT_MARKER are stripped on write so the canonical form
+# is the only privacy key on disk after migration.
 #
 # Backup at $feed_env.pre-privacy-split is the rollback path; written
 # exactly once and never overwritten.
@@ -270,11 +276,13 @@ migrate_privacy_to_mlat_private() {
     local feed_env="$1"
     [[ -f "$feed_env" ]] || return 0
 
-    local has_privacy=0 has_mlat_private=0
+    local has_privacy=0 has_mlat_private=0 has_marker=0
     grep -qE '^PRIVACY=' "$feed_env" && has_privacy=1
     grep -qE '^MLAT_PRIVATE=' "$feed_env" && has_mlat_private=1
+    grep -qE '^MLAT_MARKER=' "$feed_env" && has_marker=1
 
-    if [[ "$has_privacy" == "0" && "$has_mlat_private" == "1" ]]; then
+    # No-op when only canonical MLAT_PRIVATE is present (no stripping needed).
+    if [[ "$has_privacy" == "0" && "$has_marker" == "0" && "$has_mlat_private" == "1" ]]; then
         return 0
     fi
 
@@ -292,11 +300,20 @@ migrate_privacy_to_mlat_private() {
             --privacy) mlat_private="true" ;;
             *)         mlat_private="false" ;;
         esac
+    elif [[ "$has_marker" == "1" ]]; then
+        local marker_value
+        marker_value="$(_extract_env_value "$feed_env" MLAT_MARKER)"
+        marker_value="${marker_value#"${marker_value%%[![:space:]]*}"}"
+        marker_value="${marker_value%"${marker_value##*[![:space:]]}"}"
+        case "$marker_value" in
+            no) mlat_private="true" ;;
+            *)  mlat_private="false" ;;
+        esac
     else
         mlat_private="false"
     fi
 
-    if [[ "$has_privacy" == "1" || "$has_mlat_private" == "0" ]]; then
+    if [[ "$has_privacy" == "1" || "$has_marker" == "1" || "$has_mlat_private" == "0" ]]; then
         local backup="${feed_env}.pre-privacy-split"
         if [[ ! -f "$backup" ]]; then
             cp -fp "$feed_env" "$backup"
@@ -305,7 +322,7 @@ migrate_privacy_to_mlat_private() {
         local tmp
         tmp="$(mktemp "${feed_env}.XXXXXX")"
         # Same `grep -v` exit-1 handling as migrate_user_to_mlat_split.
-        grep -vE '^(PRIVACY|MLAT_PRIVATE)=' "$feed_env" > "$tmp" || true
+        grep -vE '^(PRIVACY|MLAT_PRIVATE|MLAT_MARKER)=' "$feed_env" > "$tmp" || true
         printf 'MLAT_PRIVATE=%s\n' "$mlat_private" >> "$tmp"
         chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
         chown --reference="$feed_env" "$tmp" 2>/dev/null || true

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -43,6 +43,19 @@ write_feed_env() {
 INPUT="127.0.0.1:30005"
 MLAT_USER="$1"
 MLAT_ENABLED=$2
+MLAT_PRIVATE=false
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+EOF
+}
+
+write_feed_env_with_private() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="$1"
+MLAT_ENABLED=$2
+MLAT_PRIVATE=$3
 LATITUDE="52.52"
 LONGITUDE="13.40"
 ALTITUDE="35m"
@@ -210,4 +223,134 @@ EOF
     grep -q '^MLAT_ENABLED=false$' "$ROOT_DIR/etc/airplanes/feed.env"
     [ ! -f "$SYSTEMCTL_LOG" ] || ! grep -q 'restart' "$SYSTEMCTL_LOG"
     [[ "$output" == *"--root=$ROOT_DIR"* ]]
+}
+
+# --- mlat private subcommand ---
+
+@test "dispatch_mlat private: missing subcommand dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/mlat.sh'
+        dispatch_mlat private
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'mlat private requires a subcommand'* ]]
+}
+
+@test "dispatch_mlat private: unknown subcommand dies" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/mlat.sh'
+        dispatch_mlat private frobnitz
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unknown mlat private subcommand: frobnitz'* ]]
+}
+
+@test "private enable flips MLAT_PRIVATE false→true, preserves other keys, restarts service" {
+    write_feed_env_with_private "alice" "true" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_private_enable
+
+    [ "$status" -eq 0 ]
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_USER="alice"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_ENABLED=true' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
+}
+
+@test "private disable flips MLAT_PRIVATE true→false, preserves other keys" {
+    write_feed_env_with_private "alice" "true" "true"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_private_disable
+
+    [ "$status" -eq 0 ]
+    grep -qx 'MLAT_PRIVATE=false' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_USER="alice"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_ENABLED=true' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "private round-trip enable→disable→enable returns to true" {
+    write_feed_env_with_private "alice" "true" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_private_enable
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+
+    apl_feed_mlat_private_disable
+    grep -qx 'MLAT_PRIVATE=false' "$ROOT_DIR/etc/airplanes/feed.env"
+
+    apl_feed_mlat_private_enable
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "private enable: missing feed.env dies with documented message" {
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+
+    run apl_feed_mlat_private_enable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'feed.env not found'* ]]
+    [[ "$output" == *'run setup first'* ]]
+}
+
+@test "private enable: unmigrated feed.env (PRIVACY= without MLAT_PRIVATE=) dies" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+PRIVACY="--privacy"
+LATITUDE="52.52"
+EOF
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_private_disable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unmigrated'* ]]
+    [[ "$output" == *'no MLAT_PRIVATE='* ]]
+    [[ "$output" == *'/usr/local/share/airplanes/update.sh'* ]]
+}
+
+@test "private enable: rewrite leaves no duplicate MLAT_PRIVATE lines" {
+    write_feed_env_with_private "alice" "true" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_private_enable
+    apl_feed_mlat_private_enable
+
+    [ "$(grep -c '^MLAT_PRIVATE=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 1 ]
+}
+
+@test "private enable under AIRPLANES_BUILD_MODE=1 skips restart, edits file" {
+    write_feed_env_with_private "alice" "true" "false"
+    ROOT="/"
+    AIRPLANES_BUILD_MODE=1
+    export AIRPLANES_BUILD_MODE
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_private_enable
+
+    [ "$status" -eq 0 ]
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ ! -f "$SYSTEMCTL_LOG" ] || ! grep -q 'restart' "$SYSTEMCTL_LOG"
+    [[ "$output" == *'AIRPLANES_BUILD_MODE'* ]]
 }

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -223,15 +223,19 @@ STUB
 
 # Helper: write a state file under the test root for the MLAT daemon.
 write_mlat_state() {
-    # write_mlat_state <decision> <reason>
+    # write_mlat_state <decision> <reason> [<mlat_private>]
     local decision="$1"
     local reason="$2"
+    local mlat_private="${3:-}"
     mkdir -p "$ROOT_DIR/run/airplanes-mlat"
     {
         printf 'schema_version=1\n'
         printf 'service=airplanes-mlat\n'
         printf 'state=%s\n' "$decision"
         printf 'reason=%s\n' "$reason"
+        if [[ -n "$mlat_private" ]]; then
+            printf 'mlat_private=%s\n' "$mlat_private"
+        fi
     } > "$ROOT_DIR/run/airplanes-mlat/state"
 }
 
@@ -307,6 +311,16 @@ STUB
     [[ "$output" == *'FIX'* ]]
     [[ "$output" == *'MLAT_USER is empty'* ]]
     [[ "$output" == *'set MLAT_ENABLED=false'* ]]
+}
+
+@test "mlat_status_line: ActiveState=failed + exit 64 + misconfigured mlat_private_invalid → actionable" {
+    write_mlat_state misconfigured mlat_private_invalid
+    stub_systemctl_active_state failed 64
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *"MLAT_PRIVATE must be 'true' or 'false'"* ]]
 }
 
 @test "mlat_status_line: ActiveState=activating + enabled → 'starting up'" {
@@ -422,6 +436,60 @@ STUB
     run mlat_status_line
     [ "$status" -eq 0 ]
     [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
+}
+
+# --- mlat_privacy_status_line: state-file-driven privacy posture ---
+
+@test "mlat_privacy_status_line: mlat_private=true → OK 'private' line" {
+    write_mlat_state enabled ok true
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_privacy_status_line
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'MLAT name privacy'* ]]
+    [[ "$output" == *'private'* ]]
+    [[ "$output" == *'name hidden'* ]]
+}
+
+@test "mlat_privacy_status_line: mlat_private=false → OK 'public' line" {
+    write_mlat_state enabled ok false
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_privacy_status_line
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'MLAT name privacy'* ]]
+    [[ "$output" == *'public'* ]]
+    [[ "$output" == *'name shown'* ]]
+}
+
+@test "mlat_privacy_status_line: state file absent → no line emitted (silent skip)" {
+    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_privacy_status_line
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "mlat_privacy_status_line: state file lacks mlat_private key → silent skip" {
+    write_mlat_state enabled ok ''  # no mlat_private key written
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_privacy_status_line
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "mlat_privacy_status_line: unknown value → warn (forward-compat)" {
+    write_mlat_state enabled ok futureschema
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_privacy_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'unknown value'* ]]
+    [[ "$output" == *'futureschema'* ]]
 }
 
 # --- receiver_status_line ---

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -261,3 +261,58 @@ run_configure_env() {
     grep -q 'MLAT_USER="Anonymous"' "$ROOT_DIR/etc/airplanes/feed.env"
     grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
 }
+
+@test "configure.sh: interactive flow defaults MLAT_PRIVATE=false" {
+    run_configure $'ci-feeder\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -qx 'MLAT_PRIVATE=false' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Comment from the legacy flow that taught operators to hand-edit
+    # PRIVACY="--privacy" must not reappear.
+    ! grep -q 'add --privacy between the quotes' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q '^PRIVACY=' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh: noninteractive AIRPLANES_MLAT_PRIVATE=true honored" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="alice" \
+        AIRPLANES_MLAT_PRIVATE="true" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh: noninteractive AIRPLANES_MLAT_PRIVATE defaults to false" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="alice" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'MLAT_PRIVATE=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh: noninteractive AIRPLANES_MLAT_PRIVATE rejects bogus value" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="alice" \
+        AIRPLANES_MLAT_PRIVATE="probably" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "AIRPLANES_MLAT_PRIVATE must be 'true' or 'false'" ]]
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "configure.sh: AIRPLANES_MLAT_PRIVATE alone triggers non-interactive mode" {
+    run_configure_env AIRPLANES_MLAT_PRIVATE="true"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Missing required non-interactive configure value: AIRPLANES_LATITUDE" ]]
+    [ ! -e "$WHIPTAIL_LOG" ]
+}

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -340,6 +340,51 @@ SH
     fi
 }
 
+# Boot-config sourcing path: legacy image's /boot/airplanes-config.txt has
+# MLAT_MARKER from PHP webconfig and no feed.env yet. Daemon falls back to
+# sourcing boot config; in-shell MLAT_MARKER fallback derives MLAT_PRIVATE.
+# This is the production legacy path that motivated the fallback.
+@test "airplanes-mlat.sh: legacy boot-config sourcing with MLAT_MARKER=no → fallback derives true" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/boot" "$root/usr/bin" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/usr/bin/airplanes-feeder"
+    cat > "$root/boot/airplanes-config.txt" <<'EOF'
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="legacy-feeder"
+MLAT_ENABLED=true
+MLAT_MARKER="no"
+EOF
+    cat > "$root/boot/airplanes-env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+MLATSERVER="feed.airplanes.live:31090"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q -- '--privacy' "$arg_log"
+}
+
 # Conflict rule: canonical MLAT_PRIVATE always wins over legacy MLAT_MARKER.
 @test "airplanes-mlat.sh: MLAT_PRIVATE=false beats legacy MLAT_MARKER=no" {
     local root="$ROOT_DIR/root"

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -26,7 +26,7 @@ USER="image-feeder"
 MLAT_USER="image-feeder"
 MLAT_ENABLED=true
 MODEAC="yes"
-MLAT_MARKER="no"
+MLAT_PRIVATE=true
 EOF
     cat > "$root/boot/airplanes-env" <<'EOF'
 INPUT="127.0.0.1:30005"
@@ -73,7 +73,7 @@ SH
     fi
 }
 
-@test "airplanes-mlat.sh reads image config and applies privacy marker" {
+@test "airplanes-mlat.sh: image-side MLAT_PRIVATE=true → mlat-client gets --privacy" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
@@ -105,14 +105,259 @@ SH
     grep -q -- "--uuid-file $root/etc/airplanes/feeder-id" "$arg_log"
 }
 
-@test "airplanes-mlat.sh lets MLAT_MARKER enable the marker" {
+@test "airplanes-mlat.sh: image-side MLAT_PRIVATE=false → no --privacy" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
     write_image_config "$root"
-    sed -i -e 's/MLAT_MARKER="no"/MLAT_MARKER="yes"/' "$root/boot/airplanes-config.txt"
-    printf 'PRIVACY="--privacy"\n' >> "$root/boot/airplanes-env"
+    sed -i -e 's/MLAT_PRIVATE=true/MLAT_PRIVATE=false/' "$root/boot/airplanes-config.txt"
     mkdir -p "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    if grep -q -- '--privacy' "$arg_log"; then
+        return 1
+    fi
+}
+
+# Legacy PRIVACY in-memory fallback. Pins the only deployed code path
+# from the pre-rename schema: a manual install whose feed.env still
+# carries PRIVACY="--privacy" (inherited from the original ADS-B
+# Exchange installer or previously hand-edited) gets the --privacy
+# flag passed through even before update.sh runs the migration.
+@test "airplanes-mlat.sh: legacy PRIVACY=--privacy with no MLAT_PRIVATE → fallback derives true" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="legacy-feeder"
+MLAT_ENABLED=true
+PRIVACY="--privacy"
+MLATSERVER="feed.airplanes.live:31090"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q -- '--privacy' "$arg_log"
+}
+
+@test "airplanes-mlat.sh: legacy PRIVACY=\"\" with no MLAT_PRIVATE → fallback derives false" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="legacy-feeder"
+MLAT_ENABLED=true
+PRIVACY=""
+MLATSERVER="feed.airplanes.live:31090"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    if grep -q -- '--privacy' "$arg_log"; then
+        return 1
+    fi
+}
+
+# Conflict rule: when both the canonical MLAT_PRIVATE and the legacy
+# PRIVACY are present, canonical wins. The legacy fallback only fires
+# when MLAT_PRIVATE is unset.
+@test "airplanes-mlat.sh: MLAT_PRIVATE=false beats legacy PRIVACY=--privacy" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+PRIVACY="--privacy"
+MLAT_PRIVATE=false
+MLATSERVER="feed.airplanes.live:31090"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    if grep -q -- '--privacy' "$arg_log"; then
+        return 1
+    fi
+}
+
+# Legacy MLAT_MARKER in-memory fallback. PHP webconfig's still-shipping
+# yes/no dropdown writes MLAT_MARKER to /boot/airplanes-config.txt
+# (inverted polarity — "no" means privacy ON). Without this fallback a
+# feeder whose user toggled privacy in legacy webconfig would silently
+# lose privacy on first daemon start under the new schema.
+@test "airplanes-mlat.sh: legacy MLAT_MARKER=no with no MLAT_PRIVATE → fallback derives true" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="legacy-feeder"
+MLAT_ENABLED=true
+MLAT_MARKER="no"
+MLATSERVER="feed.airplanes.live:31090"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q -- '--privacy' "$arg_log"
+}
+
+@test "airplanes-mlat.sh: legacy MLAT_MARKER=yes with no MLAT_PRIVATE → fallback derives false" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="legacy-feeder"
+MLAT_ENABLED=true
+MLAT_MARKER="yes"
+MLATSERVER="feed.airplanes.live:31090"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    if grep -q -- '--privacy' "$arg_log"; then
+        return 1
+    fi
+}
+
+# Conflict rule: canonical MLAT_PRIVATE always wins over legacy MLAT_MARKER.
+@test "airplanes-mlat.sh: MLAT_PRIVATE=false beats legacy MLAT_MARKER=no" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+MLAT_MARKER="no"
+MLAT_PRIVATE=false
+MLATSERVER="feed.airplanes.live:31090"
+EOF
     cat > "$stub_bin/nc" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -418,6 +663,71 @@ EOF
     [[ "$output" == *"Update Webconfig"* ]]
     # State file is not written: we exit before classifier runs.
     [ ! -f "$root/run/airplanes-mlat/state" ]
+}
+
+@test "airplanes-mlat.sh exits 64 with reason=mlat_private_invalid for hand-edited bad MLAT_PRIVATE" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'MLAT_PRIVATE=yes' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 64 ]
+    grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=mlat_private_invalid' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_private=yes' "$root/run/airplanes-mlat/state"
+    [[ "$output" == *"MLAT_PRIVATE must be 'true' or 'false'"* ]]
+}
+
+@test "airplanes-mlat.sh state file publishes mlat_private=true when MLAT_PRIVATE=true" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'MLAT_PRIVATE=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'mlat_private=true' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh state file publishes mlat_private=false when MLAT_PRIVATE absent (runtime default)" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'mlat_private=false' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh runs without state-writer lib (defensive source falls through to stub)" {

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -321,3 +321,194 @@ EOF
 # feeder names are sanitized in configure.sh to letters/digits/underscores/
 # dashes/spaces (no backslashes, no quotes), so this corner only matters for
 # hand-edited feed.env files. Documented here, not enforced.
+
+# ---------------------------------------------------------------------------
+# migrate_privacy_to_mlat_private
+# ---------------------------------------------------------------------------
+
+@test "migrate_privacy_to_mlat_private: PRIVACY=--privacy → MLAT_PRIVATE=true" {
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+PRIVACY="--privacy"
+LATITUDE="52.5"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+    grep -q '^INPUT="127.0.0.1:30005"$' "$FEED_ENV"
+    grep -q '^LATITUDE="52.5"$' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: PRIVACY=\"\" → MLAT_PRIVATE=false" {
+    cat > "$FEED_ENV" <<'EOF'
+PRIVACY=""
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: unquoted PRIVACY=--privacy → MLAT_PRIVATE=true" {
+    printf 'PRIVACY=--privacy\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: PRIVACY with surrounding whitespace tolerated" {
+    printf 'PRIVACY=" --privacy "\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: CRLF line ending tolerated" {
+    printf 'PRIVACY="--privacy"\r\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: PRIVACY with garbage value → MLAT_PRIVATE=false" {
+    printf 'PRIVACY="--something-else"\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: both keys absent → MLAT_PRIVATE=false appended" {
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+LATITUDE="52.5"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+    grep -q '^INPUT="127.0.0.1:30005"$' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: only MLAT_PRIVATE present → no-op" {
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+MLAT_PRIVATE=true
+LATITUDE="52.5"
+EOF
+    local snapshot
+    snapshot="$(cat "$FEED_ENV")"
+
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+    [ "$(cat "$FEED_ENV")" = "$snapshot" ]
+}
+
+@test "migrate_privacy_to_mlat_private: both keys present → canonical wins, PRIVACY stripped" {
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+MLAT_PRIVATE=false
+PRIVACY="--privacy"
+LATITUDE="52.5"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+    [ "$(grep -c '^MLAT_PRIVATE=' "$FEED_ENV")" -eq 1 ]
+}
+
+@test "migrate_privacy_to_mlat_private: idempotent — second call is a no-op" {
+    printf 'PRIVACY="--privacy"\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+    local snapshot
+    snapshot="$(cat "$FEED_ENV")"
+
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+    [ "$(cat "$FEED_ENV")" = "$snapshot" ]
+}
+
+@test "migrate_privacy_to_mlat_private: writes backup at .pre-privacy-split when modifying" {
+    printf 'PRIVACY="--privacy"\n' > "$FEED_ENV"
+    [ ! -f "$FEED_ENV.pre-privacy-split" ]
+
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+    [ -f "$FEED_ENV.pre-privacy-split" ]
+    grep -q '^PRIVACY="--privacy"$' "$FEED_ENV.pre-privacy-split"
+}
+
+@test "migrate_privacy_to_mlat_private: backup is NEVER overwritten on subsequent calls" {
+    printf 'PRIVACY="--privacy"\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    local backup_snapshot
+    backup_snapshot="$(cat "$FEED_ENV.pre-privacy-split")"
+
+    # Re-introduce PRIVACY and re-migrate.
+    printf 'PRIVACY=""\n' >> "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+    [ "$(cat "$FEED_ENV.pre-privacy-split")" = "$backup_snapshot" ]
+}
+
+@test "migrate_privacy_to_mlat_private: feed.env missing → no-op (no error)" {
+    [ ! -f "$FEED_ENV" ]
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+    [ ! -f "$FEED_ENV" ]
+}
+
+@test "migrate_privacy_to_mlat_private: preserves all non-privacy keys verbatim" {
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+PRIVACY="--privacy"
+LATITUDE="52.5"
+LONGITUDE="13.4"
+ALTITUDE="35m"
+NET_OPTIONS="--net-heartbeat 60"
+SOME_USER_CUSTOM_KEY="leave-me-alone"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    for line in \
+        'INPUT="127.0.0.1:30005"' \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE="52.5"' \
+        'LONGITUDE="13.4"' \
+        'ALTITUDE="35m"' \
+        'NET_OPTIONS="--net-heartbeat 60"' \
+        'SOME_USER_CUSTOM_KEY="leave-me-alone"' \
+    ; do
+        grep -qF "$line" "$FEED_ENV"
+    done
+}
+
+@test "migrate_privacy_to_mlat_private: legacy PRIVACY reappearing post-migration is stripped" {
+    # Simulates a legacy webconfig writing PRIVACY= via the symlink while
+    # MLAT_PRIVATE is already in place. Conflict rule: canonical wins, legacy
+    # stripped. (Diverges from migrate_user_to_mlat_split's re-derivation
+    # because no observed legacy PRIVACY writer needs precedence.)
+    cat > "$FEED_ENV" <<'EOF'
+MLAT_PRIVATE=false
+PRIVACY="--privacy"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+}
+
+@test "run_config_file_migrations: chains migrate_privacy_to_mlat_private after migrate_user_to_mlat_split" {
+    cat > "$FEED_ENV" <<'EOF'
+USER="alice"
+PRIVACY="--privacy"
+LATITUDE="52.5"
+EOF
+    run_config_file_migrations "$FEED_ENV"
+
+    grep -qx 'MLAT_USER="alice"' "$FEED_ENV"
+    grep -qx 'MLAT_ENABLED=true' "$FEED_ENV"
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+    ! grep -q '^USER=' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+}

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -498,6 +498,50 @@ EOF
     ! grep -q '^PRIVACY=' "$FEED_ENV"
 }
 
+@test "migrate_privacy_to_mlat_private: MLAT_MARKER=no → MLAT_PRIVATE=true, stripped" {
+    # PHP webconfig writes MLAT_MARKER via its yes/no dropdown with
+    # inverted polarity: "no" means privacy ON.
+    printf 'MLAT_MARKER="no"\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+    ! grep -q '^MLAT_MARKER=' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: MLAT_MARKER=yes → MLAT_PRIVATE=false, stripped" {
+    printf 'MLAT_MARKER="yes"\n' > "$FEED_ENV"
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+    ! grep -q '^MLAT_MARKER=' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: PRIVACY wins over MLAT_MARKER when both present" {
+    # PRIVACY is the more deliberate hand-edit signal (CLI fragment);
+    # MLAT_MARKER is the still-shipping PHP webconfig form. If a config
+    # carries both, prefer PRIVACY.
+    cat > "$FEED_ENV" <<'EOF'
+PRIVACY="--privacy"
+MLAT_MARKER="yes"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=true' "$FEED_ENV"
+    ! grep -q '^PRIVACY=' "$FEED_ENV"
+    ! grep -q '^MLAT_MARKER=' "$FEED_ENV"
+}
+
+@test "migrate_privacy_to_mlat_private: canonical MLAT_PRIVATE wins over MLAT_MARKER" {
+    cat > "$FEED_ENV" <<'EOF'
+MLAT_PRIVATE=false
+MLAT_MARKER="no"
+EOF
+    migrate_privacy_to_mlat_private "$FEED_ENV"
+
+    grep -qx 'MLAT_PRIVATE=false' "$FEED_ENV"
+    ! grep -q '^MLAT_MARKER=' "$FEED_ENV"
+}
+
 @test "run_config_file_migrations: chains migrate_privacy_to_mlat_private after migrate_user_to_mlat_split" {
     cat > "$FEED_ENV" <<'EOF'
 USER="alice"

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -108,7 +108,7 @@ USER="image-feeder"
 MLAT_USER="image-feeder"
 MLAT_ENABLED=true
 MODEAC="yes"
-MLAT_MARKER="no"
+MLAT_PRIVATE=true
 EOF
     cat > "$root/boot/airplanes-env" <<'EOF'
 INPUT="127.0.0.1:30005"

--- a/update.sh
+++ b/update.sh
@@ -357,15 +357,18 @@ source "$GIT/scripts/lib/service-account.sh"
 source "$GIT/scripts/lib/update-builds.sh"
 
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
-    # Unset USER before sourcing so a process-environment $USER (e.g. the
-    # systemd User= or the login shell) can't bleed into the legacy-USER
-    # detection below. Same precaution applies in the manual-install branch.
-    unset USER MLAT_USER MLAT_ENABLED
+    # Unset USER (and the privacy keys) before sourcing so a process-
+    # environment value (systemd User= or login-shell $USER, or a stray
+    # MLAT_PRIVATE from the orchestrator's env) can't bleed into the
+    # legacy-USER detection or the privacy resolution below. Same
+    # precaution applies in the manual-install branch.
+    unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
     if [[ -f "$FEED_ENV" ]]; then
-        # Migrate legacy USER if present before sourcing so the shell sees
-        # the new schema directly. No-op when feed.env was written by a
-        # post-split writer (configure.sh, image first-run, new webconfig).
+        # Migrate legacy keys before sourcing so the shell sees the new
+        # schema directly. No-op when feed.env was written by a post-split
+        # writer (configure.sh, image first-run, new webconfig).
         migrate_user_to_mlat_split "$FEED_ENV"
+        migrate_privacy_to_mlat_private "$FEED_ENV"
         source "$FEED_ENV"
     else
         source "$BOOT_CONFIG"
@@ -395,11 +398,24 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
     JSON_OPTIONS="${JSON_OPTIONS:-"--json-location-accuracy 2"}"
     MLAT_USER="${MLAT_USER-}"
     MLAT_ENABLED="${MLAT_ENABLED:-true}"
+    # Legacy MLAT_MARKER read fallback. PHP webconfig still writes
+    # MLAT_MARKER (inverted polarity, "no" = privacy ON) to
+    # /boot/airplanes-config.txt. When this branch sources BOOT_CONFIG
+    # because feed.env is absent, the migrator never saw the key. Without
+    # this fallback, a legacy-image feeder updating to the new schema
+    # would silently lose its stored privacy preference.
+    if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
+        case "$MLAT_MARKER" in
+            no) MLAT_PRIVATE="true" ;;
+            *)  MLAT_PRIVATE="false" ;;
+        esac
+    fi
+    MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 else
     prepare_legacy_feed_env_migration "$LEGACY_FEED_ENV" "$FEED_ENV" "$ETC_AIRPLANES"
     run_config_file_migrations "$FEED_ENV"
 
-    unset USER MLAT_USER MLAT_ENABLED
+    unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
     if [[ -f "$FEED_ENV" ]]; then
         source "$FEED_ENV"
         migrate_add_uat_input_default "$FEED_ENV"
@@ -408,6 +424,13 @@ else
     fi
     MLAT_USER="${MLAT_USER-}"
     MLAT_ENABLED="${MLAT_ENABLED:-true}"
+    if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
+        case "$MLAT_MARKER" in
+            no) MLAT_PRIVATE="true" ;;
+            *)  MLAT_PRIVATE="false" ;;
+        esac
+    fi
+    MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 fi
 if [[ -z $INPUT ]] || [[ -z $INPUT_TYPE ]] \
     || [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]] \


### PR DESCRIPTION
MLAT privacy posture was split across two keys with different schemas. PRIVACY in feed.env stored the literal --privacy CLI fragment, and MLAT_MARKER (yes|no, with inverted polarity — "no" meant privacy on) was a separate image-side override. This replaces both with one MLAT_PRIVATE=true|false boolean.

The daemon assembles the --privacy flag locally at exec time, so the literal flag string never appears on disk. An idempotent update-time migration converts legacy PRIVACY values in feed.env (with a one-shot backup at feed.env.pre-privacy-split) and leaves a daemon-side in-memory fallback for the brief gap between any out-of-repo writer and the next update. Invalid hand-edited values fail loud with exit 64 instead of silently leaking privacy.

A new `sudo apl-feed mlat private enable|disable` subcommand mirrors `apl-feed mlat enable|disable`. Privacy posture appears in `apl-feed status` via the daemon's runtime state file, not by re-reading feed.env.