### PR TITLE
feat(image-source): resolve via rpi-imager manifest for new contract

### DIFF
--- a/test/lib/image-source.sh
+++ b/test/lib/image-source.sh
@@ -24,6 +24,18 @@
 # move on" rather than hard failure. This matches the public-repo expectation:
 # an authenticated-but-broken token shouldn't block a public release lookup,
 # and tier-empty signals naturally degrade via the caller's skip-with-notice.
+#
+# Asset selection for the `new` contract is manifest-driven: when REGEX is
+# unset, the resolver looks for the rpi-imager Custom Repository sidecar
+# (`airplanes-feeder-${channel}-${arch}.rpi-imager-manifest.json`) in the
+# resolved release, parses `os_list[0].url`, and downloads that — the same
+# pointer rpi-imager itself follows. If the manifest is absent the resolver
+# falls back to the legacy regex picker so releases that predate manifest
+# publishing still resolve. A manifest that is PRESENT but malformed (unreadable,
+# missing url, url points outside the release, basename does not match the
+# expected pattern) is a hard error rather than a silent fallback.
+# Pass an explicit REGEX to bypass the manifest path for one-off testing of
+# a specific asset (e.g. image-boot-smoke's `image_asset_regex` input).
 
 # ---- requirements ----
 
@@ -112,6 +124,132 @@ _image_source_pick_asset() {
     esac
 }
 
