### PR TITLE
Retire LATITUDE/LONGITUDE sentinels for explicit GEO_CONFIGURED flag

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -84,10 +84,18 @@ derive_mlat_keys() {
 # Heuristic: treat (0, 0) as the legacy/placeholder sentinel pair (image
 # freeze writes both as 0). A single zero axis is a legitimate coordinate
 # (equator at lon!=0, or prime meridian at lat!=0) and counts as
-# configured. The Atlantic (0,0) point is uninhabited so the false-negative
-# blast radius is empty in practice.
+# configured. The Atlantic (0,0) point is uninhabited so the false-
+# negative blast radius is empty in practice. Recognizes decimal/signed
+# zero forms (0.00000, +0, -0) so a noninteractive AIRPLANES_LATITUDE that
+# uses a decimal-zero placeholder isn't misclassified as configured.
+_geo_axis_unset_or_zero() {
+    [[ -z "$1" ]] && return 0
+    [[ "$1" =~ ^[+-]?0+(\.0+)?$ ]] && return 0
+    return 1
+}
 derive_geo_configured() {
-    if [[ "$RECEIVERLATITUDE" == "0" && "$RECEIVERLONGITUDE" == "0" ]]; then
+    if _geo_axis_unset_or_zero "$RECEIVERLATITUDE" \
+        && _geo_axis_unset_or_zero "$RECEIVERLONGITUDE"; then
         GEO_CONFIGURED="false"
     else
         GEO_CONFIGURED="true"

--- a/configure.sh
+++ b/configure.sh
@@ -81,8 +81,22 @@ derive_mlat_keys() {
     fi
 }
 
+# Heuristic: treat (0, 0) as the legacy/placeholder sentinel pair (image
+# freeze writes both as 0). A single zero axis is a legitimate coordinate
+# (equator at lon!=0, or prime meridian at lat!=0) and counts as
+# configured. The Atlantic (0,0) point is uninhabited so the false-negative
+# blast radius is empty in practice.
+derive_geo_configured() {
+    if [[ "$RECEIVERLATITUDE" == "0" && "$RECEIVERLONGITUDE" == "0" ]]; then
+        GEO_CONFIGURED="false"
+    else
+        GEO_CONFIGURED="true"
+    fi
+}
+
 write_feed_env() {
     derive_mlat_keys
+    derive_geo_configured
     mkdir -p "$ETC_AIRPLANES"
     tee "$FEED_ENV" >/dev/null <<EOF
 # /etc/airplanes/feed.env — operator-supplied configuration for the
@@ -94,6 +108,12 @@ write_feed_env() {
 LATITUDE="$RECEIVERLATITUDE"
 LONGITUDE="$RECEIVERLONGITUDE"
 ALTITUDE="$RECEIVERALTITUDE"
+# Explicit "user has provided real coordinates" flag. The daemon refuses
+# to start MLAT until this is true; the legacy "LATITUDE=0 means unset"
+# sentinel is retired. Image freeze writes false; configure.sh writes
+# true when both coords are non-zero (Atlantic 0,0 placeholders stay
+# false). The webconfig UI writes this explicitly when the user saves.
+GEO_CONFIGURED=$GEO_CONFIGURED
 
 # Display name shown on the MLAT map. Used as mlat-client's --user.
 MLAT_USER="$MLAT_USER"

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -15,12 +15,12 @@ BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
 FEED_ENV="$(airplanes_path /etc/airplanes/feed.env)"
 FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
 
-# Unset USER (and the privacy keys) before sourcing so the process env
-# can't bleed into the legacy-USER, legacy-PRIVACY, or legacy-MLAT_MARKER
-# fallbacks below. systemd's User= sets $USER for airplanes-mlat.service;
-# an env-supplied MLAT_PRIVATE / PRIVACY / MLAT_MARKER (e.g. from a
-# Drop-In) would otherwise mask the on-disk value.
-unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
+# Unset USER (and the privacy / geo keys) before sourcing so the process
+# env can't bleed into any of the legacy fallbacks below. systemd's User=
+# sets $USER for airplanes-mlat.service; an env-supplied MLAT_PRIVATE /
+# PRIVACY / MLAT_MARKER / GEO_CONFIGURED (e.g. from a Drop-In) would
+# otherwise mask the on-disk value.
+unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER GEO_CONFIGURED
 if [[ -f "$FEED_ENV" ]]; then
     source "$FEED_ENV"
 elif [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && -f "$BOOT_CONFIG" ]]; then
@@ -95,6 +95,23 @@ if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
 fi
 MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 
+# Legacy GEO_CONFIGURED read fallback. A feed.env predating the explicit
+# flag won't have GEO_CONFIGURED set. update.sh's migrate_geo_to_configured_flag
+# adds it on every update; this in-memory derivation handles a daemon
+# restart that races ahead. Heuristic: both LATITUDE and LONGITUDE non-
+# empty and non-"0" → true; else false. Conservative — matches the prior
+# (LATITUDE==0 || LONGITUDE==0) sentinel disable so legacy feeders see no
+# behavior change. The Atlantic (0,0) point is uninhabited; legitimate
+# equator-or-prime-meridian feeders have at most one axis at zero and
+# pass this check.
+if [[ ! -v GEO_CONFIGURED ]]; then
+    if [[ -n "${LATITUDE:-}" && "$LATITUDE" != 0 && -n "${LONGITUDE:-}" && "$LONGITUDE" != 0 ]]; then
+        GEO_CONFIGURED="true"
+    else
+        GEO_CONFIGURED="false"
+    fi
+fi
+
 # Product-side defaults. feed.env holds operator data; brand endpoints
 # and the local result-output bundle default here so a slim feed.env
 # still produces a working daemon, and an airplanes.live-side endpoint
@@ -130,19 +147,19 @@ fi
 # Classify the daemon's config decision. Order matters: invalid
 # MLAT_PRIVATE is checked first (fail-loud rather than silently
 # defaulting), then explicit MLAT_ENABLED disable (so a user who turns
-# MLAT off on a fresh feeder with lat/lon still 0 sees reason=
-# mlat_enabled_false rather than reason=latitude_zero), then geo
-# sentinels. MLAT_USER is no longer a classifier input — empty values are
-# substituted with a per-device fallback above, so the only "misconfigured"
-# branch left is the strict MLAT_PRIVATE shape.
+# MLAT off on a fresh feeder before configuring geo sees reason=
+# mlat_enabled_false rather than reason=geo_not_configured), then the
+# explicit geo flag. MLAT_USER is no longer a classifier input — empty
+# values are substituted with a per-device Anonymous-<short-id> fallback
+# above, so the only "misconfigured" branch left is the strict
+# MLAT_PRIVATE shape.
 _mlat_classify() {
     case "$MLAT_PRIVATE" in
         true|false) ;;
         *) printf 'misconfigured mlat_private_invalid\n'; return ;;
     esac
     if [[ "$MLAT_ENABLED" != "true" ]]; then printf 'disabled mlat_enabled_false\n'; return; fi
-    if [[ "$LATITUDE" == 0 ]]; then printf 'disabled latitude_zero\n'; return; fi
-    if [[ "$LONGITUDE" == 0 ]]; then printf 'disabled longitude_zero\n'; return; fi
+    if [[ "$GEO_CONFIGURED" != "true" ]]; then printf 'disabled geo_not_configured\n'; return; fi
     printf 'enabled ok\n'
 }
 
@@ -157,6 +174,7 @@ airplanes_write_state "$STATE_FILE" \
     "mlat_enabled=${MLAT_ENABLED:-}" \
     "mlat_user=${MLAT_USER:-}" \
     "mlat_private=${MLAT_PRIVATE:-}" \
+    "geo_configured=${GEO_CONFIGURED:-}" \
     "latitude=${LATITUDE:-}" \
     "longitude=${LONGITUDE:-}" || true
 

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -98,17 +98,21 @@ MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 # Legacy GEO_CONFIGURED read fallback. A feed.env predating the explicit
 # flag won't have GEO_CONFIGURED set. update.sh's migrate_geo_to_configured_flag
 # adds it on every update; this in-memory derivation handles a daemon
-# restart that races ahead. Heuristic: both LATITUDE and LONGITUDE non-
-# empty and non-"0" → true; else false. Conservative — matches the prior
-# (LATITUDE==0 || LONGITUDE==0) sentinel disable so legacy feeders see no
-# behavior change. The Atlantic (0,0) point is uninhabited; legitimate
-# equator-or-prime-meridian feeders have at most one axis at zero and
-# pass this check.
+# restart that races ahead. Heuristic: BOTH coords numerically zero (or
+# empty) → false; anything else → true. The (0,0) point is uninhabited so
+# the placeholder pair is unambiguous; a single zero axis is a legitimate
+# coordinate (equator at lon!=0, or prime meridian at lat!=0) and counts
+# as configured. Matches configure.sh's writer-side heuristic exactly.
+_geo_axis_unset_or_zero() {
+    [[ -z "$1" ]] && return 0
+    [[ "$1" =~ ^[+-]?0+(\.0+)?$ ]] && return 0
+    return 1
+}
 if [[ ! -v GEO_CONFIGURED ]]; then
-    if [[ -n "${LATITUDE:-}" && "$LATITUDE" != 0 && -n "${LONGITUDE:-}" && "$LONGITUDE" != 0 ]]; then
-        GEO_CONFIGURED="true"
-    else
+    if _geo_axis_unset_or_zero "${LATITUDE:-}" && _geo_axis_unset_or_zero "${LONGITUDE:-}"; then
         GEO_CONFIGURED="false"
+    else
+        GEO_CONFIGURED="true"
     fi
 fi
 

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -250,6 +250,7 @@ _render_mlat_decision() {
             local detail
             case "$reason" in
                 mlat_enabled_false) detail="disabled by config (MLAT_ENABLED=false)" ;;
+                geo_not_configured) detail="disabled by config (location not set)" ;;
                 latitude_zero)      detail="disabled by config (LATITUDE=0)" ;;
                 longitude_zero)     detail="disabled by config (LONGITUDE=0)" ;;
                 *)                  detail="disabled by config ($reason)" ;;

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -315,20 +315,36 @@ migrate_privacy_to_mlat_private() {
     fi
 }
 
