### PR TITLE
Fall back to Anonymous-<short-id> when MLAT_USER is empty

### DIFF
--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -43,6 +43,32 @@ fi
 MLAT_ENABLED="${MLAT_ENABLED:-true}"
 MLAT_USER="${MLAT_USER-}"
 
+# MLAT display name is optional. When unset or empty, derive a per-device
+# fallback from the canonical feeder-id so each feeder still gets a distinct
+# map identity instead of every blank-name feeder aggregating under a shared
+# anonymous pin. webconfig writes a user-supplied MLAT_USER directly when
+# the operator provides one. Falls back to plain "Anonymous" when the
+# feeder-id file is missing, a symlink, or doesn't contain a canonical UUID
+# — guards against a symlink-swap that would otherwise let the first 8 bytes
+# of an unrelated file leak into the public state file as MLAT_USER, and
+# against malformed content (control bytes, BOM) reaching mlat-client.
+if [[ -z "$MLAT_USER" ]]; then
+    _mlat_user_short_id=""
+    if [[ -f "$FEEDER_ID_FILE" && ! -L "$FEEDER_ID_FILE" && -r "$FEEDER_ID_FILE" ]]; then
+        _mlat_user_candidate="$(tr -d '\r\n' < "$FEEDER_ID_FILE" 2>/dev/null || true)"
+        if [[ "$_mlat_user_candidate" =~ ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$ ]]; then
+            _mlat_user_short_id="${_mlat_user_candidate:0:8}"
+        fi
+        unset _mlat_user_candidate
+    fi
+    if [[ -n "$_mlat_user_short_id" ]]; then
+        MLAT_USER="Anonymous-$_mlat_user_short_id"
+    else
+        MLAT_USER="Anonymous"
+    fi
+    unset _mlat_user_short_id
+fi
+
 # Legacy PRIVACY read fallback. update.sh's migrate_privacy_to_mlat_private
 # converts PRIVACY=--privacy to MLAT_PRIVATE=true on every run; this in-
 # memory derivation handles a daemon restart that races ahead of the next
@@ -106,8 +132,9 @@ fi
 # defaulting), then explicit MLAT_ENABLED disable (so a user who turns
 # MLAT off on a fresh feeder with lat/lon still 0 sees reason=
 # mlat_enabled_false rather than reason=latitude_zero), then geo
-# sentinels, then the empty-MLAT_USER check. The misconfigured branch
-# is the strict-fail-with-exit-64 shape.
+# sentinels. MLAT_USER is no longer a classifier input — empty values are
+# substituted with a per-device fallback above, so the only "misconfigured"
+# branch left is the strict MLAT_PRIVATE shape.
 _mlat_classify() {
     case "$MLAT_PRIVATE" in
         true|false) ;;
@@ -116,7 +143,6 @@ _mlat_classify() {
     if [[ "$MLAT_ENABLED" != "true" ]]; then printf 'disabled mlat_enabled_false\n'; return; fi
     if [[ "$LATITUDE" == 0 ]]; then printf 'disabled latitude_zero\n'; return; fi
     if [[ "$LONGITUDE" == 0 ]]; then printf 'disabled longitude_zero\n'; return; fi
-    if [[ -z "$MLAT_USER" ]]; then printf 'misconfigured mlat_user_empty\n'; return; fi
     printf 'enabled ok\n'
 }
 
@@ -146,9 +172,6 @@ case "$STATE" in
         case "$REASON" in
             mlat_private_invalid)
                 echo "MLAT_PRIVATE must be 'true' or 'false' (got: '${MLAT_PRIVATE:-}'); refusing to start mlat-client." >&2