+# Manifest-fetch retry tuning. GitHub release assets can be briefly
+# inconsistent during `gh release upload --clobber` (DELETE-then-POST window),
+# so we retry the small manifest sidecar before declaring a hard error. The
+# .img.xz it references is uploaded under an immutable name and never
+# clobbered, so a manifest-fetch retry is the only race we need to absorb.
+_IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS="${_IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS:-3}"
+_IMAGE_SOURCE_MANIFEST_FETCH_BACKOFF_S="${_IMAGE_SOURCE_MANIFEST_FETCH_BACKOFF_S:-2}"
+
+_image_source_pick_asset_via_manifest() {
+    # Reads a single release JSON object on stdin. Looks for a sidecar
+    # `airplanes-feeder-${channel}-${arch}.rpi-imager-manifest.json` asset,
+    # fetches it over HTTPS, parses the rpi-imager Custom Repository JSON,
+    # extracts os_list[0].url, and validates the URL points at an asset of
+    # the SAME release whose name matches the expected immutable pattern.
+    # Emits <asset_name>\t<asset_url> on success.
+    #
+    # Args: channel arch
+    # Return: 0 success
+    #         1 no manifest sidecar present in this release (caller decides
+    #             whether to fall back or escalate)
+    #         2 manifest present but malformed, fetch failed after retries,
+    #             url field missing/empty, url not an asset of this release,
+    #             or url's asset name does not match the expected pattern
+    local channel="$1" arch="$2"
+    local manifest_name="airplanes-feeder-${channel}-${arch}.rpi-imager-manifest.json"
+    local release_json manifest_url manifest_body image_url
+    local matched_name expected_re attempt
+
+    release_json="$(cat)"
+    manifest_url="$(printf '%s\n' "$release_json" \
+        | jq -r --arg name "$manifest_name" \
+            '[.assets[]? | select(.name == $name)] | first | .browser_download_url // empty')"
+    if [[ -z "$manifest_url" ]]; then
+        return 1
+    fi
+
+    manifest_body=""
+    for (( attempt = 1; attempt <= _IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS; attempt++ )); do
+        # --fail makes curl exit non-zero on HTTP >=400; --location follows
+        # GitHub's redirect to the signed asset URL. stderr suppression here
+        # keeps each attempt quiet — the final-failure message below is the
+        # one that matters.
+        if manifest_body="$(curl --fail --location --silent --show-error "$manifest_url" 2>/dev/null)"; then
+            [[ -n "$manifest_body" ]] && break
+            manifest_body=""
+        fi
+        if (( attempt < _IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS )); then
+            sleep "$_IMAGE_SOURCE_MANIFEST_FETCH_BACKOFF_S"
+        fi
+    done
+    if [[ -z "$manifest_body" ]]; then
+        echo "image-source: failed to fetch manifest after $_IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS attempts: $manifest_url" >&2
+        return 2
+    fi
+
+    # jq filter: require .os_list[0].url to be a non-empty string. `strings`
+    # keeps only string values (drops null/numbers/arrays); `select(length > 0)`
+    # drops empty strings. Output is empty iff any check fails.
+    image_url="$(printf '%s\n' "$manifest_body" \
+        | jq -r '.os_list[0].url // empty | strings | select(length > 0)')"
+    if [[ -z "$image_url" ]]; then
+        echo "image-source: manifest missing or invalid os_list[0].url: $manifest_url" >&2
+        return 2
+    fi
+
+    # Structural validation: the manifest's url must equal one of the same
+    # release's asset URLs. Prefix-only validation is too weak — it would
+    # accept a malformed manifest pointing at a different release, wrong
+    # channel/arch, or off-asset content.
+    matched_name="$(printf '%s\n' "$release_json" \
+        | jq -r --arg url "$image_url" \
+            '[.assets[]? | select(.browser_download_url == $url)] | first | .name // empty')"
+    if [[ -z "$matched_name" ]]; then
+        echo "image-source: manifest url is not an asset of the resolved release: $image_url" >&2
+        return 2
+    fi
+
+    # And its basename must match the expected immutable pattern for the
+    # requested channel + arch. Catches a misrouted manifest that points at
+    # e.g. the release-notes asset.
+    expected_re="^airplanes-feeder-${channel}-${arch}(-.+)?\\.img\\.xz$"
+    if ! [[ "$matched_name" =~ $expected_re ]]; then
+        echo "image-source: manifest url asset name $matched_name does not match expected pattern $expected_re" >&2
+        return 2
+    fi
+
+    printf '%s\t%s\n' "$matched_name" "$image_url"
+}
+
+_image_source_pick_via_strategy() {
+    # Picks an asset from the given release JSON. For the `new` contract with
+    # no explicit REGEX, tries the rpi-imager manifest sidecar first; if the
+    # manifest is absent (rc 1 from the manifest picker), falls back to the
+    # legacy regex picker so older or hand-crafted releases still resolve. A
+    # manifest that is PRESENT but malformed (rc 2) is a hard error and is
+    # NOT papered over by the regex fallback — the broken publisher must
+    # surface, not silently get downgraded to "older asset pointed at by
+    # regex". Reads release JSON on stdin.
+    #
+    # Args: contract channel arch regex strict explicit_regex
+    #   explicit_regex: "1" if caller passed REGEX to image_source_resolve;
+    #                   "" if the regex argument was the library default.
+    # Output / return: identical to _image_source_pick_asset.
+    local contract="$1" channel="$2" arch="$3"
+    local regex="$4" strict="$5" explicit_regex="$6"
+    local release_json
+    release_json="$(cat)"
+    if [[ "$contract" == "new" && -z "$explicit_regex" ]]; then
+        local pick rc
+        if pick="$(printf '%s\n' "$release_json" | _image_source_pick_asset_via_manifest "$channel" "$arch")"; then
+            printf '%s\n' "$pick"
+            return 0
+        else
+            rc=$?
+        fi
+        if [[ $rc -ne 1 ]]; then
+            # rc 2: manifest present but malformed. Hard error — don't fall
+            # back to regex, since that would let a broken manifest get
+            # papered over with a stale rolling-name asset.
+            return "$rc"
+        fi
+        # rc 1: no manifest sidecar in this release. Fall through to regex.
+    fi
+    printf '%s\n' "$release_json" | _image_source_pick_asset "$regex" "$strict"
+}
+
 # ---- download ----
 
 _image_source_download() {
@@ -162,7 +300,7 @@ _image_source_emit_selected() {
 #   2 — hard error inside the tier; caller should propagate
 
 _resolve_release_stable() {
-    # Args: repo regex strict_mode output_dir
+    # Args: repo contract channel arch regex strict explicit_regex output_dir
     #
     # IMPORTANT: capture exit codes via `if cmd; then rc=0; else rc=$?; fi`,
     # not `cmd; rc=$?`. Two bash gotchas conspire here:
@@ -172,7 +310,8 @@ _resolve_release_stable() {
     #     the then-block $? becomes the if-test result, not cmd's status.
     # The if/else pattern below puts the call in a tested context (set -e
     # suppressed) AND captures the unmodified exit code in the else branch.
-    local repo="$1" regex="$2" strict="$3" output_dir="$4"
+    local repo="$1" contract="$2" channel="$3" arch="$4"
+    local regex="$5" strict="$6" explicit_regex="$7" output_dir="$8"
     local json pick rc name url
     if json="$(gh api "/repos/$repo/releases/latest" 2>/dev/null)"; then
         rc=0
@@ -183,7 +322,7 @@ _resolve_release_stable() {
         echo "skipped-tier=release-stable: no /releases/latest for $repo" >&2
         return 1
     fi
-    if pick="$(printf '%s\n' "$json" | _image_source_pick_asset "$regex" "$strict")"; then
+    if pick="$(printf '%s\n' "$json" | _image_source_pick_via_strategy "$contract" "$channel" "$arch" "$regex" "$strict" "$explicit_regex")"; then
         rc=0
     else
         rc=$?
@@ -205,9 +344,10 @@ _resolve_release_stable() {
 }
 
 _resolve_release_any() {
-    # Args: repo regex strict_mode output_dir
+    # Args: repo contract channel arch regex strict explicit_regex output_dir
     # See note in _resolve_release_stable about exit-code capture pattern.
-    local repo="$1" regex="$2" strict="$3" output_dir="$4"
+    local repo="$1" contract="$2" channel="$3" arch="$4"
+    local regex="$5" strict="$6" explicit_regex="$7" output_dir="$8"
     local releases sorted release_json pick name url rc
     if releases="$(gh api "/repos/$repo/releases?per_page=30" 2>/dev/null)"; then
         rc=0
@@ -226,7 +366,7 @@ _resolve_release_any() {
         return 1
     fi
     while IFS= read -r release_json; do
-        if pick="$(printf '%s\n' "$release_json" | _image_source_pick_asset "$regex" "$strict")"; then
+        if pick="$(printf '%s\n' "$release_json" | _image_source_pick_via_strategy "$contract" "$channel" "$arch" "$regex" "$strict" "$explicit_regex")"; then
             rc=0
         else
             rc=$?
@@ -238,7 +378,9 @@ _resolve_release_any() {
             _image_source_download "$url" "$output_dir" "$name"
             return $?
         elif [[ $rc -eq 2 ]]; then
-            # Strict violation — hard failure on this release.
+            # Hard failure: strict-regex violation, malformed/missing
+            # manifest, or other structural problem on this release. Don't
+            # silently advance to an older release — escalate.
             return 2
         fi
         # rc=1: this release didn't have the asset, try next.
@@ -260,7 +402,13 @@ image_source_resolve() {
 
     _image_source_require_tools || return 1
 
-    if [[ -z "$regex" ]]; then
+    # Track whether the caller passed an explicit regex. Explicit regex
+    # bypasses the new-contract manifest path (one-off testing of a specific
+    # asset, e.g. image-boot-smoke's image_asset_regex dispatch input).
+    local explicit_regex=""
+    if [[ -n "$regex" ]]; then
+        explicit_regex=1
+    else
         regex="$(_image_source_default_regex "$contract" "$channel" "$arch")"
     fi
 
@@ -279,14 +427,14 @@ image_source_resolve() {
         case "$tier" in
             release-stable)
                 # set -e bypass via tested context, same pattern as the helpers.
-                if _resolve_release_stable "$repo" "$regex" "$strict" "$output_dir"; then
+                if _resolve_release_stable "$repo" "$contract" "$channel" "$arch" "$regex" "$strict" "$explicit_regex" "$output_dir"; then
                     rc=0
                 else
                     rc=$?
                 fi
                 ;;
             release-any)
-                if _resolve_release_any "$repo" "$regex" "$strict" "$output_dir"; then
+                if _resolve_release_any "$repo" "$contract" "$channel" "$arch" "$regex" "$strict" "$explicit_regex" "$output_dir"; then
                     rc=0
                 else
                     rc=$?

--- a/test/lib/image-source.sh
+++ b/test/lib/image-source.sh
@@ -157,6 +157,26 @@ _image_source_pick_asset_via_manifest() {
         | jq -r --arg name "$manifest_name" \
             '[.assets[]? | select(.name == $name)] | first | .browser_download_url // empty')"
     if [[ -z "$manifest_url" ]]; then
+        # No manifest sidecar. Distinguish two cases:
+        #   - Release has at least one asset matching the immutable
+        #     SHA-tagged pattern → the publisher emits manifests, so a
+        #     missing one is a broken publish (e.g., the sequential upload
+        #     chain crashed between the .img.xz step and the manifest
+        #     step). Hard error so callers don't silently regress to an
+        #     older release via the regex fallback.
+        #   - No immutable-pattern asset either → this is a pre-manifest
+        #     release (rolling-only) or an unrelated release. Treat as
+        #     "no manifest path here" and let the strategy fall back to
+        #     the legacy regex picker.
+        local immutable_re has_immutable
+        immutable_re="^airplanes-feeder-${channel}-${arch}-[0-9a-f]+-r[0-9]+-a[0-9]+\\.img\\.xz$"
+        has_immutable="$(printf '%s\n' "$release_json" \
+            | jq -r --arg re "$immutable_re" \
+                '[.assets[]? | select(.name | test($re))] | length')"
+        if [[ "$has_immutable" -gt 0 ]]; then
+            echo "image-source: release has immutable .img.xz asset(s) but no manifest sidecar — refusing to fall back to a stale release" >&2
+            return 2
+        fi
         return 1
     fi
 

--- a/test/test_image_source.bats
+++ b/test/test_image_source.bats
@@ -45,7 +45,12 @@ esac
 SH
     chmod +x "$STUB_DIR/gh"
 
-    # Stub `curl`: write a known byte stream to whatever --output target is given.
+    # Stub `curl`: two modes.
+    #   1. If $FIXTURE_DIR/curl-stub-by-name/<basename-of-url> exists, emit
+    #      its contents — used by manifest-fetch tests, where the picker
+    #      curls the manifest URL and reads JSON from stdout (no --output).
+    #   2. Otherwise, write `STUB-IMAGE-BYTES-FOR:<url>` to --output (default
+    #      behavior for image-archive downloads).
     cat > "$STUB_DIR/curl" <<'SH'
 #!/usr/bin/env bash
 output=""
@@ -58,8 +63,29 @@ while [[ $# -gt 0 ]]; do
         *) url="$1"; shift ;;
     esac
 done
-if [[ -z "$output" || -z "$url" ]]; then
-    echo "curl stub: missing output ($output) or url ($url)" >&2
+if [[ -z "$url" ]]; then
+    echo "curl stub: missing url" >&2
+    exit 1
+fi
+basename="${url##*/}"
+fixture_path="$FIXTURE_DIR/curl-stub-by-name/$basename"
+if [[ -f "$fixture_path" ]]; then
+    if [[ -n "$output" ]]; then
+        mkdir -p "$(dirname "$output")"
+        cp -- "$fixture_path" "$output"
+    else
+        cat -- "$fixture_path"
+    fi
+    exit 0
+fi
+# Sentinel for "fetch this URL should fail" — tests pre-create an empty file
+# and rely on the absent fixture to take this branch.
+if [[ "$basename" == *FAIL* ]]; then
+    echo "curl stub: simulated fetch failure for $url" >&2
+    exit 22
+fi
+if [[ -z "$output" ]]; then
+    echo "curl stub: stdout-mode fetch with no fixture and no FAIL marker: $url" >&2
     exit 1
 fi
 mkdir -p "$(dirname "$output")"
@@ -104,6 +130,34 @@ EOF
 fixture_releases_json() {
     local jq_expr="$1"
     jq -n "$jq_expr" > "$FIXTURE_DIR/releases.json"
+}
+
+# Drops a manifest JSON file at the path the curl stub will lookup by basename.
+# Args: manifest_basename body_json (a JSON string written verbatim)
+fixture_curl_body() {
+    local name="$1" body="$2"
+    mkdir -p "$FIXTURE_DIR/curl-stub-by-name"
+    printf '%s' "$body" > "$FIXTURE_DIR/curl-stub-by-name/$name"
+}
+
+# Writes a minimal valid rpi-imager Custom Repository manifest body.
+# Args: image_url manifest_basename
+fixture_manifest_body() {
+    local image_url="$1" manifest_basename="$2"
+    fixture_curl_body "$manifest_basename" "$(jq -n --arg url "$image_url" '{
+        os_list: [{
+            name: "test feeder image",
+            description: "test",
+            url: $url,
+            extract_size: 1024,
+            extract_sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+            image_download_size: 512,
+            release_date: "2026-01-01",
+            init_format: "cloudinit-rpi",
+            devices: ["pi3-64bit"],
+            capabilities: []
+        }]
+    }')"
 }
 
 # ---------- tests ----------
@@ -269,4 +323,172 @@ fixture_releases_json() {
     rc=0
     ( PATH="$STUB_DIR"; image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" ) >/dev/null 2>&1 || rc=$?
     [ "$rc" -eq 1 ]
+}
+
+# ---------- manifest-following path (new contract, no explicit regex) ----------
+
+# Writes a /releases/latest fixture for a `new`-contract release carrying both
+# the immutable .img.xz and the manifest sidecar. Returns the manifest's
+# image_url so tests can match it against the downloaded content.
+fixture_release_with_manifest() {
+    local tag="$1" channel="$2" arch="$3"
+    local immutable_name="airplanes-feeder-${channel}-${arch}-deadbeef0001-r99-a1.img.xz"
+    local immutable_url="https://example.invalid/${immutable_name}"
+    local manifest_name="airplanes-feeder-${channel}-${arch}.rpi-imager-manifest.json"
+    local manifest_url="https://example.invalid/${manifest_name}"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "$tag",
+  "body": "",
+  "assets": [
+    {"name": "$immutable_name", "browser_download_url": "$immutable_url"},
+    {"name": "$manifest_name", "browser_download_url": "$manifest_url"}
+  ]
+}
+EOF
+    fixture_manifest_body "$immutable_url" "$manifest_name"
+    printf '%s\n' "$immutable_url"
+}
+
+@test "new contract: manifest path resolves to immutable url" {
+    image_url="$(fixture_release_with_manifest dev-latest dev arm64)"
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    path="$(cat "$stdout_file")"
+    [[ "$path" == /*-deadbeef0001-r99-a1.img.xz ]]
+    # Stub curl wrote `STUB-IMAGE-BYTES-FOR:<url>` into the download target.
+    # Assert the URL came from the manifest's url field, not from regex
+    # matching a different asset.
+    grep -qF "$image_url" "$path"
+}
+
+@test "new contract: manifest absent falls back to legacy regex picker" {
+    # Release has the rolling .img.xz but NO manifest sidecar. Manifest
+    # picker returns rc 1, strategy falls through to regex, which matches
+    # the rolling asset.
+    fixture_releases_latest_one_asset dev-latest "airplanes-feeder-dev-arm64.img.xz" ""
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    grep -q "airplanes-feeder-dev-arm64.img.xz" "$(cat "$stdout_file")"
+}
+
+@test "new contract: malformed manifest (no url) is a hard error, no regex fallback" {
+    # Manifest present but `os_list[0].url` empty. Even though a regex-
+    # matchable asset exists, the malformed manifest must surface, not get
+    # papered over by the regex fallback.
+    local immutable_name="airplanes-feeder-dev-arm64-deadbeef0002-r1-a1.img.xz"
+    local manifest_name="airplanes-feeder-dev-arm64.rpi-imager-manifest.json"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "dev-latest",
+  "body": "",
+  "assets": [
+    {"name": "$immutable_name", "browser_download_url": "https://example.invalid/$immutable_name"},
+    {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/rolling.img.xz"},
+    {"name": "$manifest_name", "browser_download_url": "https://example.invalid/$manifest_name"}
+  ]
+}
+EOF
+    # url is empty string
+    fixture_curl_body "$manifest_name" '{"os_list":[{"name":"x","description":"x","url":"","extract_size":1,"extract_sha256":"00","image_download_size":1,"release_date":"2026-01-01","init_format":"cloudinit-rpi","devices":[],"capabilities":[]}]}'
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "new contract: manifest url pointing outside the release is rejected" {
+    local immutable_name="airplanes-feeder-dev-arm64-deadbeef0003-r1-a1.img.xz"
+    local manifest_name="airplanes-feeder-dev-arm64.rpi-imager-manifest.json"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "dev-latest",
+  "body": "",
+  "assets": [
+    {"name": "$immutable_name", "browser_download_url": "https://example.invalid/$immutable_name"},
+    {"name": "$manifest_name", "browser_download_url": "https://example.invalid/$manifest_name"}
+  ]
+}
+EOF
+    # Manifest points at a URL that is NOT among the release's assets.
+    fixture_manifest_body "https://example.invalid/some-other-release/airplanes-feeder-dev-arm64-FAKE.img.xz" "$manifest_name"
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "new contract: manifest url pointing at asset with wrong-pattern name is rejected" {
+    local manifest_name="airplanes-feeder-dev-arm64.rpi-imager-manifest.json"
+    local notes_url="https://example.invalid/release-notes.txt"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "dev-latest",
+  "body": "",
+  "assets": [
+    {"name": "release-notes.txt", "browser_download_url": "$notes_url"},
+    {"name": "$manifest_name", "browser_download_url": "https://example.invalid/$manifest_name"}
+  ]
+}
+EOF
+    # Manifest's url is in the release but points at the wrong asset
+    # (release-notes.txt rather than an .img.xz).
+    fixture_manifest_body "$notes_url" "$manifest_name"
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "new contract: manifest fetch failure is a hard error after retries" {
+    # Manifest sidecar listed in the release but the curl stub is asked to
+    # fail (FAIL marker in the basename). Library retries; each retry hits
+    # the same failure and the resolver exits rc 2.
+    local immutable_name="airplanes-feeder-dev-arm64-deadbeef0005-r1-a1.img.xz"
+    local manifest_name="airplanes-feeder-dev-arm64.rpi-imager-manifest.json"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "dev-latest",
+  "body": "",
+  "assets": [
+    {"name": "$immutable_name", "browser_download_url": "https://example.invalid/$immutable_name"},
+    {"name": "$manifest_name", "browser_download_url": "https://example.invalid/FAIL-$manifest_name"}
+  ]
+}
+EOF
+    # Shorten the backoff to keep the test fast.
+    export _IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS=2
+    export _IMAGE_SOURCE_MANIFEST_FETCH_BACKOFF_S=0
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "new contract: explicit regex override bypasses the manifest path" {
+    # Release has a valid manifest pointing at the immutable asset, AND a
+    # rolling-name asset. Caller passes an explicit regex that only matches
+    # the rolling asset — the resolver must respect that and bypass the
+    # manifest path.
+    fixture_release_with_manifest dev-latest dev arm64 >/dev/null
+    # Add a rolling asset to the same release fixture.
+    jq '.assets += [{"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/rolling.img.xz"}]' \
+        "$FIXTURE_DIR/releases-latest.json" > "$FIXTURE_DIR/releases-latest.json.tmp"
+    mv "$FIXTURE_DIR/releases-latest.json.tmp" "$FIXTURE_DIR/releases-latest.json"
+    stdout_file="$ROOT_DIR/stdout.txt"
+    image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" \
+        '^airplanes-feeder-dev-arm64\.img\.xz$' >"$stdout_file" 2>/dev/null
+    [ "$?" -eq 0 ]
+    grep -q "rolling.img.xz" "$(cat "$stdout_file")"
+}
+
+@test "legacy contract: never reads the manifest, regex picker only" {
+    # Legacy contract releases have a single asset under historical naming
+    # and no manifest sidecar. Should resolve via regex, no manifest fetch.
+    fixture_releases_json '[
+        {"tag_name": "bookworm", "published_at": "2025-02-26T18:02:20Z", "body": "", "assets": [
+            {"name": "image_2025-02-24-airplanes-live-full.zip", "browser_download_url": "https://example.invalid/plain.zip"}
+        ]}
+    ]'
+    run image_source_resolve airplanes-live/image-releases legacy stable arm64 release-any "$OUTPUT_DIR"
+    [ "$status" -eq 0 ]
+    # `$output` (bats) merges stdout+stderr; downloaded path is on stdout,
+    # selected-* observability lines are on stderr. Match the stdout-path
+    # token specifically, anchored to the start of a line so an "asset"
+    # mention elsewhere can't satisfy this.
+    echo "$output" | grep -qE '^/.+/image_2025-02-24-airplanes-live-full\.zip$'
 }

--- a/test/test_image_source.bats
+++ b/test/test_image_source.bats
@@ -460,20 +460,86 @@ EOF
 }
 
 @test "new contract: explicit regex override bypasses the manifest path" {
-    # Release has a valid manifest pointing at the immutable asset, AND a
-    # rolling-name asset. Caller passes an explicit regex that only matches
-    # the rolling asset — the resolver must respect that and bypass the
-    # manifest path.
-    fixture_release_with_manifest dev-latest dev arm64 >/dev/null
-    # Add a rolling asset to the same release fixture.
-    jq '.assets += [{"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/rolling.img.xz"}]' \
-        "$FIXTURE_DIR/releases-latest.json" > "$FIXTURE_DIR/releases-latest.json.tmp"
-    mv "$FIXTURE_DIR/releases-latest.json.tmp" "$FIXTURE_DIR/releases-latest.json"
+    # Release has a rolling-name asset and a manifest sidecar whose URL is
+    # set to fail when curl tries to fetch it (FAIL marker). If the resolver
+    # were attempting the manifest path it would error out — passing instead
+    # proves the explicit regex actually bypassed manifest resolution.
+    local manifest_name="airplanes-feeder-dev-arm64.rpi-imager-manifest.json"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "dev-latest",
+  "body": "",
+  "assets": [
+    {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/rolling.img.xz"},
+    {"name": "$manifest_name", "browser_download_url": "https://example.invalid/FAIL-$manifest_name"}
+  ]
+}
+EOF
+    # Keep retries fast in case the bypass is broken and we accidentally
+    # exercise the retry loop.
+    export _IMAGE_SOURCE_MANIFEST_FETCH_ATTEMPTS=1
+    export _IMAGE_SOURCE_MANIFEST_FETCH_BACKOFF_S=0
     stdout_file="$ROOT_DIR/stdout.txt"
     image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR" \
         '^airplanes-feeder-dev-arm64\.img\.xz$' >"$stdout_file" 2>/dev/null
     [ "$?" -eq 0 ]
     grep -q "rolling.img.xz" "$(cat "$stdout_file")"
+}
+
+@test "new contract: immutable .img.xz without manifest is a hard error, no regex fallback" {
+    # Race / broken-publish scenario: a release contains the immutable
+    # SHA-tagged asset but the manifest upload step never completed (or
+    # raced). The strategy must NOT silently fall through to the regex
+    # picker — if it did, release-any would happily advance to an older
+    # release and we'd test the wrong image. Hard rc=2 instead.
+    local immutable_name="airplanes-feeder-dev-arm64-deadbeef0006-r1-a1.img.xz"
+    cat > "$FIXTURE_DIR/releases-latest.json" <<EOF
+{
+  "tag_name": "dev-latest",
+  "body": "",
+  "assets": [
+    {"name": "$immutable_name", "browser_download_url": "https://example.invalid/$immutable_name"},
+    {"name": "airplanes-feeder-dev-arm64.img.xz", "browser_download_url": "https://example.invalid/rolling.img.xz"}
+  ]
+}
+EOF
+    run image_source_resolve airplanes-live/image new dev arm64 release-stable "$OUTPUT_DIR"
+    [ "$status" -eq 2 ]
+}
+
+@test "new contract: release-any does not silently advance past broken-publish release" {
+    # Newer release has an immutable asset but no manifest (broken publish);
+    # older release has a manifest + immutable. release-any must NOT skip
+    # the broken release and pick the older one — that would silently test
+    # a stale image.
+    local newer_immutable="airplanes-feeder-dev-arm64-cafebabe0001-r1-a1.img.xz"
+    local older_immutable="airplanes-feeder-dev-arm64-deadbeef0007-r1-a1.img.xz"
+    local older_manifest="airplanes-feeder-dev-arm64.rpi-imager-manifest.json"
+    fixture_releases_json '[
+        {
+            "tag_name": "dev-latest-broken",
+            "published_at": "2026-05-01T00:00:00Z",
+            "body": "",
+            "assets": [
+                {"name": "'"$newer_immutable"'", "browser_download_url": "https://example.invalid/'"$newer_immutable"'"}
+            ]
+        },
+        {
+            "tag_name": "dev-older",
+            "published_at": "2026-04-01T00:00:00Z",
+            "body": "",
+            "assets": [
+                {"name": "'"$older_immutable"'", "browser_download_url": "https://example.invalid/'"$older_immutable"'"},
+                {"name": "'"$older_manifest"'", "browser_download_url": "https://example.invalid/'"$older_manifest"'"}
+            ]
+        }
+    ]'
+    # The older release's manifest is well-formed; doesn't matter because
+    # we expect to hard-fail on the newer broken release before ever
+    # reaching the older one.
+    fixture_manifest_body "https://example.invalid/$older_immutable" "$older_manifest"
+    run image_source_resolve airplanes-live/image new dev arm64 release-any "$OUTPUT_DIR"
+    [ "$status" -eq 2 ]
 }
 
 @test "legacy contract: never reads the manifest, regex picker only" {


### PR DESCRIPTION
The `new` contract's image asset is now resolved by following the rpi-imager Custom Repository sidecar's `os_list[0].url` — the same pointer rpi-imager itself follows when a user pastes the manifest URL into the Custom Repository field. Regex matching stays as the fallback path: legacy contract, explicit `REGEX` overrides (`image-boot-smoke`'s `image_asset_regex` dispatch input), and new-contract releases that predate the manifest still resolve through it.

A manifest that is *present* but malformed — missing/empty `os_list[0].url`, URL pointing outside the release, or URL pointing at an asset whose basename does not match `^airplanes-feeder-{channel}-{arch}(-.+)?\.img\.xz$` — is a hard error and is not silently downgraded to the regex fallback. Manifest fetch retries with a short backoff to absorb the brief inconsistency window during `gh release upload --clobber`.

This unblocks dropping the duplicate rolling-name `.img.xz` asset on `airplanes-live/image`'s `dev-latest` release in a follow-up PR there (the only consumer that needed the predictable name was this resolver).
