### PR TITLE
ci(upgrade-smoke): rename matrix to stable/legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,37 +203,38 @@ jobs:
           name: update-regression-artifacts
           path: ${{ runner.temp }}/update-regression
 
-  legacy-upgrade-smoke:
-    name: legacy script upgrade smoke (${{ matrix.legacy.label }})
+  upgrade-smoke:
+    name: script upgrade smoke (${{ matrix.source.label }})
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        legacy:
-          # Tracking-main axis: catches regressions in the "current main →
-          # candidate" upgrade path as main moves. Becomes near-identity
-          # to the candidate after a dev→main merge.
-          - label: tracking main
+        source:
+          # `stable` axis tracks origin/main HEAD — the currently-released
+          # script-installed feeders. Catches regressions in the
+          # "main → candidate" upgrade path as main moves.
+          - label: stable
             ref: main
-          # Pinned pre-schema-split axis: hard regression coverage for
-          # feeders installed before MLAT_USER / MLAT_ENABLED split landed.
-          # Update this SHA only when retiring legacy coverage deliberately.
-          - label: pinned pre-schema-split
+          # `legacy` axis pins a pre-schema-split commit so historical
+          # regression coverage survives the dev→main merge that introduces
+          # the MLAT_USER / MLAT_ENABLED split. Update only when retiring
+          # the coverage deliberately.
+          - label: legacy
             ref: 9318d02efd70488f831cbcb84ca3ec4cb9cc9ece
     steps:
-      - name: Checkout legacy (${{ matrix.legacy.label }})
+      - name: Checkout source (${{ matrix.source.label }})
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.legacy.ref }}
-          path: legacy
+          ref: ${{ matrix.source.ref }}
+          path: source
           persist-credentials: false
 
-      - name: Pin legacy branch label to main
+      - name: Pin source branch label to main
         run: |
-          current="$(git -C legacy rev-parse --abbrev-ref HEAD)"
+          current="$(git -C source rev-parse --abbrev-ref HEAD)"
           if [[ "$current" != "main" ]]; then
-            git -C legacy branch -f main HEAD
+            git -C source branch -f main HEAD
           fi
 
       - name: Checkout candidate (PR / branch HEAD)
@@ -253,22 +254,22 @@ jobs:
           fi
 
       - name: Prepare diagnostics directory
-        run: mkdir -p "${{ runner.temp }}/legacy-upgrade-smoke"
+        run: mkdir -p "${{ runner.temp }}/upgrade-smoke"
 
-      - name: Run legacy upgrade smoke
+      - name: Run upgrade smoke
         run: |
           docker run --rm \
-            -e AIRPLANES_LEGACY_REPO=file:///legacy \
+            -e AIRPLANES_SOURCE_REPO=file:///source \
             -e AIRPLANES_CANDIDATE_REPO=file:///candidate \
-            -v "$PWD/legacy:/legacy:ro" \
+            -v "$PWD/source:/source:ro" \
             -v "$PWD/candidate:/candidate:ro" \
-            -v "${{ runner.temp }}/legacy-upgrade-smoke:/tmp/legacy-upgrade-diag" \
+            -v "${{ runner.temp }}/upgrade-smoke:/tmp/upgrade-smoke-diag" \
             debian:13-slim \
-            bash /candidate/test/legacy-upgrade-smoke.sh
+            bash /candidate/test/upgrade-smoke.sh
 
       - name: Upload diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: legacy-upgrade-smoke-diagnostics
-          path: ${{ runner.temp }}/legacy-upgrade-smoke
+          name: upgrade-smoke-diagnostics-${{ matrix.source.label }}
+          path: ${{ runner.temp }}/upgrade-smoke

--- a/test/upgrade-smoke.sh
+++ b/test/upgrade-smoke.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${AIRPLANES_LEGACY_REPO:?AIRPLANES_LEGACY_REPO is required}"
+: "${AIRPLANES_SOURCE_REPO:?AIRPLANES_SOURCE_REPO is required}"
 : "${AIRPLANES_CANDIDATE_REPO:?AIRPLANES_CANDIDATE_REPO is required}"
 
