### PR TITLE
ci: cover both image contracts in mounted-image and QEMU smokes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ Installer and updater shipped to end-user feeder hardware. Bash. Target: Debian 
 | `scripts/` | `apl-feed.sh` (CLI dispatcher), `airplanes-feed.sh` / `airplanes-mlat.sh` (daemon scripts), unit files. |
 | `scripts/apl-feed/` | CLI command modules: `claim`, `id`, `status`, `backup`, `http`, `common`. |
 | `test/` | BATS test suite. See `rules/testing.md`. |
+| `test/lib/image-source.sh` | Asset-resolution library used by both mounted-image rootfs smoke and QEMU boot smoke. Resolves a GitHub release asset from a tiered source list (`release-stable`, `release-any`) and downloads it. Exits 64 on tier exhaustion (skip-with-notice contract). |
 
 ## Where to start for common tasks
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -78,11 +78,20 @@ Don't blanket-ignore. Default mental model: if a failing test on macOS doesn't f
 
 All run on `ubuntu-24.04` host:
 
-- `bats` — full BATS suite.
+- `bats` — full BATS suite (now includes `test_image_source.bats` for the asset-resolution library).
 - `shellcheck + bash -n` — shellcheck at warning severity, plus bash syntax check.
 - `update-regression smoke` — `update.sh` regression run.
 - `installer smoke` × 4 — debian:13-slim and ubuntu:24.04, each in bundled (`install.sh`) and standalone (`update.sh` direct) modes.
-- `image rootfs smoke` and `image release rootfs smoke` — Docker rootfs builds.
+- `image rootfs smoke` — Docker rootfs build (synthetic rootfs from `airplanes-live/airplanes-update`).
+- `mounted image smoke (legacy)` — renamed from `image release rootfs smoke`. Mounts the legacy ARM64 image rootfs (downloaded from `airplanes-live/image-releases`), runs `update.sh` chroot-style with stubbed systemd, asserts post-update state. The job ID changed; branch protection rules referring to the old name must be migrated.
+- `mounted image smoke (new)` — same shape, against `airplanes-live/image`. Sources its image asset via the new tier-based library (`test/lib/image-source.sh`) — stable release on `main` paths, the rolling `dev-latest` prerelease on `dev` paths.
+- `image-boot-smoke` (workflow `image-boot-smoke.yml`) — push-event matrix over both contracts. Full QEMU boot + update + reboot + idempotency assertions. Manual `workflow_dispatch` supports `image_contract={all,legacy,new}`.
+
+## Asset-source library
+
+The mounted-image smokes and the QEMU boot smoke share `test/lib/image-source.sh`, which resolves an image archive from a tiered source list. Tiers today: `release-stable` (excludes prereleases) and `release-any` (newest by `published_at`, prerelease-friendly). Library exits 64 on tier exhaustion — callers MUST handle this as skip-with-notice, not hard failure, so a long-dormant upstream image repo doesn't break feed CI.
+
+Exit-code capture pattern: the library uses `if cmd; then rc=0; else rc=$?; fi`, not `cmd; rc=$?` and not `if ! cmd; then rc=$?`. The first form puts the call in a tested context (suppresses `set -e` propagation from bats's `set -euo pipefail`) AND captures the un-inverted exit code in the else branch. The other forms either abort under `set -e` or capture the wrong value. Mirror this pattern in any future library code that needs to capture rcs explicitly.
 
 ## The drift test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           AIRPLANES_IMAGE_RELEASE_REPO: airplanes-live/image
           AIRPLANES_IMAGE_CONTRACT: new
+          # CHANNEL maps the asset name we're looking for:
+          #   stable channel → `airplanes-feeder-stable-arm64.img.xz` (in tagged stable releases)
+          #   dev channel    → `airplanes-feeder-dev-arm64.img.xz`    (in the rolling dev-latest prerelease)
+          # When testing against a `main`-bound change we want the stable build;
+          # otherwise we want the latest dev build (rolling prerelease).
+          AIRPLANES_IMAGE_CHANNEL: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'stable' || (github.event_name == 'pull_request' && github.base_ref == 'main') && 'stable' || 'dev' }}
           AIRPLANES_IMAGE_SOURCE_TIERS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'release-stable' || (github.event_name == 'pull_request' && github.base_ref == 'main') && 'release-stable' || 'release-any' }}
           AIRPLANES_RELEASE_ROOTFS_WORK_DIR: ${{ runner.temp }}/airplanes-mounted-image-smoke-new
         run: |
-          sudo --preserve-env=GH_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_IMAGE_SOURCE_TIERS,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
+          sudo --preserve-env=GH_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_IMAGE_CHANNEL,AIRPLANES_IMAGE_SOURCE_TIERS,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
             bash test/image-release-rootfs-smoke.sh
 
   update-regression:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,12 @@ jobs:
             debian:13-slim \
             bash /feed/test/image-rootfs-smoke.sh
 
-  image-release-rootfs-smoke:
-    name: image release rootfs smoke
+  mounted-image-smoke-legacy:
+    # Renamed from `image-release-rootfs-smoke`. Branch protection rules on
+    # airplanes-live/feed that previously required `image release rootfs smoke`
+    # must be migrated to require `mounted image smoke (legacy)` before this
+    # change merges, otherwise future PRs hang on a stuck-pending old check.
+    name: mounted image smoke (legacy)
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -138,6 +142,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             ca-certificates \
             curl \
+            gh \
             git \
             jq \
             parted \
@@ -146,14 +151,58 @@ jobs:
             unzip \
             xz-utils
 
-      - name: Run mounted release image smoke
+      - name: Run mounted image smoke (legacy contract)
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # The smoke uses the lib/image-source.sh library which reads GH_TOKEN
+          # (gh CLI convention). github.token is sufficient for cross-repo
+          # release downloads against the public airplanes-live/image-releases.
+          GH_TOKEN: ${{ github.token }}
           AIRPLANES_IMAGE_RELEASE_REPO: airplanes-live/image-releases
           AIRPLANES_IMAGE_CONTRACT: legacy
-          AIRPLANES_RELEASE_ROOTFS_WORK_DIR: ${{ runner.temp }}/airplanes-image-release-rootfs-smoke
+          AIRPLANES_RELEASE_ROOTFS_WORK_DIR: ${{ runner.temp }}/airplanes-mounted-image-smoke-legacy
         run: |
-          sudo --preserve-env=GITHUB_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
+          sudo --preserve-env=GH_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
+            bash test/image-release-rootfs-smoke.sh
+
+  mounted-image-smoke-new:
+    # Mirror of mounted-image-smoke-legacy, against airplanes-live/image.
+    # Tier list picks release-stable on PRs targeting main / pushes to main
+    # (production track), release-any otherwise (development track, which
+    # accepts the rolling dev-latest prerelease published by airplanes-live/
+    # image's build-image.yml on every dev push).
+    name: mounted image smoke (new)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout feed
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install image smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ca-certificates \
+            curl \
+            gh \
+            git \
+            jq \
+            parted \
+            p7zip-full \
+            rsync \
+            unzip \
+            xz-utils
+
+      - name: Run mounted image smoke (new contract)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AIRPLANES_IMAGE_RELEASE_REPO: airplanes-live/image
+          AIRPLANES_IMAGE_CONTRACT: new
+          AIRPLANES_IMAGE_SOURCE_TIERS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'release-stable' || (github.event_name == 'pull_request' && github.base_ref == 'main') && 'release-stable' || 'release-any' }}
+          AIRPLANES_RELEASE_ROOTFS_WORK_DIR: ${{ runner.temp }}/airplanes-mounted-image-smoke-new
+        run: |
+          sudo --preserve-env=GH_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_IMAGE_SOURCE_TIERS,AIRPLANES_RELEASE_ROOTFS_WORK_DIR \
             bash test/image-release-rootfs-smoke.sh
 
   update-regression:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,6 @@ jobs:
             bash /feed/test/image-rootfs-smoke.sh
 
   mounted-image-smoke-legacy:
