### PR TITLE
Tag-based releases: stable channel + release CI + install.sh template marker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,23 @@ jobs:
           PUSH_REF: ${{ github.ref_name }}
           DISPATCH_REF: ${{ inputs.validation_ref }}
         run: |
+          # Push tags are pre-validated by the validate-tag job. Dispatch
+          # input is operator-supplied and must be sanity-checked before it
+          # flows into the rendered install.sh as a shell string literal —
+          # otherwise a malicious dispatch could inject quote characters and
+          # produce a rendered asset that executes attacker-supplied code.
+          # Allow: tag-shaped strings (v0.0.0-validation, v0.1.0-test, etc.)
+          # plus the strict semver shape. Reject anything else.
           if [[ "$EVENT_NAME" == "push" ]]; then
-            echo "ref=$PUSH_REF" >> "$GITHUB_OUTPUT"
+            REF="$PUSH_REF"
           else
-            echo "ref=$DISPATCH_REF" >> "$GITHUB_OUTPUT"
+            REF="$DISPATCH_REF"
+            if ! [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+              echo "::error::validation_ref '$REF' must match v[0-9]+.[0-9]+.[0-9]+ optionally followed by -[alnum.]+"
+              exit 1
+            fi
           fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Render dist/install.sh
         env:
@@ -211,7 +223,7 @@ jobs:
         working-directory: dist
         run: sha256sum -c SHA256SUMS
 
-      - name: Create draft release with assets
+      - name: Create or update draft release with assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
@@ -220,13 +232,26 @@ jobs:
           # release content after publish, so create as draft, attach assets,
           # then flip to published. This avoids a window where the release is
           # public but assets aren't all uploaded yet.
-          gh release create "$TAG_NAME" \
-            --draft \
-            --title "$TAG_NAME" \
-            --generate-notes \
-            dist/install.sh \
-            dist/update.sh \
-            dist/SHA256SUMS
+          #
+          # Re-entrant: if a previous job partially succeeded (draft created
+          # but asset upload failed), a re-run finds the existing draft and
+          # uses `--clobber` on upload to overwrite stale assets.
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Draft release $TAG_NAME exists; uploading assets with --clobber"
+            gh release upload "$TAG_NAME" \
+              dist/install.sh \
+              dist/update.sh \
+              dist/SHA256SUMS \
+              --clobber
+          else
+            gh release create "$TAG_NAME" \
+              --draft \
+              --title "$TAG_NAME" \
+              --generate-notes \
+              dist/install.sh \
+              dist/update.sh \
+              dist/SHA256SUMS
+          fi
 
       - name: Publish (flip draft to released)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,231 @@
+name: Release
+
+# Triggers:
+#   push of a v* tag — full release flow: validate format, run tests, render
+#       dist/install.sh with the tag substituted, publish a GitHub Release
+#       with install.sh + update.sh + SHA256SUMS attached.
+#   workflow_dispatch — validation mode: render dist/install.sh against an
+#       arbitrary supplied ref (defaults to v0.0.0-validation) and run the
+#       installer smoke against the rendered artifact. No GitHub Release
+#       published, no tag push required. Use this to exercise the pipeline
+#       before tagging anything for real.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      validation_ref:
+        description: 'Tag-shaped string to substitute into __FEED_REF__ for validation render (default: v0.0.0-validation)'
+        type: string
+        default: v0.0.0-validation
+
+permissions:
+  contents: read
+
+jobs:
+  validate-tag:
+    name: validate tag format
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Strict semver check
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Strict: vMAJOR.MINOR.PATCH, no leading zeroes, no prereleases.
+          # Matches the regex airplanes_resolve_latest_stable_tag uses.
+          if ! [[ "$REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Tag '$REF_NAME' does not match strict v[MAJOR].[MINOR].[PATCH] format."
+            echo "::error::Expected examples: v0.1.0, v1.2.3. Reject leading zeroes (v01.2.3) and prereleases (v0.1.0-rc.1)."
+            exit 1
+          fi
+
+  test:
+    name: bats + lint
+    needs: [validate-tag]
+    if: |
+      always() &&
+      (needs.validate-tag.result == 'success' || needs.validate-tag.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install shellcheck, bats, jq, curl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck bats jq curl
+
+      - name: Run shellcheck (warning severity)
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 shellcheck -S warning
+
+      - name: Run bash syntax check
+        run: |
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 -n1 bash -n
+
+      - name: Run bats suite
+        run: bats test/
+
+  render:
+    name: render dist/install.sh
+    needs: [test]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      ref: ${{ steps.derive.outputs.ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Derive ref to substitute
+        id: derive
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_REF: ${{ github.ref_name }}
+          DISPATCH_REF: ${{ inputs.validation_ref }}
+        run: |
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            echo "ref=$PUSH_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$DISPATCH_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Render dist/install.sh
+        env:
+          FEED_REF: ${{ steps.derive.outputs.ref }}
+        run: |
+          mkdir -p dist
+          # Substitute the literal __FEED_REF__ marker with the tag string.
+          # Python avoids regex-escaping pitfalls (slashes, dots) in shell sed.
+          python3 - "$FEED_REF" install.sh dist/install.sh <<'PY'
+          import sys
+          ref, src, dst = sys.argv[1], sys.argv[2], sys.argv[3]
+          with open(src) as f:
+              content = f.read()
+          if "__FEED_REF__" not in content:
+              sys.stderr.write("ERROR: __FEED_REF__ marker not found in install.sh\n")
+              sys.exit(1)
+          content = content.replace("__FEED_REF__", ref)
+          with open(dst, "w") as f:
+              f.write(content)
+          PY
+          chmod +x dist/install.sh
+
+      - name: Assert rendered asset contains no __FEED_REF__
+        run: |
+          if grep -q '__FEED_REF__' dist/install.sh; then
+            echo "::error::dist/install.sh still contains __FEED_REF__ after render."
+            exit 1
+          fi
+
+      - name: Copy update.sh into dist (no rendering needed)
+        run: |
+          cp update.sh dist/update.sh
+          chmod +x dist/update.sh
+
+      - name: Generate SHA256SUMS
+        working-directory: dist
+        run: sha256sum install.sh update.sh > SHA256SUMS
+
+      - name: Upload rendered artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-assets
+          path: |
+            dist/install.sh
+            dist/update.sh
+            dist/SHA256SUMS
+          retention-days: 7
+
+  validation-smoke:
+    name: validation render smoke
+    needs: [render]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download rendered artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-assets
+          path: dist/
+
+      - name: Assert rendered AIRPLANES_RELEASE_REF matches dispatch input
+        env:
+          EXPECTED_REF: ${{ needs.render.outputs.ref }}
+        run: |
+          if ! grep -F "AIRPLANES_RELEASE_REF='$EXPECTED_REF'" dist/install.sh; then
+            echo "::error::dist/install.sh does not contain AIRPLANES_RELEASE_REF='$EXPECTED_REF'"
+            grep "AIRPLANES_RELEASE_REF" dist/install.sh || true
+            exit 1
+          fi
+
+      - name: Bash syntax check on rendered installer
+        run: bash -n dist/install.sh
+
+      - name: Verify SHA256SUMS
+        working-directory: dist
+        run: sha256sum -c SHA256SUMS
+
+  release:
+    name: publish GitHub Release
+    needs: [render]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Download rendered artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-assets
+          path: dist/
+
+      - name: Verify SHA256SUMS
+        working-directory: dist
+        run: sha256sum -c SHA256SUMS
+
+      - name: Create draft release with assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Draft-first publishing: GitHub's immutable-release model locks
+          # release content after publish, so create as draft, attach assets,
+          # then flip to published. This avoids a window where the release is
+          # public but assets aren't all uploaded yet.
+          gh release create "$TAG_NAME" \
+            --draft \
+            --title "$TAG_NAME" \
+            --generate-notes \
+            dist/install.sh \
+            dist/update.sh \
+            dist/SHA256SUMS
+
+      - name: Publish (flip draft to released)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release edit "$TAG_NAME" --draft=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,12 @@ jobs:
           if "__FEED_REF__" not in content:
               sys.stderr.write("ERROR: __FEED_REF__ marker not found in install.sh\n")
               sys.exit(1)
-          content = content.replace("__FEED_REF__", ref)
+          # Replace only the FIRST occurrence: the AIRPLANES_RELEASE_REF
+          # assignment line. The second occurrence is the comparison sentinel
+          # ("did substitution happen?") and must stay literal — otherwise
+          # the rendered installer's "if substituted, use the ref" check
+          # collapses into always-equal and we'd fall through to "main".
+          content = content.replace("__FEED_REF__", ref, 1)
           with open(dst, "w") as f:
               f.write(content)
           PY

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Find your antenna coordinates and elevation:
 Then install the feed client:
 
 ```
-curl -L -o /tmp/feed.sh https://raw.githubusercontent.com/airplanes-live/feed/main/install.sh
+curl -L -o /tmp/feed.sh https://github.com/airplanes-live/feed/releases/latest/download/install.sh
 sudo bash /tmp/feed.sh
 ```
 
@@ -139,7 +139,7 @@ sudo apl-feed restore airplanes-feeder-backup.json --force
 Update without reconfiguring:
 
 ```
-curl -L -o /tmp/update.sh https://raw.githubusercontent.com/airplanes-live/feed/main/update.sh
+curl -L -o /tmp/update.sh https://github.com/airplanes-live/feed/releases/latest/download/update.sh
 sudo bash /tmp/update.sh
 ```
 
@@ -206,7 +206,7 @@ sudo bash /usr/local/share/tar1090/uninstall.sh airplanes
 Run the installer again to change your feeder settings:
 
 ```
-curl -L -o /tmp/feed.sh https://raw.githubusercontent.com/airplanes-live/feed/main/install.sh
+curl -L -o /tmp/feed.sh https://github.com/airplanes-live/feed/releases/latest/download/install.sh
 sudo bash /tmp/feed.sh
 ```
 

--- a/dist/install-shim.sh
+++ b/dist/install-shim.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# airplanes.live feed installer — compat shim.
+#
+# This file replaces install.sh on feed/main after a stable release exists.
+# Users who curl the legacy raw.githubusercontent.com URL get redirected to
+# the rendered installer attached to the latest GitHub Release.
+#
+# Source of truth for the actual install logic is install.sh on feed/dev,
+# rendered into dist/install.sh at release time with __FEED_REF__ substituted
+# for the tag being released. See docs/RELEASE_CHECKLIST.md.
+
+set -e
+
+echo "Switching to the latest stable airplanes.live feed release..."
+
+# -fsSL: fail on HTTP error, silent progress, follow redirects.
+# Pipe to sudo bash so the redirected installer keeps the same elevation
+# semantics as the legacy curl-pipe-bash form.
+exec curl -fsSL https://github.com/airplanes-live/feed/releases/latest/download/install.sh | sudo bash -s -- "$@"

--- a/dist/install-shim.sh
+++ b/dist/install-shim.sh
@@ -9,11 +9,15 @@
 # rendered into dist/install.sh at release time with __FEED_REF__ substituted
 # for the tag being released. See docs/RELEASE_CHECKLIST.md.
 
-set -e
+set -eo pipefail
 
 echo "Switching to the latest stable airplanes.live feed release..."
 
 # -fsSL: fail on HTTP error, silent progress, follow redirects.
 # Pipe to sudo bash so the redirected installer keeps the same elevation
 # semantics as the legacy curl-pipe-bash form.
-exec curl -fsSL https://github.com/airplanes-live/feed/releases/latest/download/install.sh | sudo bash -s -- "$@"
+#
+# pipefail is mandatory here — without it, a curl 404 (release missing or
+# yanked) feeds an empty body to bash which exits 0, silently producing a
+# "successful" no-op install.
+curl -fsSL https://github.com/airplanes-live/feed/releases/latest/download/install.sh | sudo bash -s -- "$@"

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,106 @@
+# Release checklist
+
+Step-by-step runbook for cutting a `feed` release. Lives here so it's versioned with the rest of the repo.
+
+Releases are append-only — if `v0.1.0` fails after publish, fix and tag `v0.1.1`. Never delete a release tag, never force-push to it. GitHub's release-tag protection rules enforce this from the platform side.
+
+## Tag format
+
+Strict semver, lowercase `v` prefix, no leading zeroes, no prereleases:
+
+- `v0.1.0` ✓
+- `v1.2.3` ✓
+- `v01.2.3` ✗ (leading zero)
+- `v0.1.0-rc.1` ✗ (prerelease — not used at the feed layer for v0.1.x; if soak is needed, that happens on the dev channel)
+
+The same regex is enforced in three places:
+
+- `validate-tag` job in `.github/workflows/release.yml` (CI rejects malformed tags).
+- `airplanes_resolve_latest_stable_tag` in `scripts/lib/install-update-common.sh` and `update.sh` (feeders ignore non-conforming tags during update resolution).
+
+## Pre-release validation
+
+Before cutting a real tag, exercise the pipeline via `workflow_dispatch`:
+
+```
+gh workflow run release.yml -R airplanes-live/feed \
+    -f validation_ref=v0.0.0-validation
+```
+
+This renders `dist/install.sh` with `__FEED_REF__` substituted to `v0.0.0-validation`, runs the substitution-correctness assertion, runs `bash -n` on the rendered script, and verifies the `SHA256SUMS`. No GitHub Release is published.
+
+If the dispatch run succeeds end-to-end, the release pipeline is ready for a real tag.
+
+## Cutting a release
+
+### 1. Land changes on feed/dev, verify CI is green
+
+All v0.1.x work lands on feed/dev first. CI must be green on the commit you intend to ship.
+
+### 2. Merge feed/dev → feed/main
+
+Standard PR. Squash or merge, your call. The merge commit on feed/main is the commit you'll tag.
+
+At this point `install.sh` on feed/main is the **full installer** (with the `__FEED_REF__` marker intact). This is intentional — release CI renders `dist/install.sh` from this file, so it must contain the marker to substitute.
+
+### 3. Tag the merge commit
+
+```
+git fetch origin
+git checkout main
+git pull --ff-only
+git tag -a -s v0.1.0 -m "feed v0.1.0"
+git push origin v0.1.0
+```
+
+Use annotated signed tags (`-a -s`). The tag push triggers `release.yml`, which:
+
+1. Validates the tag format
+2. Runs the full test suite on the tagged commit
+3. Renders `dist/install.sh` with `__FEED_REF__=v0.1.0`
+4. Asserts the rendered asset contains no remaining `__FEED_REF__` literal
+5. Creates a draft GitHub Release with `install.sh`, `update.sh`, `SHA256SUMS`
+6. Flips draft to published, marks as `latest`
+
+After the release publishes, `https://github.com/airplanes-live/feed/releases/latest/download/install.sh` returns the tag-pinned installer.
+
+### 4. Apply install.sh shim swap on feed/main
+
+**Only after the release is published.** This step replaces `feed/main/install.sh` with a tiny shim that redirects to `releases/latest/download/install.sh`. Anyone curling the legacy URL keeps getting a working install — they're redirected to the just-published release asset.
+
+Do NOT do this before tagging — if `install.sh` on the tagged commit is a shim, release CI will render the shim (instead of the full installer) and publish that as `dist/install.sh`. The release asset would be a self-referential redirect.
+
+The shim content lives in `dist/install-shim.sh` in the repo. Apply via PR:
+
+```
+git checkout main
+git pull --ff-only
+git checkout -b chore/install-shim-swap
+cp dist/install-shim.sh install.sh
+git add install.sh
+git commit -m "chore(install): replace install.sh with releases/latest shim"
+git push origin chore/install-shim-swap
+gh pr create --base main --title "Replace install.sh with releases/latest shim" --body "Activates the compat shim now that v0.1.0 release exists."
+```
+
+Merge the PR. After this, `feed/main/install.sh` redirects to the release asset.
+
+### 5. Verify
+
+- `curl -fsSL https://github.com/airplanes-live/feed/releases/latest/download/install.sh | head -3` returns the rendered installer (look for the substituted `AIRPLANES_RELEASE_REF='v0.1.0'` line).
+- `curl -fsSL https://raw.githubusercontent.com/airplanes-live/feed/main/install.sh | head -3` returns the shim (look for the `curl … releases/latest/download/install.sh` line).
+- The release page shows `install.sh`, `update.sh`, `SHA256SUMS` as assets and `v0.1.0` is marked as the latest release.
+
+## What can go wrong
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `validate-tag` job fails | Tag format violation (leading zero, prerelease, missing prefix) | Re-tag with corrected format. Don't delete the bad tag — leave it for archaeology. |
+| `render` job: "ERROR: `__FEED_REF__` marker not found in install.sh" | Shim swap happened before tag | Revert the shim swap on feed/main, re-tag with the full installer present. |
+| `release` job: asset upload fails | GitHub API blip or permissions | Re-run the failed job. The release is still in draft so this is safe. |
+| Published release has wrong assets | Manual upload, wrong source build | Cut next patch tag (`v0.1.1`) and ship that. Never edit the published v0.1.0. |
+| User reports `releases/latest/download/install.sh` returns 404 | First release not yet published, or `latest` flag missing | Confirm release is marked `Set as the latest release` on GitHub. |
+
+## Subsequent releases (v0.1.1, v0.2.0, …)
+
+Same as v0.1.0 except step 4 (shim swap) is already done. Skip directly from tag-push (step 3) to verify (step 5).

--- a/install.sh
+++ b/install.sh
@@ -10,22 +10,24 @@ else
     AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
     AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
 
-    # Release CI renders this asset with __FEED_REF__ substituted for the
-    # tag being released, so a curl of releases/<tag>/download/install.sh
-    # installs that exact tag. The source-tree copy on feed/dev or feed/main
-    # leaves the placeholder literal; AIRPLANES_RELEASE_REF resets to empty
-    # in that case and the fallback chain lands on "main" — same behavior as
-    # before this template marker existed.
+    # The next line carries the release-CI template marker. CI replaces
+    # ONLY THE FIRST occurrence of the marker string in this file (via
+    # str.replace count=1), so this assignment is the substitution target.
+    # The unrendered sentinel below is split across shell concatenation
+    # so the substitution doesn't match it and the post-render comparison
+    # stays meaningful. See docs/RELEASE_CHECKLIST.md.
     #
     # An explicit AIRPLANES_FEED_BRANCH env var still wins (image-build use,
     # operator overrides). Source-clone use sources install-update-common.sh,
     # which defines airplanes_resolve_feed_branch for stable-channel tag
     # resolution; the inline fallback doesn't do channel resolution and
-    # provides a no-op stub so call sites work either way.
+    # provides a no-op stub so call sites work uniformly.
     AIRPLANES_RELEASE_REF='__FEED_REF__'
-    if [[ "$AIRPLANES_RELEASE_REF" == "__FEED_REF__" ]]; then
+    _airplanes_unrendered_marker='__''FEED_REF__'
+    if [[ "$AIRPLANES_RELEASE_REF" == "$_airplanes_unrendered_marker" ]]; then
         AIRPLANES_RELEASE_REF=""
     fi
+    unset _airplanes_unrendered_marker
     AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-${AIRPLANES_RELEASE_REF:-main}}"
     unset AIRPLANES_RELEASE_REF
 

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,27 @@ if [[ -f "$SCRIPT_DIR/scripts/lib/install-update-common.sh" ]]; then
 else
     AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
     AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
-    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
+
+    # Release CI renders this asset with __FEED_REF__ substituted for the
+    # tag being released, so a curl of releases/<tag>/download/install.sh
+    # installs that exact tag. The source-tree copy on feed/dev or feed/main
+    # leaves the placeholder literal; AIRPLANES_RELEASE_REF resets to empty
+    # in that case and the fallback chain lands on "main" — same behavior as
+    # before this template marker existed.
+    #
+    # An explicit AIRPLANES_FEED_BRANCH env var still wins (image-build use,
+    # operator overrides). Source-clone use sources install-update-common.sh,
+    # which defines airplanes_resolve_feed_branch for stable-channel tag
+    # resolution; the inline fallback doesn't do channel resolution and
+    # provides a no-op stub so call sites work either way.
+    AIRPLANES_RELEASE_REF='__FEED_REF__'
+    if [[ "$AIRPLANES_RELEASE_REF" == "__FEED_REF__" ]]; then
+        AIRPLANES_RELEASE_REF=""
+    fi
+    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-${AIRPLANES_RELEASE_REF:-main}}"
+    unset AIRPLANES_RELEASE_REF
+
+    airplanes_resolve_feed_branch() { :; }
 
     airplanes_path() {
         local path="$1"
@@ -104,6 +124,12 @@ airplanes_init_paths
 airplanes_require_root
 mkdir -p "$IPATH"
 airplanes_install_bootstrap_deps
+
+# Resolve the "stable" channel sentinel into a concrete tag now that git is
+# available. No-op in inline-fallback mode (the stub returns immediately) and
+# no-op in lib-sourced mode when AIRPLANES_FEED_BRANCH is already concrete.
+airplanes_resolve_feed_branch
+
 getGIT "$AIRPLANES_FEED_REPO" "$AIRPLANES_FEED_BRANCH" "$GIT"
 
 cd "$GIT"

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -51,7 +51,15 @@ airplanes_resolve_feed_branch() {
     local resolved rc=0
     resolved="$(airplanes_resolve_latest_stable_tag "$AIRPLANES_FEED_REPO")" || rc=$?
     case $rc in
-        0) AIRPLANES_FEED_BRANCH="$resolved" ;;
+        0)
+            # Export so the resolved tag survives update.sh's self-replace
+            # re-exec. Without this, a default-stable install re-resolves on
+            # every self-replace and could install a different tag if a new
+            # release lands mid-update (or thrash on a transient ls-remote
+            # failure between invocations).
+            AIRPLANES_FEED_BRANCH="$resolved"
+            export AIRPLANES_FEED_BRANCH
+            ;;
         1)
             echo "ERROR: stable release channel selected but no v[MAJOR].[MINOR].[PATCH] tags exist at $AIRPLANES_FEED_REPO." >&2
             echo "       Keeping current install unchanged." >&2

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -6,27 +6,92 @@
 AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
 AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
 
-# Image-built feeders pin their runtime-update branch to the channel they were
-# built from via /etc/airplanes/release-channel. Without this, a dev-channel
-# image falls back to feed/main on the first webconfig-triggered update and
-# self-replaces update.sh with the older main version (sticky regression: the
-# pin is never re-asserted because main's update.sh has no awareness of it).
-# Manual installs without the file get the historical "main" default.
+# Resolve the latest semver-strict release tag from the feed remote.
+# Strict format: vMAJOR.MINOR.PATCH with no leading zeroes, no prereleases.
+# Echoes the tag name on success.
+# Returns 0 = found, 1 = lookup OK but no matching tags, 2 = lookup itself failed.
+airplanes_resolve_latest_stable_tag() {
+    local repo="${1:-$AIRPLANES_FEED_REPO}"
+    local refs latest=""
+    if ! refs="$(GIT_TERMINAL_PROMPT=0 git ls-remote --tags --refs "$repo" 2>/dev/null)"; then
+        return 2
+    fi
+    if [[ -z "$refs" ]]; then
+        return 1
+    fi
+    local _sha _refname _tag
+    while IFS=$'\t' read -r _sha _refname; do
+        _tag="${_refname#refs/tags/}"
+        if [[ "$_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            if [[ -z "$latest" ]]; then
+                latest="$_tag"
+            else
+                latest="$(printf '%s\n%s\n' "$latest" "$_tag" | sort -V | tail -n 1)"
+            fi
+        fi
+    done <<< "$refs"
+    if [[ -z "$latest" ]]; then
+        return 1
+    fi
+    printf '%s' "$latest"
+    return 0
+}
+
+# Resolve AIRPLANES_FEED_BRANCH from the channel sentinel "stable" to the
+# actual latest tag. No-op if AIRPLANES_FEED_BRANCH is already a concrete
+# ref (a tag name, branch, or SHA). Aborts loudly with distinct messages
+# for "lookup failed" (network/DNS/TLS) versus "no matching tags exist".
 #
-# Allowlist enforced: only {main, dev}. An existing file with a different
-# value is treated as operator error and aborts the update — silently
-# falling back to "main" would recreate the dev → main downgrade through
-# corruption instead of absence. Image build (image stage 06) applies the
-# same allowlist so a typoed AIRPLANES_FEED_BRANCH never reaches a flashed
-# rootfs.
+# Must be called AFTER bootstrap deps (git) are installed — the resolver
+# uses git ls-remote.
+airplanes_resolve_feed_branch() {
+    if [[ "${AIRPLANES_FEED_BRANCH:-}" != "stable" ]]; then
+        return 0
+    fi
+    local resolved rc=0
+    resolved="$(airplanes_resolve_latest_stable_tag "$AIRPLANES_FEED_REPO")" || rc=$?
+    case $rc in
+        0) AIRPLANES_FEED_BRANCH="$resolved" ;;
+        1)
+            echo "ERROR: stable release channel selected but no v[MAJOR].[MINOR].[PATCH] tags exist at $AIRPLANES_FEED_REPO." >&2
+            echo "       Keeping current install unchanged." >&2
+            exit 1
+            ;;
+        2)
+            echo "ERROR: could not query release tags from $AIRPLANES_FEED_REPO (network/DNS/TLS failure)." >&2
+            echo "       Keeping current install unchanged." >&2
+            exit 1
+            ;;
+    esac
+}
+
+# Image-built feeders pin their runtime-update channel via
+# /etc/airplanes/release-channel. Allowlist: stable, dev, main. Manual
+# installs without the file default to the stable channel.
+#
+# 'main' is accepted as a legacy alias for 'stable'. Pre-stable-release
+# images may have written 'main' to the file before this script learned
+# about stable-tag resolution; treating it as an alias keeps those
+# images updatable without forcing a re-flash.
+#
+# For the stable channel, AIRPLANES_FEED_BRANCH is set to the literal
+# string "stable" as a sentinel. The actual tag is resolved later by
+# airplanes_resolve_feed_branch (which calls git ls-remote, so it must
+# be invoked AFTER bootstrap deps install). This keeps the source-time
+# block cheap and lets curl-pipe-bash bootstrap reach deps install
+# before any network resolution.
+#
+# An explicit AIRPLANES_FEED_BRANCH env var bypasses this entire
+# mechanism so operators can pin to any ref for testing/recovery.
 if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
     _release_channel_file="${AIRPLANES_ROOT%/}/etc/airplanes/release-channel"
     if [[ -r "$_release_channel_file" ]]; then
         _release_channel="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
         case "$_release_channel" in
-            main|dev) AIRPLANES_FEED_BRANCH="$_release_channel" ;;
+            stable|main) AIRPLANES_FEED_BRANCH="stable" ;;
+            dev) AIRPLANES_FEED_BRANCH="dev" ;;
             *)