-DIAG_DIR=/tmp/legacy-upgrade-diag
+DIAG_DIR=/tmp/upgrade-smoke-diag
 mkdir -p "$DIAG_DIR"
 MOCK_PID=
 
@@ -35,8 +35,8 @@ trap on_exit EXIT
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 # pkg-config is pre-installed on Raspberry Pi OS but absent from debian:13-slim;
-# legacy main's update.sh package list doesn't include it (dev's does), so
-# without this the readsb build fails to link ncurses on the legacy install.
+# main's update.sh package list doesn't include it (dev's does), so without
+# this the readsb build fails to link ncurses during the source install.
 apt-get install -y --no-install-recommends bash ca-certificates git pkg-config python3
 git config --global --add safe.directory '*'
 
@@ -131,36 +131,36 @@ export APL_FEED_SERVER_URL="http://127.0.0.1:18080"
 export APL_FEED_MAX_RETRY_TIME=5
 export AIRPLANES_PACKAGE_MANAGER=apt
 
-# ---- Phase 1: install legacy ----
-# Legacy main's install.sh AND update.sh both hardcode
+# ---- Phase 1: install source ----
+# main's install.sh AND update.sh both hardcode
 # REPO="https://github.com/airplanes-live/feed.git". A literal
-# `bash /legacy/install.sh` would re-fetch *public* main into $IPATH/git,
-# silently bypassing the SHA pinning of the /legacy mount. Mimic install.sh
+# `bash /source/install.sh` would re-fetch *public* main into $IPATH/git,
+# silently bypassing the SHA pinning of the /source mount. Mimic install.sh
 # (which is just mkdir + apt + clone + setup.sh) but seed $IPATH/git from
 # the mount, then redirect the in-update.sh re-fetch at the same mount so
 # the pin holds end-to-end.
-echo "=== Phase 1: install legacy from $AIRPLANES_LEGACY_REPO ==="
+echo "=== Phase 1: install source from $AIRPLANES_SOURCE_REPO ==="
 mkdir -p /usr/local/share/airplanes
-git clone --branch main "$AIRPLANES_LEGACY_REPO" /usr/local/share/airplanes/git
+git clone --branch main "$AIRPLANES_SOURCE_REPO" /usr/local/share/airplanes/git
 
 sed -i \
-    -e 's|^REPO=".*airplanes-live/feed\.git"$|REPO="'"$AIRPLANES_LEGACY_REPO"'"|' \
+    -e 's|^REPO=".*airplanes-live/feed\.git"$|REPO="'"$AIRPLANES_SOURCE_REPO"'"|' \
     /usr/local/share/airplanes/git/update.sh
 
 bash /usr/local/share/airplanes/git/setup.sh
 
-# Post-install sanity. Only assert artifacts that legacy main is guaranteed
+# Post-install sanity. Only assert artifacts the source install is guaranteed
 # to produce — apl-feed CLI, feed.env-only layout, etc. are dev-branch
-# additions that predate this test. Phase 2's detect_legacy_env picks the
-# right config file regardless of which shape legacy produced.
+# additions that predate this test. Phase 2's detect_source_env picks the
+# right config file regardless of which shape the source produced.
 test -d /usr/local/share/airplanes/git
 
-# ---- Phase 2: seed legacy USER= state ----
-# Force the migration code path: drop any MLAT_* keys the legacy install may
+# ---- Phase 2: seed USER= state ----
+# Force the migration code path: drop any MLAT_* keys the source install may
 # have written, leave a single legacy USER=. Detect whichever config file the
 # install actually produced — modern main writes /etc/airplanes/feed.env;
 # ancient main writes /etc/default/airplanes as a real file.
