### PR TITLE
Drop legacy USER fallback; require migrated boot config schema

### DIFF
--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -16,8 +16,8 @@ FEED_ENV="$(airplanes_path /etc/airplanes/feed.env)"
 FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
 
 # Unset USER (and the new keys) before sourcing so the process env's $USER
-# (systemd User= sets it to airplanes-feed) can't bleed into the legacy-USER
-# fallback below.
+# (systemd User= sets it to airplanes-feed) can't be mistaken for a legacy
+# boot-config key.
 unset USER MLAT_USER MLAT_ENABLED
 if [[ -f "$FEED_ENV" ]]; then
     source "$FEED_ENV"
@@ -28,27 +28,15 @@ else
     source "$FEED_ENV"
 fi
 
-# Legacy USER read fallback. update.sh's migrate_user_to_mlat_split splits
-# USER into MLAT_USER + MLAT_ENABLED on every run, but a daemon restart
-# triggered by the legacy PHP webconfig (which still writes USER=) can race
-# ahead of the next update. When that happens, derive MLAT_USER/MLAT_ENABLED
-# in-memory so the daemon doesn't strict-fail on missing config. Removed
-# when airplanes-update is archived.
-#
-# Test "set vs unset" rather than "non-empty" — an explicit MLAT_USER=""
-# written by a future-aware writer is respected as "user opted in but left
-# the name blank" and triggers the strict-fail below.
-if [[ ! -v MLAT_USER && ! -v MLAT_ENABLED && -v USER ]]; then
-    case "$USER" in
-        0|disable)
-            MLAT_USER=""
-            MLAT_ENABLED="false"
-            ;;
-        *)
-            MLAT_USER="$USER"
-            MLAT_ENABLED="true"
-            ;;
-    esac
+# Schema guard: this wrapper requires the new MLAT_USER + MLAT_ENABLED
+# schema. The legacy USER= → MLAT_USER translation is owned by airplanes-
+# webconfig's migrate-config.sh (also vendored into airplanes-update's
+# skeleton). Reaching this state means a config source has USER= but the
+# migrator never ran against it.
+if [[ -v USER && ! -v MLAT_USER && ! -v MLAT_ENABLED ]]; then
+    echo "ERROR: legacy USER= schema detected without MLAT_USER. " >&2
+    echo "Run 'Update Webconfig' to migrate the boot config, then restart this service." >&2
+    exit 64
 fi
 MLAT_ENABLED="${MLAT_ENABLED:-true}"
 MLAT_USER="${MLAT_USER-}"

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -174,6 +174,14 @@ migrate_user_to_mlat_split() {
             mlat_user=""
             mlat_enabled="false"
             ;;
+        '')
+            # Empty USER → "Anonymous" so the daemon's strict-fail on
+            # empty MLAT_USER never fires. Mirrors the writer-side
+            # defaults in configure.sh, apl-feed/mlat.sh, and
+            # airplanes-webconfig's migrate-config.sh.
+            mlat_user="Anonymous"
+            mlat_enabled="true"
+            ;;
         *)
             mlat_user="$user_value"
             mlat_enabled="true"

--- a/test/image-build-mode.sh
+++ b/test/image-build-mode.sh
@@ -68,6 +68,12 @@ sed -i \
     -e 's/^ALTITUDE=.*/ALTITUDE="35m"/' \
     -e 's/^USER=.*/USER="image-rootfs-smoke"/' \
     "$ROOT_DIR/boot/airplanes-config.txt"
+# Run the airplanes-update vendored migrator on the boot config, mirroring
+# update-airplanes.sh's pre-feed-update step in production. After this,
+# feed/update.sh sees a post-split config (MLAT_USER + MLAT_ENABLED) and
+# its strict guard for legacy USER= is satisfied.
+bash "$UPDATE_DIR/skeleton/usr/local/lib/airplanes-update/migrate-config.sh" \
+    "$ROOT_DIR/boot/airplanes-config.txt"
 printf '%s\n' 'VERSION_ID="13"' > "$ROOT_DIR/etc/os-release"
 ln -sfn /boot/airplanes-config.txt "$ROOT_DIR/etc/default/airplanes"
 

--- a/test/image-build-mode.sh
+++ b/test/image-build-mode.sh
@@ -68,12 +68,18 @@ sed -i \
     -e 's/^ALTITUDE=.*/ALTITUDE="35m"/' \
     -e 's/^USER=.*/USER="image-rootfs-smoke"/' \
     "$ROOT_DIR/boot/airplanes-config.txt"