-                echo "ERROR: $_release_channel_file contains '$_release_channel' (expected one of: main, dev)" >&2
+                echo "ERROR: $_release_channel_file contains '$_release_channel' (expected one of: stable, dev, main)" >&2
                 exit 1
                 ;;
         esac
@@ -34,7 +99,7 @@ if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
     fi
     unset _release_channel_file
 fi
-AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
+AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-stable}"
 
 airplanes_path() {
     local path="$1"

--- a/test/test_inline_fallback_drift.bats
+++ b/test/test_inline_fallback_drift.bats
@@ -92,6 +92,8 @@ function_body() {
     lib="$(<"$LIB")"
 
     for fn in \
+        airplanes_resolve_latest_stable_tag \
+        airplanes_resolve_feed_branch \
         airplanes_path \
         airplanes_init_paths \
         airplanes_is_image_install \

--- a/test/test_install_script.bats
+++ b/test/test_install_script.bats
@@ -133,3 +133,66 @@ SH
     [ -f "$ROOT_DIR/root/standalone-setup-pwd" ]
     [ "$(cat "$ROOT_DIR/root/standalone-setup-pwd")" = "$ROOT_DIR/root/usr/local/share/airplanes/git" ]
 }
+
+# __FEED_REF__ template behavior: the source-tree install.sh leaves the
+# placeholder literal (release CI substitutes it before publishing as the
+# release asset). When literal, AIRPLANES_RELEASE_REF resets to empty and
+# the fallback chain lands on "main". When substituted (simulated here
+# via sed), AIRPLANES_RELEASE_REF holds the tag and AIRPLANES_FEED_BRANCH
+# resolves to it.
+
+extract_release_ref_eval() {
+    # Print the post-evaluation value of AIRPLANES_FEED_BRANCH when the
+    # script's inline fallback block runs in isolation. We extract only
+    # the marker handling + AIRPLANES_FEED_BRANCH assignment to avoid
+    # pulling in unrelated globals. Pattern matches the AIRPLANES_RELEASE_REF
+    # assignment line regardless of whether the placeholder has been
+    # substituted by release CI.
+    local script="$1"
+    awk '
+        /^[[:space:]]*AIRPLANES_RELEASE_REF=/ { in_block = 1 }
+        in_block { print }
+        in_block && /unset AIRPLANES_RELEASE_REF/ { exit }
+    ' "$script"
+}
+
+@test "inline fallback __FEED_REF__ literal falls through to main" {
+    local snippet
+    snippet="$(extract_release_ref_eval "$INSTALL")"
+    run env -u AIRPLANES_FEED_BRANCH bash -c "$snippet
+printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "inline fallback __FEED_REF__ substituted uses the tag value" {
+    local rendered="$ROOT_DIR/install-rendered.sh"
+    python3 -c '
+import sys
+src, dst, ref = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src) as f: c = f.read()
+with open(dst, "w") as f: f.write(c.replace("__FEED_REF__", ref, 1))
+' "$INSTALL" "$rendered" "v0.1.0"
+    local snippet
+    snippet="$(extract_release_ref_eval "$rendered")"
+    run env -u AIRPLANES_FEED_BRANCH bash -c "$snippet
+printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "v0.1.0" ]
+}
+
+@test "inline fallback __FEED_REF__ substituted still respects explicit env override" {
+    local rendered="$ROOT_DIR/install-rendered.sh"
+    python3 -c '
+import sys
+src, dst, ref = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src) as f: c = f.read()
+with open(dst, "w") as f: f.write(c.replace("__FEED_REF__", ref, 1))
+' "$INSTALL" "$rendered" "v0.1.0"
+    local snippet
+    snippet="$(extract_release_ref_eval "$rendered")"
+    run env AIRPLANES_FEED_BRANCH=v0.2.0-test bash -c "$snippet
+printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "v0.2.0-test" ]
+}

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -232,14 +232,38 @@ write_archive_fallback_stubs() {
     rm -rf "$fresh_root"
 }
 