-                ;;
-            mlat_user_empty)
-                echo "MLAT_ENABLED=true but MLAT_USER is empty; refusing to start mlat-client." >&2
                 ;;
             *)
                 echo "Misconfigured ($REASON); refusing to start mlat-client." >&2

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -181,8 +181,9 @@ _render_systemd_state() {
 # published decision from /run/airplanes-mlat/state when the unit is
 # active or transitioning; falls through to systemd-derived rendering
 # otherwise. Special-cases failed-with-exit-64 (the strict misconfig
-# fail from airplanes-mlat.sh) to surface the MLAT_USER-empty actionable
-# message via the state file's reason key.
+# fail from airplanes-mlat.sh — today only fires for an invalid
+# MLAT_PRIVATE value) to surface the actionable message via the state
+# file's reason key.
 mlat_status_line() {
     local label="MLAT service"
     local unit="airplanes-mlat.service"
@@ -270,7 +271,6 @@ _render_mlat_misconfig_reason() {
     local reason="$1"
     local label="MLAT service"
     case "$reason" in
-        mlat_user_empty)      status_line fail "$label" "MLAT_USER is empty (set MLAT_USER, or set MLAT_ENABLED=false)" ;;
         mlat_private_invalid) status_line fail "$label" "MLAT_PRIVATE must be 'true' or 'false' in feed.env" ;;
         *)                    status_line fail "$label" "misconfigured ($reason)" ;;
     esac

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -302,17 +302,6 @@ STUB
     [[ "$output" == *'disabled by config (LONGITUDE=0)'* ]]
 }
 