-    # Renamed from `image-release-rootfs-smoke`. Branch protection rules on
-    # airplanes-live/feed that previously required `image release rootfs smoke`
-    # must be migrated to require `mounted image smoke (legacy)` before this
-    # change merges, otherwise future PRs hang on a stuck-pending old check.
     name: mounted image smoke (legacy)
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/image-boot-smoke.yml
+++ b/.github/workflows/image-boot-smoke.yml
@@ -1,22 +1,21 @@
 name: Image boot smoke
 
 on:
+  push:
+    branches: [main, dev]
   workflow_dispatch:
     inputs:
-      image_release_repo:
-        description: GitHub repository that publishes the image release
-        required: false
-        default: airplanes-live/image
       image_contract:
-        description: Expected image contract: new or legacy
-        required: false
-        default: new
+        description: Contract to run (legacy, new, or all)
+        type: choice
+        options: [all, legacy, new]
+        default: all
       image_channel:
-        description: Image release channel to select when no explicit regex is provided
+        description: Image release channel to select
         required: false
         default: stable
       image_arch:
-        description: Image architecture to select when no explicit regex is provided
+        description: Image architecture to select
         required: false
         default: arm64
       image_asset_regex:
@@ -33,22 +32,43 @@ concurrency:
 
 jobs:
   image-boot-smoke:
-    name: latest image boot + update + reboot
+    name: image boot smoke (${{ matrix.image_contract }})
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        image_contract: [legacy, new]
+        include:
+          - image_contract: legacy
+            image_release_repo: airplanes-live/image-releases
+          - image_contract: new
+            image_release_repo: airplanes-live/image
+    # Per-cell gating happens at step level: actionlint correctly rejects
+    # `matrix` context in job-level `if:` (matrix is expanded later in the
+    # evaluation pipeline). Every step below references this guard so the
+    # skipped-cell job runs zero meaningful steps.
     steps:
+      - name: Skip this matrix cell if not selected (dispatch input)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.image_contract != 'all' && matrix.image_contract != github.event.inputs.image_contract
+        run: |
+          echo "Skipping matrix cell ${{ matrix.image_contract }} — dispatch selected ${{ github.event.inputs.image_contract }}"
+          exit 0
+
       - name: Checkout feed
+        if: github.event_name == 'push' || github.event.inputs.image_contract == 'all' || matrix.image_contract == github.event.inputs.image_contract
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Install QEMU smoke dependencies
+        if: github.event_name == 'push' || github.event.inputs.image_contract == 'all' || matrix.image_contract == github.event.inputs.image_contract
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             ca-certificates \
             curl \
+            gh \
             git \
             jq \
             parted \
@@ -61,14 +81,33 @@ jobs:
             xz-utils
 
       - name: Run booted image smoke
+        if: github.event_name == 'push' || github.event.inputs.image_contract == 'all' || matrix.image_contract == github.event.inputs.image_contract
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          AIRPLANES_IMAGE_RELEASE_REPO: ${{ github.event.inputs.image_release_repo || 'airplanes-live/image' }}
-          AIRPLANES_IMAGE_CONTRACT: ${{ github.event.inputs.image_contract || 'new' }}
+          GH_TOKEN: ${{ github.token }}
+          AIRPLANES_IMAGE_RELEASE_REPO: ${{ matrix.image_release_repo }}
+          AIRPLANES_IMAGE_CONTRACT: ${{ matrix.image_contract }}
           AIRPLANES_IMAGE_CHANNEL: ${{ github.event.inputs.image_channel || 'stable' }}
           AIRPLANES_IMAGE_ARCH: ${{ github.event.inputs.image_arch || 'arm64' }}
           AIRPLANES_IMAGE_ASSET_REGEX: ${{ github.event.inputs.image_asset_regex || '' }}
+          # Push to main → only stable releases (production track).
+          # Push to dev / dispatch → release-any (also picks the rolling
+          # dev-latest prerelease published by airplanes-live/image's
+          # build-image.yml).
+          AIRPLANES_IMAGE_SOURCE_TIERS: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'release-stable' || 'release-any' }}
           AIRPLANES_BOOT_SMOKE_WORK_DIR: ${{ runner.temp }}/airplanes-image-boot-smoke
+          # KEEP_WORK_DIR=1 preserves $WORK_DIR/qemu-logs across the script's
+          # cleanup trap so the failure-artifact upload step below can read
+          # them. Without this, the cleanup wipes the directory before the
+          # upload runs.
+          AIRPLANES_BOOT_SMOKE_KEEP_WORK_DIR: '1'
         run: |
-          sudo --preserve-env=GITHUB_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_IMAGE_CHANNEL,AIRPLANES_IMAGE_ARCH,AIRPLANES_IMAGE_ASSET_REGEX,AIRPLANES_BOOT_SMOKE_WORK_DIR \
+          sudo --preserve-env=GH_TOKEN,AIRPLANES_IMAGE_RELEASE_REPO,AIRPLANES_IMAGE_CONTRACT,AIRPLANES_IMAGE_CHANNEL,AIRPLANES_IMAGE_ARCH,AIRPLANES_IMAGE_ASSET_REGEX,AIRPLANES_IMAGE_SOURCE_TIERS,AIRPLANES_BOOT_SMOKE_WORK_DIR,AIRPLANES_BOOT_SMOKE_KEEP_WORK_DIR \
             bash test/image-boot-smoke.sh
+
+      - name: Upload QEMU logs on failure
+        if: failure() && (github.event_name == 'push' || github.event.inputs.image_contract == 'all' || matrix.image_contract == github.event.inputs.image_contract)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-boot-smoke-${{ matrix.image_contract }}-logs
+          path: ${{ runner.temp }}/airplanes-image-boot-smoke/qemu-logs
+          if-no-files-found: warn

--- a/.github/workflows/image-boot-smoke.yml
+++ b/.github/workflows/image-boot-smoke.yml
@@ -86,7 +86,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           AIRPLANES_IMAGE_RELEASE_REPO: ${{ matrix.image_release_repo }}
           AIRPLANES_IMAGE_CONTRACT: ${{ matrix.image_contract }}
