### PR TITLE
Slim /etc/airplanes/feed.env to operator data only

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -85,39 +85,39 @@ write_feed_env() {
     derive_mlat_keys
     mkdir -p "$ETC_AIRPLANES"
     tee "$FEED_ENV" >/dev/null <<EOF
-INPUT="$INPUT"
-REDUCE_INTERVAL="0.5"
-
-# Display name on the MLAT map. Used as the --user argument to mlat-client.
-MLAT_USER="$MLAT_USER"
-# Explicit on/off toggle for MLAT. When false, airplanes-mlat exits early.
-MLAT_ENABLED="$MLAT_ENABLED"
-# Hide the feed name on the public MLAT map. true|false. Position is
-# never shown accurately no matter the setting. Toggle after setup with:
-#   sudo apl-feed mlat private enable
-#   sudo apl-feed mlat private disable
-MLAT_PRIVATE=$MLAT_PRIVATE
+# /etc/airplanes/feed.env — operator-supplied configuration for the
+# airplanes.live feeder daemons. Product-side defaults (brand endpoints,
+# readsb tuning, the local RESULTS output bundle, REDUCE_INTERVAL) live
+# in the daemon scripts; add overrides here only if you run a custom
+# airplanes.live backend or non-default decoder hardware.
 
 LATITUDE="$RECEIVERLATITUDE"
 LONGITUDE="$RECEIVERLONGITUDE"
-
 ALTITUDE="$RECEIVERALTITUDE"
 
-# this is the source for 978 data, use port 30978 from dump978 --raw-port
-# if you're not receiving 978, don't worry about it, not doing any harm!
-UAT_INPUT="127.0.0.1:30978"
-
-RESULTS="--results beast,connect,127.0.0.1:30104"
-RESULTS2="--results basestation,listen,31015"
-RESULTS3="--results beast,listen,30157"
-RESULTS4="--results beast,connect,127.0.0.1:30187"
-INPUT_TYPE="$INPUT_TYPE"
-
-MLATSERVER="feed.airplanes.live:31090"
-TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"
-NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0"
-JSON_OPTIONS="--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"
+# Display name shown on the MLAT map. Used as mlat-client's --user.
+MLAT_USER="$MLAT_USER"
+# Explicit on/off toggle. When false, airplanes-mlat exits early.
+MLAT_ENABLED="$MLAT_ENABLED"
+# Hide the feed name on the public MLAT map. true|false. Position is
+# never shown accurately no matter the setting. Toggle with:
+#   sudo apl-feed mlat private enable
+#   sudo apl-feed mlat private disable
+MLAT_PRIVATE=$MLAT_PRIVATE
 EOF
+
+    # Write INPUT + INPUT_TYPE only when they differ from the daemon
+    # defaults (127.0.0.1:30005 / dump1090). detect_receiver_input sets
+    # both together (Radarcape uses 127.0.0.1:10003 / radarcape_gps),
+    # so emit them as a pair to keep the override consistent.
+    if [[ "$INPUT" != "127.0.0.1:30005" ]] || [[ "$INPUT_TYPE" != "dump1090" ]]; then
+        tee -a "$FEED_ENV" >/dev/null <<EOF
+
+# Non-default receiver decoder. Defaults are 127.0.0.1:30005 / dump1090.
+INPUT="$INPUT"
+INPUT_TYPE="$INPUT_TYPE"
+EOF
+    fi
 }
 
 has_noninteractive_config_env() {

--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -48,7 +48,7 @@ UAT_PORT=$(echo $UAT_INPUT | cut -d: -f2)
 UAT_SOURCE="--net-connector $UAT_IP,$UAT_PORT,uat_in,silent_fail"
 
 REDUCE_INTERVAL="${REDUCE_INTERVAL:-0.5}"
-JSON_OPTIONS="${JSON_OPTIONS:-"--json-location-accuracy 2"}"
+JSON_OPTIONS="${JSON_OPTIONS:-"--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"}"
 MODEAC_OPTION=""
 if [[ "${MODEAC:-}" == "yes" ]]; then
     MODEAC_OPTION="--modeac"
@@ -61,8 +61,15 @@ else
 fi
 FEED_BIN="${AIRPLANES_FEED_BIN:-$DEFAULT_FEED_BIN}"
 
+# Brand endpoint + readsb tuning defaults. Apply outside the image
+# branch so fresh non-image installs (which no longer have these keys
+# in feed.env after configure.sh slimming) still produce a working
+# daemon. The image branch keeps its leaner FEED_NET_OPTIONS override
+# and adds FEED_IMAGE_OPTIONS for the baked-decoder case.
+TARGET="${TARGET:-"--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"}"
+NET_OPTIONS="${NET_OPTIONS:-"--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0"}"
+
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
-    TARGET="${TARGET:-"--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"}"
     FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-"--net-ro-interval 0.2"}"
     FEED_IMAGE_OPTIONS="${FEED_IMAGE_OPTIONS:-"--db-file=none --max-range 450"}"
 else

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -69,6 +69,26 @@ if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
 fi
 MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 