-@test "mlat_status_line: ActiveState=active + misconfigured mlat_user_empty → FIX with actionable message" {
-    write_mlat_state misconfigured mlat_user_empty
-    stub_systemctl_active_state active
-    status_init
-    STATUS_OUTPUT_JSON=0
-    run mlat_status_line
-    [[ "$output" == *'FIX'* ]]
-    [[ "$output" == *'MLAT_USER is empty'* ]]
-    [[ "$output" == *'set MLAT_ENABLED=false'* ]]
-}
-
 @test "mlat_status_line: ActiveState=failed + exit 64 + misconfigured mlat_private_invalid → actionable" {
     write_mlat_state misconfigured mlat_private_invalid
     stub_systemctl_active_state failed 64
@@ -336,23 +325,23 @@ STUB
 # Load-bearing case: misconfig surface is visible continuously across the
 # Restart=always cycle, not just during the microsecond active window.
 @test "mlat_status_line: ActiveState=activating + misconfigured → still surfaces the actionable message" {
-    write_mlat_state misconfigured mlat_user_empty
+    write_mlat_state misconfigured mlat_private_invalid
     stub_systemctl_active_state activating
     status_init
     STATUS_OUTPUT_JSON=0
     run mlat_status_line
     [[ "$output" == *'FIX'* ]]
-    [[ "$output" == *'MLAT_USER is empty'* ]]
+    [[ "$output" == *"MLAT_PRIVATE must be 'true' or 'false'"* ]]
 }
 
 @test "mlat_status_line: ActiveState=failed + exit 64 + state file present → surfaces misconfig reason" {
-    write_mlat_state misconfigured mlat_user_empty
+    write_mlat_state misconfigured mlat_private_invalid
     stub_systemctl_active_state failed 64
     status_init
     STATUS_OUTPUT_JSON=0
     run mlat_status_line
     [[ "$output" == *'FIX'* ]]
-    [[ "$output" == *'MLAT_USER is empty'* ]]
+    [[ "$output" == *"MLAT_PRIVATE must be 'true' or 'false'"* ]]
 }
 
 @test "mlat_status_line: ActiveState=failed + exit 64 + no state file → generic 'check feed.env MLAT config'" {

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -662,8 +662,9 @@ write_feed_env() {
     grep -qx 'reason=longitude_zero' "$root/run/airplanes-mlat/state"
 }
 
-@test "airplanes-mlat.sh exits 64 with state=misconfigured when MLAT_USER empty + MLAT_ENABLED=true" {
+@test "airplanes-mlat.sh: empty MLAT_USER + canonical feeder-id → state=enabled, MLAT_USER=Anonymous-<short>, mlat-client gets --user" {
     local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
     write_feed_env "$root" \
@@ -675,19 +676,120 @@ write_feed_env() {
         'INPUT="127.0.0.1:30005"' \
         'INPUT_TYPE="dump1090"' \
         'MLATSERVER="feed.airplanes.live:31090"'
+    # Seed a known feeder-id; first 8 chars form the per-device suffix.
+    printf '0a1b2c3d-4567-89ab-cdef-0123456789ab\n' > "$root/etc/airplanes/feeder-id"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=ok' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=Anonymous-0a1b2c3d' "$root/run/airplanes-mlat/state"
+    # mlat-client must receive the substituted value, not an empty --user.
+    grep -q -- '--user Anonymous-0a1b2c3d' "$arg_log"
+}
+
+@test "airplanes-mlat.sh: empty MLAT_USER + no feeder-id → state=enabled, MLAT_USER=Anonymous" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER=""' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+    # Deliberately no $root/etc/airplanes/feeder-id — the daemon falls back
+    # to plain "Anonymous" when the file is missing.
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=ok' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+    grep -q -- '--user Anonymous' "$arg_log"
+}
+
+@test "airplanes-mlat.sh: empty MLAT_USER + empty feeder-id file → MLAT_USER=Anonymous (not Anonymous-)" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER=""' 'MLAT_ENABLED=true' 'LATITUDE=52' 'LONGITUDE=13' 'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' 'INPUT_TYPE="dump1090"' 'MLATSERVER="feed.airplanes.live:31090"'
+    : > "$root/etc/airplanes/feeder-id"
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    [ "$status" -eq 64 ]
-    grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=mlat_user_empty' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=' "$root/run/airplanes-mlat/state"
+    [ "$status" -eq 0 ]
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh: empty MLAT_USER + truncated feeder-id (not a UUID) → MLAT_USER=Anonymous" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER=""' 'MLAT_ENABLED=true' 'LATITUDE=52' 'LONGITUDE=13' 'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' 'INPUT_TYPE="dump1090"' 'MLATSERVER="feed.airplanes.live:31090"'
+    # Three printable bytes — would have made a "Anonymous-abc" identity if
+    # we used raw head -c 8 without UUID validation.
+    printf 'abc' > "$root/etc/airplanes/feeder-id"
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh: empty MLAT_USER + feeder-id is a symlink → MLAT_USER=Anonymous (refuses to follow)" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER=""' 'MLAT_ENABLED=true' 'LATITUDE=52' 'LONGITUDE=13' 'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' 'INPUT_TYPE="dump1090"' 'MLATSERVER="feed.airplanes.live:31090"'
+    # Target file with a canonical-looking UUID; the daemon must still refuse
+    # to follow the symlink and fall back to plain Anonymous.
+    printf 'ffffffff-1234-5678-9abc-def012345678\n' > "$root/etc/airplanes/feeder-id.target"
+    ln -s "$root/etc/airplanes/feeder-id.target" "$root/etc/airplanes/feeder-id"
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh: empty MLAT_USER + feeder-id with CR/LF in canonical UUID → strips CR/LF, MLAT_USER=Anonymous-<short>" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER=""' 'MLAT_ENABLED=true' 'LATITUDE=52' 'LONGITUDE=13' 'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' 'INPUT_TYPE="dump1090"' 'MLATSERVER="feed.airplanes.live:31090"'
+    # CRLF line ending (Windows-edited feeder-id file) — must be stripped
+    # before the UUID regex check so the validation succeeds.
+    printf '0a1b2c3d-4567-89ab-cdef-0123456789ab\r\n' > "$root/etc/airplanes/feeder-id"
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'mlat_user=Anonymous-0a1b2c3d' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh exits 64 with schema-strict guard when boot config has legacy USER but no MLAT_USER" {
     # Simulates a feeder where airplanes-update or webconfig migration
     # did not run before the daemon started. The schema guard catches it
-    # early (before mlat_user_empty classifier) and points at the fix.
+    # early (before any MLAT_USER fallback) and points at the fix — the
+    # legacy USER= must be migrated explicitly rather than silently aliased.
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -269,6 +269,53 @@ SH
     [ "$(cat "$root/setup-marker")" = "setup-ran" ]
 }
 
+@test "update.sh does NOT run setup.sh when MLAT_USER is empty but geo is complete" {
+    # Regression: empty MLAT_USER + MLAT_ENABLED=true used to trip the
+    # "incomplete config" guard and launch setup.sh. With the daemon-side
+    # Anonymous fallback this state is valid and setup.sh must NOT run.
+    local root="$ROOT_DIR/root"
+    local feed_repo="$ROOT_DIR/feed-source"
+    local ipath="$root/usr/local/share/airplanes"
+    mkdir -p "$ipath" "$root/etc/airplanes"
+    echo 'VERSION_ID="13"' > "$root/etc/os-release"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52"
+LONGITUDE="13"
+ALTITUDE="35m"
+MLAT_USER=""
+MLAT_ENABLED="true"
+MLATSERVER="feed.airplanes.live:31090"
+TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out"
+EOF
+    copy_feed_fixture_repo "$feed_repo"
+    cat > "$feed_repo/setup.sh" <<'SH'
+#!/usr/bin/env bash
+mkdir -p "$AIRPLANES_ROOT"
+printf 'setup-ran-unexpectedly\n' > "$AIRPLANES_ROOT/setup-marker"
+exit 0
+SH
+    chmod +x "$feed_repo/setup.sh"
+    commit_all "$feed_repo"
+    cp "$feed_repo/update.sh" "$ipath/update.sh"
+    install_command_stubs
+
+    run env PATH="$STUB_DIR:/usr/bin:/bin" \
+        COMMAND_LOG="$ROOT_DIR/commands.log" \
+        AIRPLANES_ROOT="$root" \
+        AIRPLANES_SKIP_ROOT_CHECK=1 \
+        AIRPLANES_PACKAGE_MANAGER=none \
+        AIRPLANES_FEED_REPO="$feed_repo" \
+        AIRPLANES_FEED_BRANCH=main \
+        bash "$UPDATE"
+
+    # update.sh may fail later in the pipeline (no mlat/readsb repos
+    # configured) but the regression we care about is that setup.sh never
+    # ran. Status intentionally not asserted.
+    [ ! -f "$root/setup-marker" ]
+}
+
 @test "update.sh runs configured update path without touching host root" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"

--- a/update.sh
+++ b/update.sh
@@ -432,8 +432,7 @@ else
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 fi
-if [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]] \
-    || { [[ "$MLAT_ENABLED" == "true" ]] && [[ -z $MLAT_USER ]]; }; then
+if [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]]; then
     if [[ "$IMAGE_INSTALL" == "1" ]]; then
         echo "Image configuration is incomplete; refusing to run interactive setup on an image." >&2
         exit 1