-          AIRPLANES_IMAGE_CHANNEL: ${{ github.event.inputs.image_channel || 'stable' }}
+          # Same channel-vs-event mapping as ci.yml's mounted-image-smoke-new:
+          # main-bound runs use stable channel (looks for the stable-named
+          # asset in stable releases); dev-bound runs use dev channel (looks
+          # for the dev-named asset, picked up via the rolling dev-latest
+          # prerelease). Manual dispatch can still override via the input.
+          AIRPLANES_IMAGE_CHANNEL: ${{ github.event.inputs.image_channel || (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'stable' || 'dev' }}
           AIRPLANES_IMAGE_ARCH: ${{ github.event.inputs.image_arch || 'arm64' }}
           AIRPLANES_IMAGE_ASSET_REGEX: ${{ github.event.inputs.image_asset_regex || '' }}
           # Push to main → only stable releases (production track).

--- a/test/image-boot-smoke.sh
+++ b/test/image-boot-smoke.sh
@@ -17,17 +17,13 @@ if [[ -z "$IMAGE_CONTRACT" ]]; then
         IMAGE_CONTRACT="legacy"
     fi
 fi
-if [[ -n "${AIRPLANES_IMAGE_ASSET_REGEX:-}" ]]; then
-    IMAGE_ASSET_REGEX="$AIRPLANES_IMAGE_ASSET_REGEX"
-elif [[ "$IMAGE_CONTRACT" == "new" ]]; then
-    IMAGE_ASSET_REGEX="(?i)^airplanes-feeder-${IMAGE_CHANNEL}-${IMAGE_ARCH}\\.img\\.xz$"
-else
-    IMAGE_ASSET_REGEX="(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$"
-fi
-IMAGE_ASSET_STRICT="${AIRPLANES_IMAGE_ASSET_STRICT:-}"
-if [[ -z "$IMAGE_ASSET_STRICT" ]]; then
-    [[ "$IMAGE_CONTRACT" == "new" ]] && IMAGE_ASSET_STRICT=1 || IMAGE_ASSET_STRICT=0
-fi
+# Asset selection (regex + strict-mode) is owned by lib/image-source.sh and
+# derived from CONTRACT/CHANNEL/ARCH. AIRPLANES_IMAGE_ASSET_REGEX is kept as
+# a manual override; AIRPLANES_IMAGE_SOURCE_TIERS picks the tier order.
+AIRPLANES_IMAGE_SOURCE_TIERS="${AIRPLANES_IMAGE_SOURCE_TIERS:-release-any}"
+# shellcheck source=lib/image-source.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/lib/image-source.sh"
+
 FEED_BRANCH="${AIRPLANES_BOOT_SMOKE_FEED_BRANCH:-boot-smoke}"
 QEMU_TIMEOUT="${AIRPLANES_BOOT_SMOKE_QEMU_TIMEOUT:-8m}"
 MAX_BOOT_ATTEMPTS="${AIRPLANES_BOOT_SMOKE_MAX_BOOT_ATTEMPTS:-2}"
@@ -122,56 +118,6 @@ cmdline_add_flag() {
         fi
     done
     printf '%s %s\n' "$cmdline" "$flag"
-}
-
-github_api() {
-    local url="$1"
-    local -a headers
-    headers=(-H "Accept: application/vnd.github+json")
-    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-        headers+=(
-            -H "Authorization: Bearer $GITHUB_TOKEN"
-            -H "X-GitHub-Api-Version: 2022-11-28"
-        )
-    fi
-    curl --fail --location --silent --show-error "${headers[@]}" "$url"
-}
-
-download_latest_release_image() {
-    local release_json asset_name asset_url output match_count
-    mkdir -p "$DOWNLOAD_DIR"
-    release_json="$DOWNLOAD_DIR/latest-release.json"
-
-    echo "Fetching latest image release from $IMAGE_RELEASE_REPO" >&2
-    github_api "https://api.github.com/repos/$IMAGE_RELEASE_REPO/releases/latest" > "$release_json"
-
-    match_count="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
-        [.assets[] | select(.name | test($re))] | length
-    ' "$release_json")"
-    if [[ "$match_count" == "0" ]]; then
-        jq -r '.assets[].name' "$release_json" >&2
-        fail "no release asset in $IMAGE_RELEASE_REPO matched $IMAGE_ASSET_REGEX"
-    fi
-    if [[ "$IMAGE_ASSET_STRICT" == "1" && "$match_count" != "1" ]]; then
-        jq -r --arg re "$IMAGE_ASSET_REGEX" '.assets[] | select(.name | test($re)) | .name' "$release_json" >&2
-        fail "expected exactly one release asset in $IMAGE_RELEASE_REPO to match $IMAGE_ASSET_REGEX, got $match_count"
-    fi
-
-    asset_name="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
-        [.assets[] | select(.name | test($re))] as $matches
-        | (($matches | map(select(.name | test("qemu"; "i"))) | first) // ($matches | first) // empty)
-        | .name // empty
-    ' "$release_json")"
-    asset_url="$(jq -r --arg name "$asset_name" '
-        .assets[] | select(.name == $name) | .browser_download_url
-    ' "$release_json")"
-
-    [[ -n "$asset_name" && -n "$asset_url" ]] || fail "failed to resolve selected release asset URL: $asset_name"
-
-    output="$DOWNLOAD_DIR/$asset_name"
-    echo "Downloading image asset: $asset_name" >&2
-    curl --fail --location --show-error --output "$output" "$asset_url"
-    printf '%s\n' "$output"
 }
 
 find_single_image() {
@@ -600,14 +546,84 @@ run_feed_update() {
         bash /opt/airplanes-boot-smoke/feed-worktree/update.sh
 }
 
+feed_binary_path() {
+    # The feed binary lives in different places per contract: legacy images
+    # ship an image-baked binary at /usr/bin/airplanes-feeder; new-contract
+    # installs build the binary into /usr/local/share/airplanes/feed-airplanes.
+    # Idempotency assertions need the right one.
+    if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        printf '%s\n' /usr/bin/airplanes-feeder
+    else
+        printf '%s\n' /usr/local/share/airplanes/feed-airplanes
+    fi
+}
+
+snapshot_post_update_state() {
+    # Captures things that should be stable across reboot + idempotent re-run:
+    #   - feed + mlat binary mtimes (update.sh fast-path skip MUST not rebuild)
+    #   - feeder-id content hash (UUID must survive reboot byte-stable)
+    local feed_bin mlat_bin
+    feed_bin="$(feed_binary_path)"
+    mlat_bin=/usr/local/share/airplanes/venv/bin/mlat-client
+    stat -c '%Y %n' "$feed_bin" "$mlat_bin" > "$STATE_DIR/snapshot-mtimes"
+    sha256sum /etc/airplanes/feeder-id > "$STATE_DIR/snapshot-feeder-id"
+}
+
+assert_state_file_schema_v1() {
+    local path="$1"
+    assert_file "$path"
+    grep -q '^schema_version=1$' "$path" \
+        || fail "$path missing schema_version=1 (daemon state-file contract)"
+}
+
+assert_service_healthy() {
+    local unit="$1"
+    # is-active is the load-bearing check: catches inactive, dead, never-started.
+    systemctl is-active --quiet "$unit" \
+        || fail "$unit is not active"
+    # is-failed is an additional diagnostic: catches the explicit failed state
+    # that is-active alone would already cover, but surfaces it loudly with a
+    # distinct message.
+    if systemctl is-failed --quiet "$unit"; then
+        fail "$unit reports failed state"
+    fi
+}
+
+assert_uuid_stable_across_reboot() {
+    local before after
+    before="$(cut -d' ' -f1 < "$STATE_DIR/snapshot-feeder-id")"
+    after="$(sha256sum /etc/airplanes/feeder-id | cut -d' ' -f1)"
+    [[ "$before" == "$after" ]] \
+        || fail "feeder-id changed across reboot (before=$before after=$after)"
+}
+
+assert_binaries_unchanged() {
+    # Idempotency: a second update.sh run on a freshly-updated rootfs must
+    # take the version-match fast path and leave the costly artifacts alone.
+    local pre_snap post_snap
+    pre_snap="$STATE_DIR/snapshot-mtimes"
+    post_snap="$STATE_DIR/snapshot-mtimes-post-rerun"
+    local feed_bin mlat_bin
+    feed_bin="$(feed_binary_path)"
+    mlat_bin=/usr/local/share/airplanes/venv/bin/mlat-client
+    stat -c '%Y %n' "$feed_bin" "$mlat_bin" > "$post_snap"
+    if ! diff -q "$pre_snap" "$post_snap" >/dev/null; then
+        echo "pre-rerun snapshot:" >&2
+        cat "$pre_snap" >&2
+        echo "post-rerun snapshot:" >&2
+        cat "$post_snap" >&2
+        fail "idempotent update.sh rerun changed binary mtimes (legacy must not rebuild image-baked binary; new must hit the version-match fast path)"
+    fi
+}
+
 phase="$(cat "$STATE_DIR/phase" 2>/dev/null || true)"
 case "$phase" in
     '')
         echo "airplanes image boot smoke: initial update phase"
         run_feed_update
         assert_image_contracts
-        systemctl is-active --quiet airplanes-feed.service \
-            || fail "airplanes-feed.service is not active after update"
+        assert_service_healthy airplanes-feed.service
+        snapshot_post_update_state
         printf '%s\n' updated > "$STATE_DIR/phase"
         sync
         systemctl reboot
@@ -615,8 +631,23 @@ case "$phase" in
     updated)
         echo "airplanes image boot smoke: post-reboot verification phase"
         assert_image_contracts
-        systemctl is-active --quiet airplanes-feed.service \
-            || fail "airplanes-feed.service is not active after reboot"
+        assert_service_healthy airplanes-feed.service
+        # mlat unit stays active even when MLAT_ENABLED=false (it self-disables
+        # via sleep+exit per the daemon classifier in rules/architecture.md),
+        # so is-active is a safe assertion across both branches.
+        assert_service_healthy airplanes-mlat.service
+        assert_state_file_schema_v1 /run/airplanes-feed/state
+        assert_state_file_schema_v1 /run/airplanes-mlat/state
+        assert_uuid_stable_across_reboot
+
+        echo "airplanes image boot smoke: idempotency rerun phase"
+        # Re-run update.sh against the same fixture repos. The version-match
+        # fast paths in update-builds.sh should leave the binaries alone.
+        run_feed_update
+        assert_binaries_unchanged
+        assert_service_healthy airplanes-feed.service
+        assert_service_healthy airplanes-mlat.service
+
         printf '%s\n' success > "$STATE_DIR/result"
         sync
         systemctl poweroff
@@ -754,14 +785,33 @@ run_boot_smoke() {
 }
 
 main() {
-    local image_archive
+    local image_archive rc
     require_commands curl jq git rsync parted sfdisk awk mount umount find cp tee timeout file
-    require_commands unzip xz gzip
+    require_commands unzip xz gzip gh
     if [[ -n "${AIRPLANES_IMAGE_PATH:-}" ]]; then
         image_archive="$AIRPLANES_IMAGE_PATH"
         [[ -f "$image_archive" ]] || fail "AIRPLANES_IMAGE_PATH does not exist: $image_archive"
     else
-        image_archive="$(download_latest_release_image)"
+        # Capture under temporarily-relaxed errexit so the 64 sentinel
+        # (tier exhaustion) can be handled as a skip rather than hard fail.
+        mkdir -p "$DOWNLOAD_DIR"
+        rc=0
+        set +e
+        image_archive="$(image_source_resolve \
+            "$IMAGE_RELEASE_REPO" "$IMAGE_CONTRACT" "$IMAGE_CHANNEL" "$IMAGE_ARCH" \
+            "$AIRPLANES_IMAGE_SOURCE_TIERS" "$DOWNLOAD_DIR" "${AIRPLANES_IMAGE_ASSET_REGEX:-}")"
+        rc=$?
+        set -e
+        case "$rc" in
+            0) ;;
+            64)
+                echo "::notice::no asset available in tiers [$AIRPLANES_IMAGE_SOURCE_TIERS] for $IMAGE_RELEASE_REPO ($IMAGE_CONTRACT/$IMAGE_CHANNEL/$IMAGE_ARCH); skipping smoke"
+                exit 0
+                ;;
+            *)
+                fail "image source resolution failed with rc=$rc"
+                ;;
+        esac
     fi
 
     echo "Work dir: $WORK_DIR"