-# Run the airplanes-update vendored migrator on the boot config, mirroring
-# update-airplanes.sh's pre-feed-update step in production. After this,
-# feed/update.sh sees a post-split config (MLAT_USER + MLAT_ENABLED) and
-# its strict guard for legacy USER= is satisfied.
-bash "$UPDATE_DIR/skeleton/usr/local/lib/airplanes-update/migrate-config.sh" \
-    "$ROOT_DIR/boot/airplanes-config.txt"
+# Pre-seed the post-migration shape (MLAT_USER + MLAT_ENABLED) so
+# feed/update.sh's strict guard for legacy USER= is satisfied. In
+# production these keys are added by airplanes-update's migrate-config.sh
+# before update.sh runs; the migration itself is covered by airplanes-
+# webconfig's migrate-config-test.sh and airplanes-update's rootfs smokes.
+# Reading the migrator out of airplanes-update's default branch here is
+# brittle — the migrator landed on dev only, while actions/checkout picks
+# main when no ref is specified — so the test stays decoupled.
+{
+    printf 'MLAT_USER="image-rootfs-smoke"\n'
+    printf 'MLAT_ENABLED=true\n'
+} >> "$ROOT_DIR/boot/airplanes-config.txt"
 printf '%s\n' 'VERSION_ID="13"' > "$ROOT_DIR/etc/os-release"
 ln -sfn /boot/airplanes-config.txt "$ROOT_DIR/etc/default/airplanes"
 