+# Product-side defaults. feed.env holds operator data; brand endpoints
+# and the local result-output bundle default here so a slim feed.env
+# still produces a working daemon, and an airplanes.live-side endpoint
+# change ships with the next feed update rather than requiring an
+# in-field config rewrite.
+MLATSERVER="${MLATSERVER:-feed.airplanes.live:31090}"
+INPUT="${INPUT:-127.0.0.1:30005}"
+INPUT_TYPE="${INPUT_TYPE:-dump1090}"
+
+# RESULTS bundle: only apply the default outputs when none of the
+# RESULTS* slots are set on disk. Legacy single-line feed.env may carry
+# a combined `RESULTS="--results ... --results ..."` and we must not
+# duplicate outputs by stacking individual defaults on top.
+if [[ ! -v RESULTS && ! -v RESULTS1 && ! -v RESULTS2 && ! -v RESULTS3 && ! -v RESULTS4 ]]; then
+    RESULTS="--results beast,connect,127.0.0.1:30104"
+    RESULTS2="--results basestation,listen,31015"
+    RESULTS3="--results beast,listen,30157"
+    RESULTS4="--results beast,connect,127.0.0.1:30187"
+fi
+
 UUID_FILE="--uuid-file $FEEDER_ID_FILE"
 
 # State writer (defensive: a partial install where this script is in

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -124,21 +124,6 @@ migrate_strip_uuid_file_arg() {
     sed -i -E 's/[[:space:]]*--uuid-file(=|[[:space:]]+)(\/usr\/local\/share\/airplanes\/airplanes-uuid|\/boot\/airplanes-uuid)//g' "$feed_env" || true
 }
 
-# Append the UAT_INPUT default if not already present. Comment matches the
-# original wording so subsequent runs don't accidentally re-append.
-migrate_add_uat_input_default() {
-    local feed_env="$1"
-    [[ -f "$feed_env" ]] || return 0
-    if ! grep -qs -e UAT_INPUT "$feed_env"; then
-        cat >> "$feed_env" <<"EOF"
-
-# this is the source for 978 data, use port 30978 from dump978 --raw-port
-# if you're not receiving 978, don't worry about it, not doing any harm!
-UAT_INPUT="127.0.0.1:30978"
-EOF
-    fi
-}
-
 # Split the legacy USER key into MLAT_USER and MLAT_ENABLED. Idempotent:
 # no-op when USER is absent. When USER is present, derives:
 #

--- a/test/script-install.sh
+++ b/test/script-install.sh
@@ -131,4 +131,7 @@ test -f /lib/systemd/system/airplanes-mlat.service
 test -f /etc/airplanes/feeder-claim-secret
 test "$(readlink /etc/default/airplanes)" = "/etc/airplanes/feed.env"
 grep -q 'systemctl restart airplanes-feed' /tmp/systemctl.log