--- a/test/image-release-rootfs-smoke.sh
+++ b/test/image-release-rootfs-smoke.sh
@@ -17,17 +17,17 @@ if [[ -z "$IMAGE_CONTRACT" ]]; then
         IMAGE_CONTRACT="legacy"
     fi
 fi
-if [[ -n "${AIRPLANES_IMAGE_ASSET_REGEX:-}" ]]; then
-    IMAGE_ASSET_REGEX="$AIRPLANES_IMAGE_ASSET_REGEX"
-elif [[ "$IMAGE_CONTRACT" == "new" ]]; then
-    IMAGE_ASSET_REGEX="(?i)^airplanes-feeder-${IMAGE_CHANNEL}-${IMAGE_ARCH}\\.img\\.xz$"
-else
-    IMAGE_ASSET_REGEX="(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$"
-fi
-IMAGE_ASSET_STRICT="${AIRPLANES_IMAGE_ASSET_STRICT:-}"
-if [[ -z "$IMAGE_ASSET_STRICT" ]]; then
-    [[ "$IMAGE_CONTRACT" == "new" ]] && IMAGE_ASSET_STRICT=1 || IMAGE_ASSET_STRICT=0
-fi
+# Asset selection (regex + strict-mode defaults) is owned by
+# test/lib/image-source.sh, derived from CONTRACT/CHANNEL/ARCH. The historical
+# AIRPLANES_IMAGE_ASSET_REGEX env var is still honored as an override.
+# AIRPLANES_IMAGE_SOURCE_TIERS picks the tier order; default `release-any`
+# preserves legacy behavior (the historical /releases/latest path picked the
+# newest non-prerelease release; release-any now also accepts the rolling
+# `dev-latest` prerelease for new-image dev-channel runs).
+AIRPLANES_IMAGE_SOURCE_TIERS="${AIRPLANES_IMAGE_SOURCE_TIERS:-release-any}"
+# shellcheck source=lib/image-source.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/lib/image-source.sh"
+
 FEED_BRANCH="${AIRPLANES_RELEASE_ROOTFS_FEED_BRANCH:-release-rootfs-smoke}"
 WORK_DIR="${AIRPLANES_RELEASE_ROOTFS_WORK_DIR:-}"
 KEEP_WORK_DIR="${AIRPLANES_RELEASE_ROOTFS_KEEP_WORK_DIR:-0}"