--- a/test/mounted-image-upgrade.sh
+++ b/test/mounted-image-upgrade.sh
@@ -325,6 +325,12 @@ prepare_mounted_image() {
         set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" LATITUDE "52.52000"
         set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" LONGITUDE "13.40500"
         set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" ALTITUDE "35m"
+        # Simulate airplanes-update's pre-feed-update migrator step.
+        # Without this the strict guard in feed/update.sh fires on the
+        # legacy USER= schema. The migration itself is unit-tested in
+        # airplanes-webconfig and integration-tested in airplanes-update.
+        set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" MLAT_USER "image-release-rootfs-smoke"
+        set_env_value "$FEED_BOOT_DIR/airplanes-config.txt" MLAT_ENABLED "true"
     else
         [[ -f "$ROOT_MNT/etc/airplanes/feed.env" ]] || fail "new image lacks /etc/airplanes/feed.env"
         rm -f "$ROOT_MNT/usr/bin/airplanes-feeder"

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -15,11 +15,16 @@ write_image_config() {
     mkdir -p "$root/boot" "$root/usr/bin"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
     chmod +x "$root/usr/bin/airplanes-feeder"
+    # Represents post-migration boot config: USER preserved for legacy
+    # consumers, MLAT_USER + MLAT_ENABLED added by airplanes-webconfig's
+    # migrate-config.sh so the new daemon sees the split schema.
     cat > "$root/boot/airplanes-config.txt" <<'EOF'
 LATITUDE="52.52000"
 LONGITUDE="13.40500"
 ALTITUDE="35m"
 USER="image-feeder"
+MLAT_USER="image-feeder"
+MLAT_ENABLED=true
 MODEAC="yes"
 MLAT_MARKER="no"
 EOF
@@ -387,6 +392,32 @@ write_feed_env() {
     grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
     grep -qx 'reason=mlat_user_empty' "$root/run/airplanes-mlat/state"
     grep -qx 'mlat_user=' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh exits 64 with schema-strict guard when boot config has legacy USER but no MLAT_USER" {
+    # Simulates a feeder where airplanes-update or webconfig migration
+    # did not run before the daemon started. The schema guard catches it
+    # early (before mlat_user_empty classifier) and points at the fix.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    mkdir -p "$root/boot" "$root/usr/bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/usr/bin/airplanes-feeder"
+    cat > "$root/boot/airplanes-config.txt" <<'EOF'
+LATITUDE="52.52000"
+LONGITUDE="13.40500"
+ALTITUDE="35m"
+USER="legacy-only"
+EOF
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 64 ]
+    [[ "$output" == *"legacy USER= schema detected"* ]]
+    [[ "$output" == *"Update Webconfig"* ]]
+    # State file is not written: we exit before classifier runs.
+    [ ! -f "$root/run/airplanes-mlat/state" ]
 }
 
 @test "airplanes-mlat.sh runs without state-writer lib (defensive source falls through to stub)" {

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -58,6 +58,18 @@ EOF
     grep -q '^MLAT_ENABLED=false$' "$FEED_ENV"
 }
 
+@test "migrate_user_to_mlat_split: empty USER → MLAT_USER=Anonymous, MLAT_ENABLED=true" {
+    # Mirrors airplanes-webconfig's migrate-config.sh and configure.sh's
+    # DEFAULT_MLAT_NAME — empty user becomes Anonymous so the daemon's
+    # strict-fail on empty MLAT_USER never fires.
+    printf 'USER=""\n' > "$FEED_ENV"
+    migrate_user_to_mlat_split "$FEED_ENV"
+
+    grep -q '^MLAT_USER="Anonymous"$' "$FEED_ENV"
+    grep -q '^MLAT_ENABLED=true$' "$FEED_ENV"
+    ! grep -q '^USER=' "$FEED_ENV"
+}
+
 @test "migrate_user_to_mlat_split: USER=changeme → MLAT_USER=changeme, MLAT_ENABLED=true (changeme isn't a sentinel)" {
     printf 'USER="changeme"\n' > "$FEED_ENV"
     migrate_user_to_mlat_split "$FEED_ENV"

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -95,11 +95,18 @@ write_image_boot_config() {
     ln -s /boot/airplanes-config.txt "$root/etc/default/airplanes"
     printf 'ExecStart=/usr/local/bin/airplanes-feed.sh\n' > "$root/etc/systemd/system/airplanes-feed.service"
     printf 'ExecStart=/usr/local/bin/mlat.sh\n' > "$root/etc/systemd/system/airplanes-mlat.service"
+    # Post-migration shape — feed/update.sh's strict guard requires the
+    # split keys. airplanes-update's migrate-config.sh produces this from
+    # legacy USER= on every image update; the migration itself is covered
+    # by airplanes-webconfig's migrate-config-test.sh and airplanes-update's
+    # rootfs smokes. Here we treat the migrated state as the starting point.
     cat > "$root/boot/airplanes-config.txt" <<'EOF'
 LATITUDE="52.52000"
 LONGITUDE="13.40500"
 ALTITUDE="35m"
 USER="image-feeder"
+MLAT_USER="image-feeder"
+MLAT_ENABLED=true
 MODEAC="yes"
 MLAT_MARKER="no"
 EOF

--- a/update.sh
+++ b/update.sh
@@ -372,22 +372,16 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
         [[ -f "$BOOT_ENV" ]] && source "$BOOT_ENV"
     fi
 
-    # Legacy-boot-config feeders may carry USER= in airplanes-config.txt /
-    # airplanes-env. Derive the new schema in-shell so the completeness
-    # check below sees MLAT_USER/MLAT_ENABLED. The boot config itself is
-    # left alone (it's the user's edit surface and must keep working as-is
-    # for users who hand-edit it).
-    if [[ ! -v MLAT_USER && ! -v MLAT_ENABLED && -v USER ]]; then
-        case "$USER" in
-            0|disable)
-                MLAT_USER=""
-                MLAT_ENABLED="false"
-                ;;
-            *)
-                MLAT_USER="$USER"
-                MLAT_ENABLED="true"
-                ;;
-        esac
+    # Schema guard: this updater requires the boot config to already use
+    # the new MLAT_USER + MLAT_ENABLED schema. The legacy USER= →
+    # MLAT_USER translation is owned by airplanes-webconfig's migrate-
+    # config.sh (vendored into airplanes-update's skeleton). Hitting this
+    # error means the user has new feed/ scripts but the legacy stack
+    # hasn't migrated the boot config yet.
+    if [[ -v USER && ! -v MLAT_USER && ! -v MLAT_ENABLED ]]; then
+        echo "ERROR: Your boot config uses the legacy USER= schema." >&2
+        echo "Run 'Update Webconfig' first, then re-run 'Update Feeder'." >&2
+        exit 1
     fi
 
     LATITUDE="${LATITUDE:-0}"


### PR DESCRIPTION
The new daemons now require the split MLAT_USER + MLAT_ENABLED schema in feed.env or airplanes-config.txt. The USER= → MLAT_USER translation has moved to airplanes-webconfig's migrate-config.sh (also vendored into airplanes-update's skeleton), which runs before the new daemons ever read the config.

When an unmigrated config is encountered the daemon and the updater both exit with a sharp message pointing users at 'Update Webconfig'. airplanes-feed.sh is intentionally untouched — it does not key off MLAT_USER, and adding a guard there risks false-trigger from the process-environment USER under systemd User=.

Depends on the matching airplanes-update and airplanes-webconfig changes (airplanes-live/airplanes-update#2 and airplanes-live/airplanes-webconfig#3). Should land last in the release order so legacy hybrid feeders never encounter the strict guard without a migrator nearby.