-@test "missing release-channel falls back to main" {
+@test "missing release-channel falls back to stable sentinel" {
     local fresh_root
     fresh_root="$(mktemp -d)"
     mkdir -p "$fresh_root/etc"
     run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
         bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
     [ "$status" -eq 0 ]
-    [ "$output" = "main" ]
+    [ "$output" = "stable" ]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel file=stable sets AIRPLANES_FEED_BRANCH=stable sentinel" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'stable\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "stable" ]
+    rm -rf "$fresh_root"
+}
+
+@test "release-channel file=main treated as legacy alias for stable" {
+    local fresh_root
+    fresh_root="$(mktemp -d)"
+    mkdir -p "$fresh_root/etc/airplanes"
+    printf 'main\n' > "$fresh_root/etc/airplanes/release-channel"
+    run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
+        bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
+    [ "$status" -eq 0 ]
+    [ "$output" = "stable" ]
     rm -rf "$fresh_root"
 }
 
@@ -259,11 +283,11 @@ write_archive_fallback_stubs() {
     local fresh_root
     fresh_root="$(mktemp -d)"
     mkdir -p "$fresh_root/etc/airplanes"
-    printf 'main\nbogus\n' > "$fresh_root/etc/airplanes/release-channel"
+    printf 'dev\nbogus\n' > "$fresh_root/etc/airplanes/release-channel"
     run env -u AIRPLANES_FEED_BRANCH AIRPLANES_ROOT="$fresh_root" \
         bash -c "source $HELPER; printf '%s' \"\$AIRPLANES_FEED_BRANCH\""
     [ "$status" -eq 0 ]
-    [ "$output" = "main" ]
+    [ "$output" = "dev" ]
     rm -rf "$fresh_root"
 }
 
@@ -276,7 +300,7 @@ write_archive_fallback_stubs() {
         bash -c "source $HELPER"
     [ "$status" -ne 0 ]
     [[ "$output" == *"feature-x"* ]]
-    [[ "$output" == *"main, dev"* ]]
+    [[ "$output" == *"stable, dev, main"* ]]
     rm -rf "$fresh_root"
 }
 
@@ -325,4 +349,120 @@ write_archive_fallback_stubs() {
     [ "$status" -eq 0 ]
     [ "$output" = "feature-x" ]
     rm -rf "$fresh_root"
+}
+
+# Tag resolution: airplanes_resolve_latest_stable_tag picks the highest
+# semver-strict (vMAJOR.MINOR.PATCH, no leading zeroes, no prereleases) tag
+# from the configured feed remote. Tests use a local bare repo as the remote
+# so they don't depend on network or on the live feed repo's tag state.
+
+make_remote_with_tags() {
+    local remote_dir="$1"
+    shift
+    local work_dir
+    work_dir="$(mktemp -d)"
+    git -C "$work_dir" init -q -b main
+    git -C "$work_dir" config user.email test@example.invalid
+    git -C "$work_dir" config user.name "Test User"
+    echo "seed" > "$work_dir/seed"
+    git -C "$work_dir" add seed
+    git -C "$work_dir" commit -q -m "seed"
+    git init --bare -q "$remote_dir"
+    git -C "$work_dir" remote add origin "$remote_dir"
+    git -C "$work_dir" push -q origin main
+    local tag
+    for tag in "$@"; do
+        git -C "$work_dir" tag "$tag"
+    done
+    if (( $# > 0 )); then
+        git -C "$work_dir" push -q origin --tags
+    fi
+    rm -rf "$work_dir"
+}
+
+@test "airplanes_resolve_latest_stable_tag picks highest semver-strict tag" {
+    local remote
+    remote="$(mktemp -d)/remote.git"
+    make_remote_with_tags "$remote" v0.1.0 v0.1.1 v0.2.0 v1.0.0
+    run airplanes_resolve_latest_stable_tag "$remote"
+    [ "$status" -eq 0 ]
+    [ "$output" = "v1.0.0" ]
+}
+
+@test "airplanes_resolve_latest_stable_tag ignores prerelease tags" {
+    local remote
+    remote="$(mktemp -d)/remote.git"
+    make_remote_with_tags "$remote" v0.1.0 v0.2.0-rc.1 v0.2.0-rc.2
+    run airplanes_resolve_latest_stable_tag "$remote"
+    [ "$status" -eq 0 ]
+    [ "$output" = "v0.1.0" ]
+}
+
+@test "airplanes_resolve_latest_stable_tag rejects leading-zero versions" {
+    local remote
+    remote="$(mktemp -d)/remote.git"
+    make_remote_with_tags "$remote" v0.1.0 v01.02.03
+    run airplanes_resolve_latest_stable_tag "$remote"
+    [ "$status" -eq 0 ]
+    [ "$output" = "v0.1.0" ]
+}
+
+@test "airplanes_resolve_latest_stable_tag returns 1 when no matching tags" {
+    local remote
+    remote="$(mktemp -d)/remote.git"
+    make_remote_with_tags "$remote" v1.0 release-2024 some-feature
+    run airplanes_resolve_latest_stable_tag "$remote"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "airplanes_resolve_latest_stable_tag returns 2 on remote-not-found" {
+    run airplanes_resolve_latest_stable_tag "/nonexistent/path/repo.git"
+    [ "$status" -eq 2 ]
+}
+
+@test "airplanes_resolve_feed_branch resolves stable sentinel via remote" {
+    local remote
+    remote="$(mktemp -d)/remote.git"
+    make_remote_with_tags "$remote" v0.1.0 v0.2.0
+    AIRPLANES_FEED_REPO="$remote"
+    AIRPLANES_FEED_BRANCH=stable
+    airplanes_resolve_feed_branch
+    [ "$AIRPLANES_FEED_BRANCH" = "v0.2.0" ]
+}
+
+@test "airplanes_resolve_feed_branch leaves dev alone" {
+    AIRPLANES_FEED_BRANCH=dev
+    airplanes_resolve_feed_branch
+    [ "$AIRPLANES_FEED_BRANCH" = "dev" ]
+}
+
+@test "airplanes_resolve_feed_branch leaves explicit tag alone" {
+    AIRPLANES_FEED_BRANCH=v0.1.0
+    airplanes_resolve_feed_branch
+    [ "$AIRPLANES_FEED_BRANCH" = "v0.1.0" ]
+}
+
+@test "airplanes_resolve_feed_branch leaves arbitrary ref alone" {
+    AIRPLANES_FEED_BRANCH=feature-x
+    airplanes_resolve_feed_branch
+    [ "$AIRPLANES_FEED_BRANCH" = "feature-x" ]
+}
+
+@test "airplanes_resolve_feed_branch aborts with no-tags-found on stable channel + empty repo" {
+    local remote
+    remote="$(mktemp -d)/remote.git"
+    make_remote_with_tags "$remote" some-feature
+    run env AIRPLANES_FEED_REPO="$remote" AIRPLANES_FEED_BRANCH=stable \
+        bash -c "source $HELPER; airplanes_resolve_feed_branch"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no v[MAJOR].[MINOR].[PATCH] tags exist"* ]]
+}
+
+@test "airplanes_resolve_feed_branch aborts with lookup-failed on stable channel + bad remote" {
+    run env AIRPLANES_FEED_REPO="/nonexistent/path/repo.git" AIRPLANES_FEED_BRANCH=stable \
+        bash -c "source $HELPER; airplanes_resolve_feed_branch"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not query release tags"* ]]
+    [[ "$output" == *"network/DNS/TLS"* ]]
 }

--- a/update.sh
+++ b/update.sh
@@ -74,7 +74,10 @@ else
         local resolved rc=0
         resolved="$(airplanes_resolve_latest_stable_tag "$AIRPLANES_FEED_REPO")" || rc=$?
         case $rc in
-            0) AIRPLANES_FEED_BRANCH="$resolved" ;;
+            0)
+                AIRPLANES_FEED_BRANCH="$resolved"
+                export AIRPLANES_FEED_BRANCH
+                ;;
             1)
                 echo "ERROR: stable release channel selected but no v[MAJOR].[MINOR].[PATCH] tags exist at $AIRPLANES_FEED_REPO." >&2
                 echo "       Keeping current install unchanged." >&2

--- a/update.sh
+++ b/update.sh
@@ -40,20 +40,72 @@ else
     AIRPLANES_ROOT="${AIRPLANES_ROOT:-/}"
     AIRPLANES_FEED_REPO="${AIRPLANES_FEED_REPO:-https://github.com/airplanes-live/feed.git}"
 
-    # Image-built feeders pin their runtime-update branch to the channel they
-    # were built from via /etc/airplanes/release-channel. Without this, a
-    # dev-channel image silently falls back to feed/main and self-replaces
-    # update.sh with the older main version on the first update — sticky
-    # regression. Manual non-image installs (no release-channel file) keep
-    # the historical "main" default. Allowlist matches install-update-common.sh.
+    airplanes_resolve_latest_stable_tag() {
+        local repo="${1:-$AIRPLANES_FEED_REPO}"
+        local refs latest=""
+        if ! refs="$(GIT_TERMINAL_PROMPT=0 git ls-remote --tags --refs "$repo" 2>/dev/null)"; then
+            return 2
+        fi
+        if [[ -z "$refs" ]]; then
+            return 1
+        fi
+        local _sha _refname _tag
+        while IFS=$'\t' read -r _sha _refname; do
+            _tag="${_refname#refs/tags/}"
+            if [[ "$_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+                if [[ -z "$latest" ]]; then
+                    latest="$_tag"
+                else
+                    latest="$(printf '%s\n%s\n' "$latest" "$_tag" | sort -V | tail -n 1)"
+                fi
+            fi
+        done <<< "$refs"
+        if [[ -z "$latest" ]]; then
+            return 1
+        fi
+        printf '%s' "$latest"
+        return 0
+    }
+
+    airplanes_resolve_feed_branch() {
+        if [[ "${AIRPLANES_FEED_BRANCH:-}" != "stable" ]]; then
+            return 0
+        fi
+        local resolved rc=0
+        resolved="$(airplanes_resolve_latest_stable_tag "$AIRPLANES_FEED_REPO")" || rc=$?
+        case $rc in
+            0) AIRPLANES_FEED_BRANCH="$resolved" ;;
+            1)
+                echo "ERROR: stable release channel selected but no v[MAJOR].[MINOR].[PATCH] tags exist at $AIRPLANES_FEED_REPO." >&2
+                echo "       Keeping current install unchanged." >&2
+                exit 1
+                ;;
+            2)
+                echo "ERROR: could not query release tags from $AIRPLANES_FEED_REPO (network/DNS/TLS failure)." >&2
+                echo "       Keeping current install unchanged." >&2
+                exit 1
+                ;;
+        esac
+    }
+
+    # Image-built feeders pin their runtime-update channel via
+    # /etc/airplanes/release-channel. Allowlist: stable, dev, main. 'main'
+    # is accepted as a legacy alias for 'stable' so pre-stable images stay
+    # updatable without a re-flash. Manual installs without the file
+    # default to the stable channel.
+    #
+    # For the stable channel, AIRPLANES_FEED_BRANCH is set to the literal
+    # "stable" sentinel here; the actual tag is resolved later by
+    # airplanes_resolve_feed_branch (which calls git ls-remote).
     if [[ -z "${AIRPLANES_FEED_BRANCH:-}" ]]; then
         _release_channel_file="${AIRPLANES_ROOT%/}/etc/airplanes/release-channel"
         if [[ -r "$_release_channel_file" ]]; then
             _release_channel="$(head -n1 "$_release_channel_file" | tr -d '[:space:]')"
             case "$_release_channel" in