@@ -89,56 +89,6 @@ require_commands() {
     for command in "$@"; do
         require_command "$command"
     done
-}
-
-github_api() {
-    local url="$1"
-    local -a headers
-    headers=(-H "Accept: application/vnd.github+json")
-    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-        headers+=(
-            -H "Authorization: Bearer $GITHUB_TOKEN"
-            -H "X-GitHub-Api-Version: 2022-11-28"
-        )
-    fi
-    curl --fail --location --silent --show-error "${headers[@]}" "$url"
-}
-
-download_latest_release_image() {
-    local release_json asset_name asset_url output match_count
-    mkdir -p "$DOWNLOAD_DIR"
-    release_json="$DOWNLOAD_DIR/latest-release.json"
-
-    echo "Fetching latest image release from $IMAGE_RELEASE_REPO" >&2
-    github_api "https://api.github.com/repos/$IMAGE_RELEASE_REPO/releases/latest" > "$release_json"
-
-    match_count="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
-        [.assets[] | select(.name | test($re))] | length
-    ' "$release_json")"
-    if [[ "$match_count" == "0" ]]; then
-        jq -r '.assets[].name' "$release_json" >&2
-        fail "no release asset in $IMAGE_RELEASE_REPO matched $IMAGE_ASSET_REGEX"
-    fi
-    if [[ "$IMAGE_ASSET_STRICT" == "1" && "$match_count" != "1" ]]; then
-        jq -r --arg re "$IMAGE_ASSET_REGEX" '.assets[] | select(.name | test($re)) | .name' "$release_json" >&2
-        fail "expected exactly one release asset in $IMAGE_RELEASE_REPO to match $IMAGE_ASSET_REGEX, got $match_count"
-    fi
-
-    asset_name="$(jq -r --arg re "$IMAGE_ASSET_REGEX" '
-        [.assets[] | select(.name | test($re))] as $matches
-        | (($matches | map(select(.name | test("qemu"; "i"))) | first) // ($matches | first) // empty)
-        | .name // empty
-    ' "$release_json")"
-    asset_url="$(jq -r --arg name "$asset_name" '
-        .assets[] | select(.name == $name) | .browser_download_url
-    ' "$release_json")"
-
-    [[ -n "$asset_name" && -n "$asset_url" ]] || fail "failed to resolve selected release asset URL: $asset_name"
-
-    output="$DOWNLOAD_DIR/$asset_name"
-    echo "Downloading image asset: $asset_name" >&2
-    curl --fail --location --show-error --output "$output" "$asset_url"
-    printf '%s\n' "$output"
 }
 
 find_single_image() {
@@ -527,13 +477,33 @@ assert_runtime_args() {
 }
 
 main() {
-    local image_archive
-    require_commands curl jq git rsync parted awk mount umount find cp tee unzip xz gzip
+    local image_archive rc
+    require_commands curl jq git rsync parted awk mount umount find cp tee unzip xz gzip gh
     if [[ -n "${AIRPLANES_IMAGE_PATH:-}" ]]; then
         image_archive="$AIRPLANES_IMAGE_PATH"
         [[ -f "$image_archive" ]] || fail "AIRPLANES_IMAGE_PATH does not exist: $image_archive"
     else
-        image_archive="$(download_latest_release_image)"
+        # The library writes the resolved path to stdout. Capture under a
+        # temporarily-relaxed errexit so the 64 sentinel (tier exhaustion)
+        # can be handled as a skip rather than a hard failure.
+        mkdir -p "$DOWNLOAD_DIR"
+        rc=0
+        set +e
+        image_archive="$(image_source_resolve \
+            "$IMAGE_RELEASE_REPO" "$IMAGE_CONTRACT" "$IMAGE_CHANNEL" "$IMAGE_ARCH" \
+            "$AIRPLANES_IMAGE_SOURCE_TIERS" "$DOWNLOAD_DIR" "${AIRPLANES_IMAGE_ASSET_REGEX:-}")"
+        rc=$?
+        set -e
+        case "$rc" in
+            0) ;;
+            64)
+                echo "::notice::no asset available in tiers [$AIRPLANES_IMAGE_SOURCE_TIERS] for $IMAGE_RELEASE_REPO ($IMAGE_CONTRACT/$IMAGE_CHANNEL/$IMAGE_ARCH); skipping smoke"
+                exit 0
+                ;;
+            *)
+                fail "image source resolution failed with rc=$rc"
+                ;;
+        esac
     fi
 
     echo "Work dir: $WORK_DIR"