-grep -q 'UAT_INPUT="127.0.0.1:30978"' /etc/airplanes/feed.env
+# UAT_INPUT default lives in the installed daemon wrapper now (was in
+# feed.env). airplanes-feed silent_fails on the UAT connector so the
+# default is harmless on feeders without 978 hardware.
+grep -q 'UAT_INPUT="127.0.0.1:30978"' /usr/local/share/airplanes/airplanes-feed.sh

--- a/test/script-upgrade.sh
+++ b/test/script-upgrade.sh
@@ -227,20 +227,28 @@ if [[ -e /etc/default/airplanes ]]; then
         || { echo "FAIL: /etc/default/airplanes is not a symlink to feed.env" >&2; exit 1; }
 fi
 
-# 4B. Wire-protocol contract
+# 4B. Wire-protocol contract — after update.sh's default-prune migrator
+# strips canonical brand-endpoint values from feed.env, the daemon-effective
+# TARGET/MLATSERVER come from the wrapper defaults. Source feed.env, apply
+# the same `${VAR:-default}` shape the wrappers use, and assert the result.
 env -i bash -c '
     set -euo pipefail
     # shellcheck disable=SC1091
     source /etc/airplanes/feed.env
-    [[ "${TARGET:-}"     == *"feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"* ]] \
+    TARGET="${TARGET:-"--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"}"
+    MLATSERVER="${MLATSERVER:-feed.airplanes.live:31090}"
+    [[ "${TARGET}"     == *"feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"* ]] \
         || { echo "FAIL: TARGET=${TARGET:-<unset>}" >&2; exit 1; }
-    [[ "${MLATSERVER:-}" == "feed.airplanes.live:31090" ]] \
+    [[ "${MLATSERVER}" == "feed.airplanes.live:31090" ]] \
         || { echo "FAIL: MLATSERVER=${MLATSERVER:-<unset>}" >&2; exit 1; }
 '
 
 grep -q 'feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004' \
     /usr/local/share/airplanes/airplanes-feed.sh \
-    || { echo "FAIL: image-default TARGET literal missing in installed airplanes-feed.sh" >&2; exit 1; }
+    || { echo "FAIL: failover TARGET literal missing in installed airplanes-feed.sh default" >&2; exit 1; }
+
+grep -q 'feed\.airplanes\.live:31090' /usr/local/share/airplanes/airplanes-mlat.sh \
+    || { echo "FAIL: MLATSERVER literal missing in installed airplanes-mlat.sh default" >&2; exit 1; }
 
 grep -rq '/api/feeders/secret' /usr/local/share/airplanes/ \
     || { echo "FAIL: /api/feeders/secret reference missing" >&2; exit 1; }

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -556,3 +556,4 @@ EOF
     ! grep -q '^USER=' "$FEED_ENV"
     ! grep -q '^PRIVACY=' "$FEED_ENV"
 }