-detect_legacy_env() {
+detect_source_env() {
     if [[ -f /etc/airplanes/feed.env && ! -L /etc/airplanes/feed.env ]]; then
         echo /etc/airplanes/feed.env; return
     fi
@@ -169,32 +169,32 @@ detect_legacy_env() {
     fi
     echo /etc/airplanes/feed.env
 }
-LEGACY_ENV="$(detect_legacy_env)"
-echo "=== Phase 2: seed USER=ci-legacy-feeder into $LEGACY_ENV ==="
-mkdir -p "$(dirname "$LEGACY_ENV")"
-touch "$LEGACY_ENV"
+SOURCE_ENV="$(detect_source_env)"
+echo "=== Phase 2: seed USER=ci-source-feeder into $SOURCE_ENV ==="
+mkdir -p "$(dirname "$SOURCE_ENV")"
+touch "$SOURCE_ENV"
 sed -i \
     -e '/^MLAT_USER=/d' \
     -e '/^MLAT_ENABLED=/d' \
     -e '/^USER=/d' \
     -e '/^LATITUDE=/d' \
     -e '/^LONGITUDE=/d' \
-    "$LEGACY_ENV"
+    "$SOURCE_ENV"
 {
-    echo 'USER=ci-legacy-feeder'
+    echo 'USER=ci-source-feeder'
     echo 'LATITUDE=52.52000'
     echo 'LONGITUDE=13.40500'
-} >> "$LEGACY_ENV"
+} >> "$SOURCE_ENV"
 
 # ---- Phase 3: upgrade via candidate ----
-# Realistic upgrade path. Legacy main's `update.sh` has no working in-place
+# Realistic upgrade path. main's `update.sh` has no working in-place
 # self-replace (its condition `if diff "$GIT/update.sh" "$IPATH/update.sh"`
 # is satisfied only when files are *identical*, which is a no-op). Real
 # feeders upgrade by re-bootstrapping from the latest tree, so we invoke the
 # candidate's update.sh directly. The candidate's first action is to fetch
 # AIRPLANES_FEED_REPO/AIRPLANES_FEED_BRANCH into $IPATH/git and self-replace
 # $IPATH/update.sh — exercising candidate's full install path against the
-# legacy state Phases 1-2 left in place.
+# source state Phases 1-2 left in place.
 echo "=== Phase 3: upgrade via candidate from $AIRPLANES_CANDIDATE_REPO ==="
 AIRPLANES_FEED_REPO="$AIRPLANES_CANDIDATE_REPO" \
 AIRPLANES_FEED_BRANCH=dev \
@@ -210,8 +210,8 @@ env -i bash -c '
     set -euo pipefail
     # shellcheck disable=SC1091
     source /etc/airplanes/feed.env
-    [[ "${MLAT_USER:-}"    == "ci-legacy-feeder" ]] || { echo "FAIL: MLAT_USER=${MLAT_USER:-<unset>}" >&2; exit 1; }
-    [[ "${MLAT_ENABLED:-}" == "true" ]]              || { echo "FAIL: MLAT_ENABLED=${MLAT_ENABLED:-<unset>}" >&2; exit 1; }
+    [[ "${MLAT_USER:-}"    == "ci-source-feeder" ]] || { echo "FAIL: MLAT_USER=${MLAT_USER:-<unset>}" >&2; exit 1; }
+    [[ "${MLAT_ENABLED:-}" == "true" ]]             || { echo "FAIL: MLAT_ENABLED=${MLAT_ENABLED:-<unset>}" >&2; exit 1; }
 '
 
 [[ "$(grep -c '^USER='        /etc/airplanes/feed.env || true)" -eq 0 ]] \
@@ -311,4 +311,4 @@ env -i bash -c '
         || { echo "FAIL: USER=0 should yield empty MLAT_USER, got ${MLAT_USER}" >&2; exit 1; }
 '
 
-echo "=== Legacy upgrade smoke OK ==="
+echo "=== Upgrade smoke OK ==="


### PR DESCRIPTION
Renames the upgrade-smoke matrix labels so "legacy" only refers to the actually-pinned pre-schema-split commit; the previously-named "tracking main" axis is just the released stable feed and is now labeled `stable`.

Job becomes `script upgrade smoke (stable)` and `script upgrade smoke (legacy)`. Matrix variable is `source`. Driver file moves to `test/upgrade-smoke.sh` and the env vars / mount path / diagnostics dir rename to match.