-                main|dev) AIRPLANES_FEED_BRANCH="$_release_channel" ;;
+                stable|main) AIRPLANES_FEED_BRANCH="stable" ;;
+                dev) AIRPLANES_FEED_BRANCH="dev" ;;
                 *)
-                    echo "ERROR: $_release_channel_file contains '$_release_channel' (expected one of: main, dev)" >&2
+                    echo "ERROR: $_release_channel_file contains '$_release_channel' (expected one of: stable, dev, main)" >&2
                     exit 1
                     ;;
             esac
@@ -61,7 +113,7 @@ else
         fi
         unset _release_channel_file
     fi
-    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-main}"
+    AIRPLANES_FEED_BRANCH="${AIRPLANES_FEED_BRANCH:-stable}"
 
     airplanes_path() {
         local path="$1"
@@ -245,6 +297,11 @@ touch "$LOGFILE"
 
 airplanes_install_update_deps
 hash -r
+
+# Resolve the "stable" channel sentinel into a concrete tag now that git is
+# guaranteed installed. No-op if AIRPLANES_FEED_BRANCH is already a concrete
+# ref (an explicit env override, "dev", or a tag the caller supplied).
+airplanes_resolve_feed_branch
 
 if [[ "$1" == "test" ]]; then
     TEST_GIT="${AIRPLANES_TEST_GIT:-/tmp/ax_test}"


### PR DESCRIPTION
**Status:** Draft — first of three coordinated PRs implementing the v0.1.0 release model. See the launch wave description below for ordering.

## What this PR does

Extends the existing release-channel mechanism in feed/ to support stable-channel tag resolution. Three behaviors stay backward-compatible (existing release-channel files with 'dev' or 'main' keep working); the new path adds stable-channel + tag resolution.

- `scripts/lib/install-update-common.sh` + `update.sh` inline fallback: `airplanes_resolve_latest_stable_tag` resolves the highest semver-strict (`v[0-9]+.[0-9]+.[0-9]+`, no leading zeroes, no prereleases) tag via `git ls-remote --tags --refs`. `airplanes_resolve_feed_branch` resolves the 'stable' sentinel value to a concrete tag, with distinct fail-closed errors for network failure vs no-matching-tags. Never falls back to a branch.
- Allowlist becomes {stable, dev, main}; 'main' is accepted as a legacy alias for 'stable' so pre-stable images stay updatable without re-flash.
- `install.sh` gets a `__FEED_REF__` template marker. Release CI renders it once (first occurrence only) into `dist/install.sh` with the tag substituted. The unrendered sentinel is built via shell string concat so the renderer's str.replace doesn't accidentally match it. Source-tree use falls through to 'main' default.
- `.github/workflows/release.yml`: tag-triggered (`v*`) full release flow — validate strict semver, run tests, render dist/install.sh, draft-first publish to GitHub Release with install.sh + update.sh + SHA256SUMS attached. `workflow_dispatch` validation mode renders against a caller-supplied tag-shaped string and exercises the pipeline without publishing.
- `docs/RELEASE_CHECKLIST.md`: maintainer runbook for cutting a release. Documents the tag-before-shim-swap ordering (if shim is applied before tagging, release CI renders the shim as the release asset and we'd get a self-referential redirect).
- `dist/install-shim.sh`: the compat shim that replaces `install.sh` on feed/main after a stable release exists. Lives in the repo until applied at launch wave step 4.
- README curl URLs updated to `releases/latest/download/install.sh` and `releases/latest/download/update.sh`.

## Merge order (three-PR launch wave)

1. **This PR (feed/dev)** — merge first.
2. **image/dev PR2** — splits build-time pin (`AIRPLANES_FEED_BRANCH`) from runtime channel (`AIRPLANES_FEED_UPDATE_CHANNEL=stable|dev`); stage 06 writes the channel name to `/etc/airplanes/release-channel` instead of the SHA. **Must follow PR1 on dev** — without PR2, stage 06 still writes a SHA, which PR1's new allowlist rejects. Image dev builds break in the gap. Recommend same-day lockstep merge.
3. **airplanes-update/dev PR3** — bridge clones feed at latest stable tag instead of branch HEAD. Independent of PR1/PR2 at the code level; merge anytime.

## TODO before marking ready

- [ ] PR2 (image/dev) opened — required for lockstep
- [ ] PR3 (airplanes-update/dev) opened
- [ ] Maintainer reviewed
- [ ] Run `workflow_dispatch` against this branch with `validation_ref=v0.0.0-validation` to exercise the release pipeline end-to-end (artifact-only mode, no real release published)

## Deferred (won't exist in v0.1.x)

Per scope discussion: RC tags, custom semver-with-prerelease comparator, AIRPLANES_FEED_BRANCH→FEED_REF rename, auto-bump CI workflow for image, and channel-aware airplanes-update bridge are all explicitly dropped (not deferred). If we later need them, that's its own PR with concrete motivation.