+

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -315,16 +315,21 @@ SH
     [ -f "$root/etc/airplanes/feeder-id" ]
     [ -L "$ipath/airplanes-uuid" ]
     [ "$(readlink "$ipath/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
-    grep -q 'UAT_INPUT="127.0.0.1:30978"' "$root/etc/airplanes/feed.env"
+    # Canonicalisers rewrote the legacy fixture: TARGET bumped to feed2
+    # failover, NET_OPTIONS lost its --uuid-file arg. Brand endpoints are
+    # also available as daemon defaults in the installed wrappers — `[ ...
+    # -eq 0 ]` form below because `! grep` is a tested context under bats
+    # and would silently pass on match.
     grep -q 'beast_reduce_plus_out,feed2.airplanes.live,64004' "$root/etc/airplanes/feed.env"
-    ! grep -q -- '--uuid-file' "$root/etc/airplanes/feed.env"
+    [ "$(grep -c -- '--uuid-file' "$root/etc/airplanes/feed.env")" -eq 0 ]
+    grep -q 'feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004' "$ipath/airplanes-feed.sh"
+    grep -q 'feed.airplanes.live:31090' "$ipath/airplanes-mlat.sh"
     [ -L "$root/etc/default/airplanes" ]
     [ "$(readlink "$root/etc/default/airplanes")" = "$root/etc/airplanes/feed.env" ]
     grep -q 'claim register' "$ROOT_DIR/claim.log"
     grep -q -- '--max-retry-time 15' "$ROOT_DIR/claim.log"
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
     [ "$(grep -c 'systemctl daemon-reload' "$ROOT_DIR/commands.log")" = "1" ]
-    grep -q 'target-at-restart=TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"' "$ROOT_DIR/commands.log"
     # Lifecycle handover: even when MLAT is disabled by config, update.sh
     # no longer disables/stops the unit — the daemon self-disables via
     # sleep+exit. The state-file pattern depends on the daemon being
@@ -616,6 +621,9 @@ SH
     [ ! -e "$root/etc/airplanes/feed.env" ]
     [ -L "$root/etc/default/airplanes" ]
     [ "$(readlink "$root/etc/default/airplanes")" = "/boot/airplanes-config.txt" ]
+    # Brand endpoint reachable via daemon defaults in the installed
+    # wrapper (configure.sh / first-run-written feed.env stops carrying
+    # these; legacy /boot/airplanes-env values still source untouched).
     grep -q 'feed2.airplanes.live,64004' "$ipath/airplanes-feed.sh"
     grep -q 'claim register' "$ROOT_DIR/claim.log"
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"

--- a/test/test_wire_endpoints.bats
+++ b/test/test_wire_endpoints.bats
@@ -11,18 +11,30 @@ setup() {
     REPO_ROOT="$BATS_TEST_DIRNAME/.."
 }
 
-@test "configure.sh writes TARGET=feed.airplanes.live:30004 + feed2:64004 to feed.env" {
-    grep -qE '^TARGET="--net-connector feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004"$' \
-        "$REPO_ROOT/configure.sh"
-}
-
-@test "configure.sh writes MLATSERVER=feed.airplanes.live:31090 to feed.env" {
-    grep -qE '^MLATSERVER="feed\.airplanes\.live:31090"$' "$REPO_ROOT/configure.sh"
-}
-
-@test "airplanes-feed.sh image-default TARGET embeds feed.airplanes.live:30004 + feed2:64004" {
+@test "airplanes-feed.sh TARGET default embeds feed.airplanes.live:30004 + feed2:64004" {
+    # Brand endpoint lives as a daemon default since feed.env was slimmed
+    # to operator data; configure.sh no longer writes TARGET.
     grep -q 'feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004' \
         "$REPO_ROOT/scripts/airplanes-feed.sh"
+}
+
+@test "airplanes-mlat.sh MLATSERVER default embeds feed.airplanes.live:31090" {
+    grep -qE 'MLATSERVER="\$\{MLATSERVER:-feed\.airplanes\.live:31090\}"' \
+        "$REPO_ROOT/scripts/airplanes-mlat.sh"
+}
+
+@test "configure.sh does not write brand endpoints or tuning defaults to feed.env" {
+    # These keys are owned by the daemon defaults now. Keeping them in
+    # the rendered feed.env would freeze them on every feeder. `! grep -q`
+    # is a tested context for bash, so set -e doesn't fire on match —
+    # use grep -c for the count so a regression actually aborts.
+    [ "$(grep -cE '^TARGET=' "$REPO_ROOT/configure.sh")" -eq 0 ]
+    [ "$(grep -cE '^MLATSERVER=' "$REPO_ROOT/configure.sh")" -eq 0 ]
+    [ "$(grep -cE '^NET_OPTIONS=' "$REPO_ROOT/configure.sh")" -eq 0 ]
+    [ "$(grep -cE '^JSON_OPTIONS=' "$REPO_ROOT/configure.sh")" -eq 0 ]
+    [ "$(grep -cE '^REDUCE_INTERVAL=' "$REPO_ROOT/configure.sh")" -eq 0 ]
+    [ "$(grep -cE '^RESULTS[0-9]*=' "$REPO_ROOT/configure.sh")" -eq 0 ]
+    [ "$(grep -cE '^UAT_INPUT=' "$REPO_ROOT/configure.sh")" -eq 0 ]
 }
 
 @test "claim CLI posts to /api/feeders/secret" {

--- a/update.sh
+++ b/update.sh
@@ -364,11 +364,12 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
     # precaution applies in the manual-install branch.
     unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
     if [[ -f "$FEED_ENV" ]]; then
-        # Migrate legacy keys before sourcing so the shell sees the new
-        # schema directly. No-op when feed.env was written by a post-split
-        # writer (configure.sh, image first-run, new webconfig).
-        migrate_user_to_mlat_split "$FEED_ENV"
-        migrate_privacy_to_mlat_private "$FEED_ENV"
+        # Canonicalise legacy values + schema-split (USER → MLAT_USER /
+        # MLAT_ENABLED, PRIVACY → MLAT_PRIVATE, --uuid-file strip,
+        # TARGET feed→feed2 fallback rewrite, NET_OPTIONS beast_reduce_
+        # plus rewrite). No-op on canonical files written by configure.sh
+        # or first-run.
+        run_config_file_migrations "$FEED_ENV"
         source "$FEED_ENV"
     else
         source "$BOOT_CONFIG"
@@ -418,7 +419,6 @@ else
     unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
     if [[ -f "$FEED_ENV" ]]; then
         source "$FEED_ENV"
-        migrate_add_uat_input_default "$FEED_ENV"
     elif [[ -f "$BOOT_ENV" ]]; then
         source "$BOOT_ENV"
     fi
@@ -432,11 +432,8 @@ else
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 fi
-if [[ -z $INPUT ]] || [[ -z $INPUT_TYPE ]] \
-    || [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]] \
-    || [[ -z $MLATSERVER ]] || [[ -z $TARGET ]] \
-    || { [[ "$MLAT_ENABLED" == "true" ]] && [[ -z $MLAT_USER ]]; } \
-    || { [[ "$IMAGE_INSTALL" != "1" ]] && [[ -z $NET_OPTIONS ]]; }; then
+if [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]] \
+    || { [[ "$MLAT_ENABLED" == "true" ]] && [[ -z $MLAT_USER ]]; }; then
     if [[ "$IMAGE_INSTALL" == "1" ]]; then
         echo "Image configuration is incomplete; refusing to run interactive setup on an image." >&2
         exit 1
@@ -555,6 +552,7 @@ echo 50
 mkdir -p "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-mlat.service "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-feed.service "$SYSTEMD_DIR"
+
 if ! airplanes_is_build_mode; then
     systemctl daemon-reload >> "$LOGFILE" || true
 fi
@@ -693,8 +691,8 @@ Want a local web map? Install wiedehopf/tar1090 directly:
 https://github.com/wiedehopf/tar1090
 "
 
-INPUT_IP=$(echo "$INPUT" | cut -d: -f1)
-INPUT_PORT=$(echo "$INPUT" | cut -d: -f2)
+INPUT_IP=$(echo "${INPUT:-127.0.0.1:30005}" | cut -d: -f1)
+INPUT_PORT=$(echo "${INPUT:-127.0.0.1:30005}" | cut -d: -f2)
 
 ENDTEXT2="
 ---------------------


### PR DESCRIPTION
`/etc/airplanes/feed.env` used to carry both operator-supplied config (lat/lon/alt, MLAT identity) and a bag of product defaults — the airplanes.live MLATSERVER/TARGET endpoints, readsb tuning flags, the local result-output bundle. Baking those into user-editable config means every feeder freezes its copy, so a server-side endpoint change requires every feeder to update its file.

This moves them into `airplanes-feed.sh` and `airplanes-mlat.sh` as `${VAR:-default}` shell defaults, and stops `configure.sh` from writing them. New installs get a slim feed.env (operator data only) from day one.

Existing on-disk files are untouched — the daemon defaults are a strict subset of what was being written before, so legacy feed.env values still take effect when present and the daemons fall back cleanly when keys are absent. If brand endpoints need to change in future, a targeted migrator can land at that point with the actual old/new values to migrate.