@@ -441,6 +440,10 @@ if [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]] \
     bash "$GIT/setup.sh"
     exit 0
 fi
+# Empty MLAT_USER is intentionally not part of the "incomplete config" guard
+# above: the daemon (airplanes-mlat.sh) substitutes an Anonymous-<short>
+# fallback at startup, so re-running setup.sh for an empty name would re-prompt
+# the operator for nothing actionable.
 
 if [[ "$LATITUDE" == 0 ]] || [[ "$LONGITUDE" == 0 ]] || [[ "$MLAT_ENABLED" != "true" ]]; then
     MLAT_DISABLED=1


### PR DESCRIPTION
Makes MLAT_USER optional at the daemon. When MLAT_USER is empty in feed.env, airplanes-mlat.sh substitutes a per-device fallback derived from the canonical feeder-id (first 8 chars of /etc/airplanes/feeder-id, after validating it as a canonical UUID and refusing to follow symlinks). When the feeder-id file is missing, malformed, or a symlink, falls back to plain Anonymous. The state file now publishes mlat_user=Anonymous-<short> or mlat_user=Anonymous instead of the prior misconfigured mlat_user_empty exit-64.

update.sh's incomplete-config guard no longer treats MLAT_ENABLED=true + empty MLAT_USER as needing setup.sh. The daemon handles it.

This is a prerequisite for airplanes-live/image#86, which removes MLAT_USER from the boot-config allowlist entirely. Without this change merged first, every freshly-flashed feeder with no user intervention would land in MLAT misconfigured state between flash and first webconfig visit.

Removes the now-unreachable mlat_user_empty rendering from apl-feed status. configure.sh's existing DEFAULT_MLAT_NAME="Anonymous" path is unchanged (manual-install whiptail still writes a literal Anonymous to feed.env when the prompt is blank); the daemon-side per-device fallback only fires when MLAT_USER is genuinely empty at startup, i.e., the image's bootstrap-only boot config path.