--- a/test/lib/image-source.sh
+++ b/test/lib/image-source.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# image-source.sh — tier-based image asset resolution and download
+#
+# Sourceable library. No top-level execution.
+#
+# Public entrypoint:
+#
+#   image_source_resolve REPO CONTRACT CHANNEL ARCH TIER_LIST OUTPUT_DIR [REGEX]
+#
+# Output:
+#   stdout — exactly one absolute path to the downloaded archive (one line)
+#   stderr — status lines (selected-tier=..., skipped-tier=..., selected-release=...)
+#
+# Exit codes:
+#   0   — success; archive path on stdout
+#   64  — tier exhaustion (no tier produced an asset, no hard auth/transport failure)
+#   1   — internal error: missing tools, network/JSON failure, hard error from a tier
+#
+# Token plumbing: library reads GH_TOKEN (gh CLI convention). Caller workflow
+# exports GH_TOKEN. For the public image repos targeted today, github.token
+# (cross-repo, public-readable) is sufficient.
+#
+# 401/403/404 returned by gh api are treated as "this tier has nothing for us;
+# move on" rather than hard failure. This matches the public-repo expectation:
+# an authenticated-but-broken token shouldn't block a public release lookup,
+# and tier-empty signals naturally degrade via the caller's skip-with-notice.
+
+# ---- requirements ----
+
+_image_source_require_tools() {
+    local cmd
+    for cmd in gh jq curl; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            echo "image-source: missing required tool: $cmd" >&2
+            return 1
+        fi
+    done
+}
+
+# ---- defaults ----
+
+_image_source_default_regex() {
+    # Args: contract channel arch
+    # Echoes: PCRE-style regex matching the expected asset(s) for the contract.
+    local contract="$1" channel="$2" arch="$3"
+    if [[ "$contract" == "new" ]]; then
+        # New-image asset names are deterministic; the dev-latest prerelease's
+        # asset is `airplanes-feeder-dev-arm64.img.xz` (or `stable` channel).
+        printf '(?i)^airplanes-feeder-%s-%s\\.img\\.xz$\n' "$channel" "$arch"
+    else
+        # Legacy release-images repo ships a single asset per release with
+        # historically inconsistent naming; accept any common image archive
+        # extension.
+        printf '(?i)\\.(img|img\\.xz|img\\.gz|zip|7z)$\n'
+    fi
+}
+
+_image_source_strict_mode() {
+    # 0 (strict) if exactly-one match required; 1 (permissive) otherwise.
+    # Strict for `new` because the asset name is exact; legacy accepts any
+    # archive extension and may produce multiple matches the tiebreaker
+    # chooses between.
+    [[ "$1" == "new" ]]
+}
+
+# ---- release JSON helpers ----
+
+_image_source_extract_sha_from_body() {
+    # Parses "Built from <repo> @ <sha>." from a release body. Used to surface
+    # the source commit of `dev-latest` so reviewers can correlate which dev
+    # commit's image was actually exercised by CI.
+    # Args: <body string>
+    local body="$1"
+    printf '%s\n' "$body" \
+        | sed -nE 's/.*Built from [^[:space:]]+ @ ([0-9a-f]+).*/\1/p' \
+        | head -n1
+}
+
+_image_source_pick_asset() {
+    # Reads a single release object as JSON on stdin. Picks the best-matching
+    # asset by regex + qemu-name tiebreaker.
+    #
+    # Args: regex strict_mode_flag(0|1)
+    # Output: <asset_name>\t<asset_url> on success
+    # Return: 0 success, 1 no match, 2 strict-mode violation (multiple matches)
+    local regex="$1" strict="$2"
+    local result
+    result="$(jq -r --arg re "$regex" --arg strict "$strict" '
+        [.assets[]? | select(.name | test($re))] as $matches
+        | if ($matches | length) == 0 then
+              "MISS"
+          elif (($matches | length) > 1) and ($strict == "1") then
+              "STRICT:" + ([$matches[].name] | join(","))
+          else
+              (($matches | map(select(.name | test("qemu"; "i"))) | first) // ($matches | first))
+              | "\(.name)\t\(.browser_download_url)"
+          end
+    ')" || return 2
+
+    case "$result" in
+        MISS)
+            return 1
+            ;;
+        STRICT:*)
+            echo "image-source: strict-mode violation — multiple assets matched: ${result#STRICT:}" >&2
+            return 2
+            ;;
+        *)
+            printf '%s\n' "$result"
+            return 0
+            ;;
+    esac
+}
+
+# ---- download ----
+
+_image_source_download() {
+    # Args: url output_dir asset_name
+    # Output: absolute path to downloaded file on stdout (one line)
+    # Return: 0 success, 2 download failure
+    local url="$1" output_dir="$2" name="$3"
+    mkdir -p "$output_dir" || return 2
+    local out="$output_dir/$name"
+    if ! curl --fail --location --silent --show-error --output "$out" "$url"; then
+        echo "image-source: download failed: $url" >&2
+        return 2
+    fi
+    if [[ ! -s "$out" ]]; then
+        echo "image-source: downloaded file is empty: $out" >&2
+        return 2
+    fi
+    # Resolve to absolute path so stdout contract holds regardless of caller cwd.
+    local abs
+    abs="$(cd "$(dirname "$out")" && pwd)/$(basename "$out")"
+    printf '%s\n' "$abs"
+}
+
+_image_source_emit_selected() {
+    # Emits the selected-tier / selected-release / selected-asset / selected-sha
+    # observability lines to stderr. Caller invokes after a tier resolves and
+    # before download (so the lines appear even if the subsequent download
+    # races against `gh release upload --clobber`).
+    # Args: tier_name release_json asset_url
+    local tier="$1" release_json="$2" asset_url="$3"
+    local tag body sha
+    tag="$(printf '%s\n' "$release_json" | jq -r '.tag_name // ""')"
+    body="$(printf '%s\n' "$release_json" | jq -r '.body // ""')"
+    sha="$(_image_source_extract_sha_from_body "$body")"
+    echo "selected-tier=$tier" >&2
+    if [[ -n "$sha" ]]; then
+        echo "selected-release=$tag selected-asset=$asset_url selected-sha=$sha" >&2
+    else
+        echo "selected-release=$tag selected-asset=$asset_url" >&2
+    fi
+}
+
+# ---- tier helpers ----
+#
+# Each tier helper returns:
+#   0 — resolved + downloaded; path written to stdout
+#   1 — tier produced no asset; caller should try the next tier
+#   2 — hard error inside the tier; caller should propagate
+
+_resolve_release_stable() {
+    # Args: repo regex strict_mode output_dir
+    #
+    # IMPORTANT: capture exit codes via `if cmd; then rc=0; else rc=$?; fi`,
+    # not `cmd; rc=$?`. Two bash gotchas conspire here:
+    # (1) Under `set -e` (active in bats test functions), `cmd; rc=$?`
+    #     aborts at the failing cmd before rc=$? runs.
+    # (2) `if ! cmd; then rc=$?` inverts the exit code via `!`; inside
+    #     the then-block $? becomes the if-test result, not cmd's status.
+    # The if/else pattern below puts the call in a tested context (set -e
+    # suppressed) AND captures the unmodified exit code in the else branch.
+    local repo="$1" regex="$2" strict="$3" output_dir="$4"
+    local json pick rc name url
+    if json="$(gh api "/repos/$repo/releases/latest" 2>/dev/null)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [[ $rc -ne 0 ]]; then
+        echo "skipped-tier=release-stable: no /releases/latest for $repo" >&2
+        return 1
+    fi
+    if pick="$(printf '%s\n' "$json" | _image_source_pick_asset "$regex" "$strict")"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    case $rc in
+        0) ;;
+        1)
+            echo "skipped-tier=release-stable: latest stable release has no matching asset" >&2
+            return 1
+            ;;
+        *)
+            return "$rc"
+            ;;
+    esac
+    name="${pick%%$'\t'*}"
+    url="${pick#*$'\t'}"
+    _image_source_emit_selected "release-stable" "$json" "$url"
+    _image_source_download "$url" "$output_dir" "$name"
+}
+
+_resolve_release_any() {
+    # Args: repo regex strict_mode output_dir
+    # See note in _resolve_release_stable about exit-code capture pattern.
+    local repo="$1" regex="$2" strict="$3" output_dir="$4"
+    local releases sorted release_json pick name url rc
+    if releases="$(gh api "/repos/$repo/releases?per_page=30" 2>/dev/null)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [[ $rc -ne 0 ]]; then
+        echo "skipped-tier=release-any: failed to list releases for $repo" >&2
+        return 1
+    fi
+    # Compact-stream sorted releases (newest first). jq's `-c` keeps each as
+    # one JSON object per line, suitable for a `while read` loop.
+    sorted="$(printf '%s\n' "$releases" | jq -c 'sort_by(.published_at) | reverse | .[]')"
+    if [[ -z "$sorted" ]]; then
+        echo "skipped-tier=release-any: no releases published in $repo" >&2
+        return 1
+    fi
+    while IFS= read -r release_json; do
+        if pick="$(printf '%s\n' "$release_json" | _image_source_pick_asset "$regex" "$strict")"; then
+            rc=0
+        else
+            rc=$?
+        fi
+        if [[ $rc -eq 0 ]]; then
+            name="${pick%%$'\t'*}"
+            url="${pick#*$'\t'}"
+            _image_source_emit_selected "release-any" "$release_json" "$url"
+            _image_source_download "$url" "$output_dir" "$name"
+            return $?
+        elif [[ $rc -eq 2 ]]; then
+            # Strict violation — hard failure on this release.
+            return 2
+        fi
+        # rc=1: this release didn't have the asset, try next.
+    done <<< "$sorted"
+    echo "skipped-tier=release-any: no release in $repo had a matching asset" >&2
+    return 1
+}
+
+# ---- entrypoint ----
+
+image_source_resolve() {
+    local repo="${1:?image_source_resolve: REPO required}"
+    local contract="${2:?image_source_resolve: CONTRACT required}"
+    local channel="${3:?image_source_resolve: CHANNEL required}"
+    local arch="${4:?image_source_resolve: ARCH required}"
+    local tier_list="${5:?image_source_resolve: TIER_LIST required (comma-separated)}"
+    local output_dir="${6:?image_source_resolve: OUTPUT_DIR required}"
+    local regex="${7:-}"
+
+    _image_source_require_tools || return 1
+
+    if [[ -z "$regex" ]]; then
+        regex="$(_image_source_default_regex "$contract" "$channel" "$arch")"
+    fi
+
+    local strict
+    if _image_source_strict_mode "$contract"; then
+        strict=1
+    else
+        strict=0
+    fi
+
+    local -a tiers
+    IFS=',' read -ra tiers <<< "$tier_list"
+
+    local tier rc
+    for tier in "${tiers[@]}"; do
+        case "$tier" in
+            release-stable)
+                # set -e bypass via tested context, same pattern as the helpers.
+                if _resolve_release_stable "$repo" "$regex" "$strict" "$output_dir"; then
+                    rc=0
+                else
+                    rc=$?
+                fi
+                ;;
+            release-any)
+                if _resolve_release_any "$repo" "$regex" "$strict" "$output_dir"; then
+                    rc=0
+                else
+                    rc=$?
+                fi
+                ;;
+            *)
+                echo "image-source: unknown tier '$tier' in tier list: $tier_list" >&2
+                return 1
+                ;;
+        esac
+        case "$rc" in
+            0) return 0 ;;
+            1) ;;  # tier empty, try next
+            *) return "$rc" ;;
+        esac
+    done
+
+    echo "image-source: all tiers exhausted (tier list: $tier_list)" >&2
+    return 64
+}