+# Shared helper: true when val is empty, "0", "-0", "+0", "0.0",
+# "0.00000", etc. — i.e., the legacy unset/zero forms an image freeze or
+# hand-edit might leave. Used by the GEO_CONFIGURED derivation in both
+# the migration here and the in-shell fallbacks in airplanes-mlat.sh and
+# update.sh. Bash regex: optional sign, one-or-more zeros, optional
+# decimal-point-plus-zeros tail.
+_airplanes_geo_axis_unset_or_zero() {
+    [[ -z "$1" ]] && return 0
+    [[ "$1" =~ ^[+-]?0+(\.0+)?$ ]] && return 0
+    return 1
+}
+
 # Add an explicit GEO_CONFIGURED=true|false flag to feed.env, retiring
 # the legacy LATITUDE=0/LONGITUDE=0 sentinel pattern. Idempotent.
 #
-#   GEO_CONFIGURED already present       →  no-op
-#   LATITUDE and LONGITUDE both non-zero →  GEO_CONFIGURED=true
-#   anything else (zero, missing, blank) →  GEO_CONFIGURED=false
+#   GEO_CONFIGURED already present                   →  no-op
+#   BOTH LATITUDE and LONGITUDE numerically zero     →  GEO_CONFIGURED=false
+#   anything else (incl. single-zero axis)           →  GEO_CONFIGURED=true
 #
 # Heuristic note: (0, 0) is the legacy/placeholder sentinel pair (image
 # freeze writes both as 0). A single zero axis is a legitimate coordinate
-# (equator at lon!=0, or prime meridian at lat!=0); the rule preserves it
-# as configured. The Atlantic (0,0) point is uninhabited so the false-
-# negative blast radius is empty in practice. Configs written by the
-# webconfig UI will include an explicit GEO_CONFIGURED and this function
-# becomes a no-op for them.
+# (equator at lon!=0, or prime meridian at lat!=0) and counts as
+# configured — under the previous LATITUDE==0/LONGITUDE==0 sentinel
+# checks those feeders were silently disabled; this migration heals them.
+# The (0,0) point is uninhabited so the false-negative blast radius is
+# empty in practice. Configs written by the webconfig UI include an
+# explicit GEO_CONFIGURED and this function becomes a no-op for them.
+# Numerically-zero forms recognized: empty, "0", "-0", "+0", "0.0",
+# "0.00000", etc. — so hand-edits that use decimal zeros aren't classified
+# as configured.
 migrate_geo_to_configured_flag() {
     local feed_env="$1"
     [[ -f "$feed_env" ]] || return 0
@@ -342,10 +358,11 @@ migrate_geo_to_configured_flag() {
     longitude="$(_extract_env_value "$feed_env" LONGITUDE)"
 
     local geo_configured
-    if [[ -n "$latitude" && "$latitude" != "0" && -n "$longitude" && "$longitude" != "0" ]]; then
-        geo_configured="true"
-    else
+    if _airplanes_geo_axis_unset_or_zero "$latitude" \
+        && _airplanes_geo_axis_unset_or_zero "$longitude"; then
         geo_configured="false"
+    else
+        geo_configured="true"
     fi
 
     local tmp

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -315,6 +315,48 @@ migrate_privacy_to_mlat_private() {
     fi
 }
 
+# Add an explicit GEO_CONFIGURED=true|false flag to feed.env, retiring
+# the legacy LATITUDE=0/LONGITUDE=0 sentinel pattern. Idempotent.
+#
+#   GEO_CONFIGURED already present       →  no-op
+#   LATITUDE and LONGITUDE both non-zero →  GEO_CONFIGURED=true
+#   anything else (zero, missing, blank) →  GEO_CONFIGURED=false
+#
+# Heuristic note: (0, 0) is the legacy/placeholder sentinel pair (image
+# freeze writes both as 0). A single zero axis is a legitimate coordinate
+# (equator at lon!=0, or prime meridian at lat!=0); the rule preserves it
+# as configured. The Atlantic (0,0) point is uninhabited so the false-
+# negative blast radius is empty in practice. Configs written by the
+# webconfig UI will include an explicit GEO_CONFIGURED and this function
+# becomes a no-op for them.
+migrate_geo_to_configured_flag() {
+    local feed_env="$1"
+    [[ -f "$feed_env" ]] || return 0
+
+    if grep -qE '^GEO_CONFIGURED=' "$feed_env"; then
+        return 0
+    fi
+
+    local latitude longitude
+    latitude="$(_extract_env_value "$feed_env" LATITUDE)"
+    longitude="$(_extract_env_value "$feed_env" LONGITUDE)"
+
+    local geo_configured
+    if [[ -n "$latitude" && "$latitude" != "0" && -n "$longitude" && "$longitude" != "0" ]]; then
+        geo_configured="true"
+    else
+        geo_configured="false"
+    fi
+
+    local tmp
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    cp -fp "$feed_env" "$tmp" || { rm -f "$tmp"; return 1; }
+    printf 'GEO_CONFIGURED=%s\n' "$geo_configured" >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
 run_config_file_migrations() {
     local feed_env="$1"
     migrate_net_options_beast_reduce_plus "$feed_env"
@@ -322,6 +364,7 @@ run_config_file_migrations() {
     migrate_strip_uuid_file_arg "$feed_env"
     migrate_user_to_mlat_split "$feed_env"
     migrate_privacy_to_mlat_private "$feed_env"
+    migrate_geo_to_configured_flag "$feed_env"
 }
 
 # ---------------------------------------------------------------------------

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -284,7 +284,19 @@ STUB
     [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
 }
 
-@test "mlat_status_line: ActiveState=active + disabled latitude_zero → 'disabled by config (LATITUDE=0)'" {
+@test "mlat_status_line: ActiveState=active + disabled geo_not_configured → 'disabled by config (location not set)'" {
+    write_mlat_state disabled geo_not_configured
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'disabled by config (location not set)'* ]]
+}
+
+@test "mlat_status_line: ActiveState=active + disabled latitude_zero → 'disabled by config (LATITUDE=0)' (legacy state file)" {
+    # Forward/backward compat: state files written by an older daemon
+    # (which used the LATITUDE==0 sentinel) still render with a
+    # recognizable detail when the operator looks at status after upgrade.
     write_mlat_state disabled latitude_zero
     stub_systemctl_active_state active
     status_init
@@ -293,7 +305,7 @@ STUB
     [[ "$output" == *'disabled by config (LATITUDE=0)'* ]]
 }
 
-@test "mlat_status_line: ActiveState=active + disabled longitude_zero → 'disabled by config (LONGITUDE=0)'" {
+@test "mlat_status_line: ActiveState=active + disabled longitude_zero → 'disabled by config (LONGITUDE=0)' (legacy state file)" {
     write_mlat_state disabled longitude_zero
     stub_systemctl_active_state active
     status_init

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -64,9 +64,34 @@ run_configure_env() {
     [ "$status" -eq 0 ]
     grep -q 'LATITUDE="52.52000"' "$ROOT_DIR/etc/airplanes/feed.env"
     grep -q 'LONGITUDE="13.40500"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'GEO_CONFIGURED=true' "$ROOT_DIR/etc/airplanes/feed.env"
     ! grep -q '\-\-uuid-file' "$ROOT_DIR/etc/airplanes/feed.env"
     ! grep -q 'Invalid latitude' "$WHIPTAIL_LOG"
     ! grep -q 'Invalid longitude' "$WHIPTAIL_LOG"
+}
+
+@test "configure.sh emits GEO_CONFIGURED=false when both lat and lon are 0 (image-freeze placeholder)" {
+    run_configure_env \
+        AIRPLANES_MLAT_USER="image" \
+        AIRPLANES_LATITUDE="0" \
+        AIRPLANES_LONGITUDE="0" \
+        AIRPLANES_ALTITUDE="0m"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'GEO_CONFIGURED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh emits GEO_CONFIGURED=true when only one axis is 0 (legitimate equator/prime-meridian)" {
+    # Equator user (lat=0, lon!=0) is a real geographic case; configure.sh
+    # must NOT mistake them for an image-freeze placeholder.
+    run_configure_env \
+        AIRPLANES_MLAT_USER="equator" \
+        AIRPLANES_LATITUDE="0" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'GEO_CONFIGURED=true' "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
 @test "configure.sh rejects non-numeric latitude with Invalid msgbox" {

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -94,6 +94,20 @@ run_configure_env() {
     grep -qx 'GEO_CONFIGURED=true' "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
+@test "configure.sh emits GEO_CONFIGURED=false for decimal-zero pair (0.00000/0.00000)" {
+    # Defensive against decimal-zero hand-edits or older callers; the
+    # writer-side heuristic recognizes signed/decimal zero forms as
+    # numerically zero so the pair is still treated as a placeholder.
+    run_configure_env \
+        AIRPLANES_MLAT_USER="image" \
+        AIRPLANES_LATITUDE="0.00000" \
+        AIRPLANES_LONGITUDE="0.00000" \
+        AIRPLANES_ALTITUDE="0m"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'GEO_CONFIGURED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
 @test "configure.sh rejects non-numeric latitude with Invalid msgbox" {
     run_configure $'ci-feeder\nabc\n52.52000\n13.40500\n35m'
 

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -644,10 +644,34 @@ write_feed_env() {
     grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
 }
 
-@test "airplanes-mlat.sh derives GEO_CONFIGURED=false from legacy LATITUDE=0" {
+@test "airplanes-mlat.sh derives GEO_CONFIGURED=false from legacy LATITUDE=0/LONGITUDE=0 pair" {
     # feed.env predating the GEO_CONFIGURED schema addition: in-shell
-    # fallback in airplanes-mlat.sh sees LATITUDE=0 and derives false,
-    # matching the previous latitude_zero sentinel behavior.
+    # fallback sees the (0,0) placeholder pair and derives false. This is
+    # the image-freeze / uninitialized state.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=0' \
+        'LONGITUDE=0' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh fallback heals legacy equator user (LATITUDE=0, LONGITUDE!=0) → GEO_CONFIGURED=true" {
+    # Real geographic case the old LATITUDE==0 sentinel falsely disabled.
+    # The fallback heuristic recognizes single-axis zero as a legitimate
+    # coordinate and classifies as configured.
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
@@ -663,12 +687,11 @@ write_feed_env() {
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    [ "$status" -eq 0 ]
-    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
-    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
 }
 
-@test "airplanes-mlat.sh derives GEO_CONFIGURED=false from legacy LONGITUDE=0" {
+@test "airplanes-mlat.sh fallback heals legacy prime-meridian user (LATITUDE!=0, LONGITUDE=0)" {
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
@@ -684,8 +707,8 @@ write_feed_env() {
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    [ "$status" -eq 0 ]
-    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh derives GEO_CONFIGURED=true from non-zero coords (legacy feed.env)" {
@@ -705,6 +728,28 @@ write_feed_env() {
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh derives GEO_CONFIGURED=false from decimal-zero pair (0.00000/0.00000)" {
+    # Hand-edits or older configure.sh writers may use decimal-zero forms.
+    # The helper recognizes them as numerically zero so the placeholder pair
+    # isn't misclassified as configured.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE="0.00000"' \
+        'LONGITUDE="0.00000"' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh: explicit GEO_CONFIGURED wins over legacy coord derivation" {

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -621,7 +621,33 @@ write_feed_env() {
     grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes-mlat/state"
 }
 
-@test "airplanes-mlat.sh writes state=disabled,reason=latitude_zero when LATITUDE=0" {
+@test "airplanes-mlat.sh writes state=disabled,reason=geo_not_configured when GEO_CONFIGURED=false" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'GEO_CONFIGURED=false' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh derives GEO_CONFIGURED=false from legacy LATITUDE=0" {
+    # feed.env predating the GEO_CONFIGURED schema addition: in-shell
+    # fallback in airplanes-mlat.sh sees LATITUDE=0 and derives false,
+    # matching the previous latitude_zero sentinel behavior.
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
@@ -638,11 +664,11 @@ write_feed_env() {
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=latitude_zero' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
 }
 
-@test "airplanes-mlat.sh writes state=disabled,reason=longitude_zero when LONGITUDE=0" {
+@test "airplanes-mlat.sh derives GEO_CONFIGURED=false from legacy LONGITUDE=0" {
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
@@ -659,7 +685,50 @@ write_feed_env() {
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'reason=longitude_zero' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh derives GEO_CONFIGURED=true from non-zero coords (legacy feed.env)" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh: explicit GEO_CONFIGURED wins over legacy coord derivation" {
+    # Equator user (lat=0, lon!=0) with explicit GEO_CONFIGURED=true must
+    # not trip the legacy LATITUDE==0 fallback path. The explicit flag is
+    # authoritative.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'GEO_CONFIGURED=true' \
+        'LATITUDE=0' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35m' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh: empty MLAT_USER + canonical feeder-id → state=enabled, MLAT_USER=Anonymous-<short>, mlat-client gets --user" {

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -583,20 +583,65 @@ EOF
     grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
 }
 
-@test "migrate_geo_to_configured_flag: LATITUDE=0 alone → GEO_CONFIGURED=false" {
+@test "migrate_geo_to_configured_flag: equator user (LATITUDE=0, LONGITUDE non-zero) → GEO_CONFIGURED=true" {
+    # The previous LATITUDE==0 sentinel falsely disabled equator users.
+    # The migration heuristic recognizes single-axis zero as a legitimate
+    # coordinate and heals their config.
     cat > "$FEED_ENV" <<'EOF'
 LATITUDE="0"
 LONGITUDE="13.4"
 EOF
     migrate_geo_to_configured_flag "$FEED_ENV"
 
-    grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
+    grep -qx 'GEO_CONFIGURED=true' "$FEED_ENV"
 }
 
-@test "migrate_geo_to_configured_flag: LATITUDE empty → GEO_CONFIGURED=false" {
+@test "migrate_geo_to_configured_flag: prime-meridian user (LATITUDE non-zero, LONGITUDE=0) → GEO_CONFIGURED=true" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="51.5"
+LONGITUDE="0"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=true' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: LATITUDE empty (LONGITUDE non-zero) → GEO_CONFIGURED=true" {
+    # Empty axis is treated as numerically zero; the other axis is real, so
+    # this is still a legitimate single-axis-zero coordinate.
     cat > "$FEED_ENV" <<'EOF'
 LATITUDE=""
 LONGITUDE="13.4"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=true' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: both axes empty → GEO_CONFIGURED=false" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE=""
+LONGITUDE=""
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: decimal-zero pair (0.00000/0.00000) → GEO_CONFIGURED=false" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="0.00000"
+LONGITUDE="0.00000"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: signed-zero pair (+0/-0) → GEO_CONFIGURED=false" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="+0"
+LONGITUDE="-0"
 EOF
     migrate_geo_to_configured_flag "$FEED_ENV"
 

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -557,3 +557,120 @@ EOF
     ! grep -q '^PRIVACY=' "$FEED_ENV"
 }
 
+# ---------------------------------------------------------------------------
+# migrate_geo_to_configured_flag
+# ---------------------------------------------------------------------------
+
+@test "migrate_geo_to_configured_flag: both coords non-zero → GEO_CONFIGURED=true" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="52.5"
+LONGITUDE="13.4"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=true' "$FEED_ENV"
+    grep -qx 'LATITUDE="52.5"' "$FEED_ENV"
+    grep -qx 'LONGITUDE="13.4"' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: legacy LATITUDE=0/LONGITUDE=0 → GEO_CONFIGURED=false" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="0"
+LONGITUDE="0"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: LATITUDE=0 alone → GEO_CONFIGURED=false" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="0"
+LONGITUDE="13.4"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: LATITUDE empty → GEO_CONFIGURED=false" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE=""
+LONGITUDE="13.4"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    grep -qx 'GEO_CONFIGURED=false' "$FEED_ENV"
+}
+
+@test "migrate_geo_to_configured_flag: GEO_CONFIGURED already present → no-op" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="0"
+LONGITUDE="0"
+GEO_CONFIGURED=true
+EOF
+    local snapshot
+    snapshot="$(cat "$FEED_ENV")"
+
+    migrate_geo_to_configured_flag "$FEED_ENV"
+    [ "$(cat "$FEED_ENV")" = "$snapshot" ]
+}
+
+@test "migrate_geo_to_configured_flag: idempotent — second call is a no-op" {
+    cat > "$FEED_ENV" <<'EOF'
+LATITUDE="52.5"
+LONGITUDE="13.4"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+    local snapshot
+    snapshot="$(cat "$FEED_ENV")"
+
+    migrate_geo_to_configured_flag "$FEED_ENV"
+    [ "$(cat "$FEED_ENV")" = "$snapshot" ]
+}
+
+@test "migrate_geo_to_configured_flag: feed.env missing → no-op (no error)" {
+    [ ! -f "$FEED_ENV" ]
+    migrate_geo_to_configured_flag "$FEED_ENV"
+    [ ! -f "$FEED_ENV" ]
+}
+
+@test "migrate_geo_to_configured_flag: preserves all other keys verbatim" {
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+LATITUDE="52.5"
+LONGITUDE="13.4"
+ALTITUDE="35m"
+NET_OPTIONS="--net-heartbeat 60"
+EOF
+    migrate_geo_to_configured_flag "$FEED_ENV"
+
+    for line in \
+        'INPUT="127.0.0.1:30005"' \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'MLAT_PRIVATE=false' \
+        'LATITUDE="52.5"' \
+        'LONGITUDE="13.4"' \
+        'ALTITUDE="35m"' \
+        'NET_OPTIONS="--net-heartbeat 60"' \
+    ; do
+        grep -qF "$line" "$FEED_ENV"
+    done
+}
+
+@test "run_config_file_migrations: chains migrate_geo_to_configured_flag last in the pipeline" {
+    cat > "$FEED_ENV" <<'EOF'
+USER="alice"
+LATITUDE="52.5"
+LONGITUDE="13.4"
+EOF
+    run_config_file_migrations "$FEED_ENV"
+
+    grep -qx 'MLAT_USER="alice"' "$FEED_ENV"
+    grep -qx 'GEO_CONFIGURED=true' "$FEED_ENV"
+}
+

--- a/update.sh
+++ b/update.sh
@@ -412,15 +412,16 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
         esac
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
-    # Legacy GEO_CONFIGURED fallback. feed.env predating the flag falls
-    # through this derivation: both coords non-empty and non-"0" → true,
-    # else false. Matches the prior LATITUDE==0/LONGITUDE==0 sentinel
-    # disable, so legacy feeders see no behavior change.
+    # Legacy GEO_CONFIGURED fallback. Both coords numerically zero (or
+    # empty) → false; anything else → true. Matches configure.sh's writer-
+    # side heuristic so a real equator or prime-meridian operator with a
+    # legacy feed.env doesn't get false-classified as unconfigured.
     if [[ ! -v GEO_CONFIGURED ]]; then
-        if [[ -n "$LATITUDE" && "$LATITUDE" != 0 && -n "$LONGITUDE" && "$LONGITUDE" != 0 ]]; then
-            GEO_CONFIGURED="true"
-        else
+        if _airplanes_geo_axis_unset_or_zero "$LATITUDE" \
+            && _airplanes_geo_axis_unset_or_zero "$LONGITUDE"; then
             GEO_CONFIGURED="false"
+        else
+            GEO_CONFIGURED="true"
         fi
     fi
 else
@@ -443,10 +444,11 @@ else
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
     if [[ ! -v GEO_CONFIGURED ]]; then
-        if [[ -n "${LATITUDE:-}" && "$LATITUDE" != 0 && -n "${LONGITUDE:-}" && "$LONGITUDE" != 0 ]]; then
-            GEO_CONFIGURED="true"
-        else
+        if _airplanes_geo_axis_unset_or_zero "${LATITUDE:-}" \
+            && _airplanes_geo_axis_unset_or_zero "${LONGITUDE:-}"; then
             GEO_CONFIGURED="false"
+        else
+            GEO_CONFIGURED="true"
         fi
     fi
 fi

--- a/update.sh
+++ b/update.sh
@@ -362,7 +362,7 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
     # MLAT_PRIVATE from the orchestrator's env) can't bleed into the
     # legacy-USER detection or the privacy resolution below. Same
     # precaution applies in the manual-install branch.
-    unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
+    unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER GEO_CONFIGURED
     if [[ -f "$FEED_ENV" ]]; then
         # Canonicalise legacy values + schema-split (USER → MLAT_USER /
         # MLAT_ENABLED, PRIVACY → MLAT_PRIVATE, --uuid-file strip,
@@ -412,11 +412,22 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
         esac
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
+    # Legacy GEO_CONFIGURED fallback. feed.env predating the flag falls
+    # through this derivation: both coords non-empty and non-"0" → true,
+    # else false. Matches the prior LATITUDE==0/LONGITUDE==0 sentinel
+    # disable, so legacy feeders see no behavior change.
+    if [[ ! -v GEO_CONFIGURED ]]; then
+        if [[ -n "$LATITUDE" && "$LATITUDE" != 0 && -n "$LONGITUDE" && "$LONGITUDE" != 0 ]]; then
+            GEO_CONFIGURED="true"
+        else
+            GEO_CONFIGURED="false"
+        fi
+    fi
 else
     prepare_legacy_feed_env_migration "$LEGACY_FEED_ENV" "$FEED_ENV" "$ETC_AIRPLANES"
     run_config_file_migrations "$FEED_ENV"
 
-    unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER
+    unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER GEO_CONFIGURED
     if [[ -f "$FEED_ENV" ]]; then
         source "$FEED_ENV"
     elif [[ -f "$BOOT_ENV" ]]; then
@@ -431,6 +442,13 @@ else
         esac
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
+    if [[ ! -v GEO_CONFIGURED ]]; then
+        if [[ -n "${LATITUDE:-}" && "$LATITUDE" != 0 && -n "${LONGITUDE:-}" && "$LONGITUDE" != 0 ]]; then
+            GEO_CONFIGURED="true"
+        else
+            GEO_CONFIGURED="false"
+        fi
+    fi
 fi
 if [[ -z $LATITUDE ]] || [[ -z $LONGITUDE ]] || [[ -z $ALTITUDE ]]; then
     if [[ "$IMAGE_INSTALL" == "1" ]]; then
@@ -445,7 +463,7 @@ fi
 # fallback at startup, so re-running setup.sh for an empty name would re-prompt
 # the operator for nothing actionable.
 
-if [[ "$LATITUDE" == 0 ]] || [[ "$LONGITUDE" == 0 ]] || [[ "$MLAT_ENABLED" != "true" ]]; then
+if [[ "$GEO_CONFIGURED" != "true" ]] || [[ "$MLAT_ENABLED" != "true" ]]; then
     MLAT_DISABLED=1
 else
     MLAT_DISABLED=0


### PR DESCRIPTION
The MLAT daemon's classifier previously gated on LATITUDE==0 / LONGITUDE==0 as a sentinel for 'location not configured.' That incorrectly disabled MLAT for feeders at the equator (lat=0, lon!=0) and the prime meridian (lat!=0, lon=0), and conflated the value 0 with the absence of user intent. Replaces both sentinel checks with an explicit GEO_CONFIGURED=true|false key in feed.env.

configure.sh emits the flag based on the coordinates it writes — both zero counts as the image-freeze placeholder pair (false), anything else counts as configured so a real equator or prime-meridian operator sees their feeder enabled. airplanes-mlat.sh and update.sh both gain an in-shell derivation of the flag from existing LATITUDE/LONGITUDE for feed.env files predating the schema; an idempotent update-time migration adds the explicit key on every update so the derivation only fires in the gap between daemon restart and the next update. The state file at /run/airplanes-mlat/state now publishes geo_configured, and status output renders 'disabled by config (location not set)' for the new geo_not_configured reason while preserving the prior latitude_zero / longitude_zero detail lines for state files written by older daemons.

This is a breaking change for consumers that pattern-match the latitude_zero / longitude_zero classifier reasons — they now see geo_not_configured for the same disabled state. A matching image PR adds the flag to the webconfig API + emits it from the Go apply-config helper.