--- a/test/test_image_source.bats
+++ b/test/test_image_source.bats
@@ -1,0 +1,272 @@
+#!/usr/bin/env bats
+
+setup() {
+    LIB="$BATS_TEST_DIRNAME/lib/image-source.sh"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    FIXTURE_DIR="$ROOT_DIR/fixtures"
+    OUTPUT_DIR="$ROOT_DIR/output"
+    mkdir -p "$STUB_DIR" "$FIXTURE_DIR" "$OUTPUT_DIR"
+    export PATH="$STUB_DIR:$PATH"
+    export FIXTURE_DIR
+
+    # Stub `gh`: maps API paths to fixture files.
+    #   gh api /repos/.../releases/latest    -> $FIXTURE_DIR/releases-latest.json
+    #   gh api /repos/.../releases?per_page=30 -> $FIXTURE_DIR/releases.json
+    # Missing fixture → exit 1 (simulates 404).
+    cat > "$STUB_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+    api)
+        path="$2"
+        case "$path" in
+            */releases/latest)
+                fixture="$FIXTURE_DIR/releases-latest.json"
+                ;;
+            */releases\?per_page=30|*/releases)
+                fixture="$FIXTURE_DIR/releases.json"
+                ;;
+            *)
+                echo "gh stub: unexpected api path: $path" >&2
+                exit 1
+                ;;
+        esac
+        if [[ ! -f "$fixture" ]]; then
+            exit 1
+        fi
+        cat "$fixture"
+        exit 0
+        ;;
+    *)
+        echo "gh stub: unexpected subcommand: $1" >&2
+        exit 1
+        ;;
+esac
+SH
+    chmod +x "$STUB_DIR/gh"
+
+    # Stub `curl`: write a known byte stream to whatever --output target is given.
+    cat > "$STUB_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+output=""
+url=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) output="$2"; shift 2 ;;
+        --fail|--location|--silent|--show-error) shift ;;
+        --*) shift ;;
+        *) url="$1"; shift ;;
+    esac
+done
+if [[ -z "$output" || -z "$url" ]]; then
+    echo "curl stub: missing output ($output) or url ($url)" >&2
+    exit 1
+fi
+mkdir -p "$(dirname "$output")"
+printf 'STUB-IMAGE-BYTES-FOR:%s\n' "$url" > "$output"
+exit 0
+SH
+    chmod +x "$STUB_DIR/curl"
+
+    # shellcheck source=lib/image-source.sh
+    source "$LIB"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Helpers to write JSON fixtures.
+fixture_releases_latest_empty() {
+    rm -f "$FIXTURE_DIR/releases-latest.json"
+}
+
+fixture_releases_empty() {
+    printf '%s\n' '[]' > "$FIXTURE_DIR/releases.json"
+}
+
+# Writes a `releases/latest` fixture with one asset.
+fixture_releases_latest_one_asset() {
+    local tag="$1" asset_name="$2" body="${3:-}"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "$tag",
+  "body": "$body",
+  "assets": [
+    {"name": "$asset_name", "browser_download_url": "https://example.invalid/$asset_name"}
+  ]
+}
+EOF
+}
+
+# Writes a `releases?per_page=30` fixture from a jq-built array argument.
+# Args: <jq array expression that constructs releases>
+fixture_releases_json() {
+    local jq_expr="$1"
+    jq -n "$jq_expr" > "$FIXTURE_DIR/releases.json"
+}
+
+# ---------- tests ----------
+
+@test "tier exhaustion when nothing matches anywhere" {
+    fixture_releases_latest_empty
+    fixture_releases_empty
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable,release-any "$OUTPUT_DIR"
+    [ "$status" -eq 64 ]
+}
+
+@test "release-stable resolves and downloads when latest stable has matching asset" {
+    fixture_releases_latest_one_asset stable/v0.1.0 "airplanes-feeder-dev-arm64.img.xz" ""
+    # Separate stdout from stderr so we can verify the stdout contract directly.
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    status=$?
+    [ "$status" -eq 0 ]
+    path="$(cat "$stdout_file")"
+    [[ "$path" == /*.img.xz ]]
+    [ -s "$path" ]
+    grep -q "airplanes-feeder-dev-arm64.img.xz" "$path"
+}
+
+@test "release-stable returns tier-empty when latest has no matching asset" {
+    fixture_releases_latest_one_asset stable/v0.1.0 "completely-unrelated.txt" ""
+    # release-stable alone exhausts → 64
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 64 ]
+}
+
+@test "release-any iterates from newest, falls back to older when newest has no matching asset" {
+    fixture_releases_json '[
+        {"tag_name": "newer", "published_at": "2026-04-01T00:00:00Z", "body": "", "assets": [{"name": "irrelevant.txt", "browser_download_url": "https://example.invalid/x"}]},
+        {"tag_name": "older", "published_at": "2026-01-01T00:00:00Z", "body": "", "assets": [{"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/older.img.xz"}]}
+    ]'
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-any "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    path="$(cat "$stdout_file")"
+    # Curl stub writes the URL into the downloaded file; assert the older
+    # release's URL was used.
+    grep -q "older.img.xz" "$path"
+}
+
+@test "release-any picks newest matching when newest also matches" {
+    fixture_releases_json '[
+        {"tag_name": "newer", "published_at": "2026-04-01T00:00:00Z", "body": "", "assets": [{"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/newer.img.xz"}]},
+        {"tag_name": "older", "published_at": "2026-01-01T00:00:00Z", "body": "", "assets": [{"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/older.img.xz"}]}
+    ]'
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-any "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    path="$(cat "$stdout_file")"
+    grep -q "newer.img.xz" "$path"
+}
+
+@test "qemu tiebreaker prefers asset with qemu in name (legacy/permissive)" {
+    fixture_releases_json '[
+        {"tag_name": "bookworm", "published_at": "2025-02-26T18:02:20Z", "body": "", "assets": [
+            {"name": "image_2025-02-24-airplanes-live-full.zip", "browser_download_url": "https://example.invalid/plain.zip"},
+            {"name": "image_2025-02-24-qemu.zip", "browser_download_url": "https://example.invalid/qemu.zip"}
+        ]}
+    ]'
+    run image_source_resolve airplanes-live/image-releases legacy stable arm64 release-any "$OUTPUT_DIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *qemu.zip ]]
+}
+
+@test "strict mode (new) fails hard on multiple matching assets in one release" {
+    # New contract uses an exact-match regex. If two assets ever match
+    # (publish-step bug), the strict check produces rc=2 — caller should
+    # see non-64 non-0.
+    fixture_releases_latest_empty
+    fixture_releases_json '[
+        {"tag_name": "dev-latest", "published_at": "2026-04-01T00:00:00Z", "body": "", "assets": [
+            {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/a.img.xz"},
+            {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/b.img.xz"}
+        ]}
+    ]'
+    run image_source_resolve airplanes-live/image new dev arm64 release-any "$OUTPUT_DIR"
+    [ "$status" -ne 0 ]
+    [ "$status" -ne 64 ]
+}
+
+@test "release-any continues past first release if it has no matching asset" {
+    fixture_releases_json '[
+        {"tag_name": "newer-no-asset", "published_at": "2026-04-01T00:00:00Z", "body": "", "assets": [{"name": "release-notes.txt", "browser_download_url": "https://example.invalid/notes.txt"}]},
+        {"tag_name": "older-good", "published_at": "2026-01-01T00:00:00Z", "body": "", "assets": [{"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/older.img.xz"}]}
+    ]'
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-any "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    grep -q "older.img.xz" "$(cat "$stdout_file")"
+}
+
+@test "tier chain: release-stable exhausts, release-any provides the asset" {
+    fixture_releases_latest_empty
+    fixture_releases_json '[
+        {"tag_name": "dev-latest", "published_at": "2026-05-01T00:00:00Z", "body": "", "assets": [
+            {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/dev.img.xz"}
+        ]}
+    ]'
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-stable,release-any "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    grep -q "dev.img.xz" "$(cat "$stdout_file")"
+}
+
+@test "selected-tier and selected-release emitted on stderr" {
+    fixture_releases_latest_one_asset stable/v0.1.0 "airplanes-feeder-dev-arm64.img.xz" ""
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 0 ]
+    # Combined output (bats `run` merges stdout+stderr into $output by default
+    # but we asserted stdout-only contract elsewhere; for this test we check
+    # the merged output for the diagnostic lines.)
+    echo "$output" | grep -q '^selected-tier=release-stable$'
+    echo "$output" | grep -q '^selected-release=stable/v0.1.0 selected-asset=https://example.invalid/airplanes-feeder-dev-arm64.img.xz$'
+}
+
+@test "selected-sha extracted from release body when Built from ... @ ... pattern is present" {
+    fixture_releases_latest_one_asset dev-latest "airplanes-feeder-dev-arm64.img.xz" "Built from airplanes-live/image @ abc123def456."
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'selected-sha=abc123def456'
+}
+
+@test "stdout is exactly one absolute path, terminated by newline" {
+    fixture_releases_latest_one_asset stable/v0.1.0 "airplanes-feeder-dev-arm64.img.xz" ""
+    # Run with stdout separated from stderr so we can validate stdout alone.
+    stdout_file="$ROOT_DIR/stdout.txt"
+    stderr_file="$ROOT_DIR/stderr.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" >"$stdout_file" 2>"$stderr_file"
+    [ "$(wc -l < "$stdout_file" | tr -d ' ')" -eq 1 ]
+    path="$(cat "$stdout_file")"
+    [[ "$path" =~ ^/.+\.(img|img\.xz|img\.gz|zip|7z)$ ]]
+    [ -s "$path" ]
+}
+
+@test "gh exit-1 (missing fixture / 401-like) is treated as tier-not-found, library continues" {
+    # No releases/latest fixture → gh stub exits 1 → release-stable returns
+    # tier-empty. release-any has a valid fixture → resolve succeeds.
+    fixture_releases_latest_empty
+    fixture_releases_json '[
+        {"tag_name": "dev-latest", "published_at": "2026-04-01T00:00:00Z", "body": "", "assets": [
+            {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/dev.img.xz"}
+        ]}
+    ]'
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable,release-any "$OUTPUT_DIR"
+    [ "$status" -eq 0 ]
+}
+
+@test "unknown tier in list returns internal-error rc=1" {
+    run image_source_resolve airplanes-live/image new dev arm64 bogus-tier "$OUTPUT_DIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "missing required tool returns internal-error rc=1" {
+    fixture_releases_latest_one_asset stable/v0.1.0 "airplanes-feeder-dev-arm64.img.xz" ""
+    # Narrow PATH in a subshell so the global PATH (used by teardown's rm)
+    # stays intact. Inside the subshell, jq is no longer reachable, so the
+    # library's preflight tools check fails with rc=1.
+    rc=0
+    ( PATH="$STUB_DIR"; image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" ) >/dev/null 2>&1 || rc=$?
+    [ "$rc" -eq 1 ]
+}


### PR DESCRIPTION
Extends CI to exercise both the legacy and new image contracts at both layers: rootfs-mount on every PR/push, and full QEMU boot on push to main/dev. The QEMU probe also picks up new assertions (UUID stability across reboot, daemon state-file schema, and an idempotency rerun that verifies update.sh's fast paths don't rebuild costly artifacts).

The legacy `image-release-rootfs-smoke` job is renamed to `mounted-image-smoke-legacy` (display name `mounted image smoke (legacy)`), and a symmetric `mounted-image-smoke-new` is added. The `image-boot-smoke` workflow gains a push trigger and a `[legacy, new]` matrix; the existing `workflow_dispatch` continues to honor inputs, with a new `all` sentinel for running both contracts at once.

Asset resolution is now centralized in `test/lib/image-source.sh`, a tier-based resolver (`release-stable`, `release-any`) with BATS coverage. The new-image side picks up its dev-channel image from a rolling `dev-latest` prerelease in `airplanes-live/image` (paired PR: airplanes-live/image#63). Releases never expire, so the 90-day workflow-artifact retention window is no longer a coverage concern; no PAT or GitHub App is needed.

**Branch protection migration required before merge.** Renaming the legacy job changes its check name. Any required-check rules on `airplanes-live/feed` that reference `image release rootfs smoke` must be migrated to `mounted image smoke (legacy)` (and the new `mounted image smoke (new)` / `image boot smoke (legacy)` / `image boot smoke (new)` should be added where appropriate) before merging, otherwise future PRs will hang on a stuck-pending old check.
