### PR TITLE
Strict-fail when ALTITUDE is empty

### DIFF
--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -153,10 +153,13 @@ fi
 # defaulting), then explicit MLAT_ENABLED disable (so a user who turns
 # MLAT off on a fresh feeder before configuring geo sees reason=
 # mlat_enabled_false rather than reason=geo_not_configured), then the
-# explicit geo flag. MLAT_USER is no longer a classifier input — empty
-# values are substituted with a per-device Anonymous-<short-id> fallback
-# above, so the only "misconfigured" branch left is the strict
-# MLAT_PRIVATE shape.
+# explicit geo flag, then the empty-ALTITUDE strict-fail. MLAT_USER is
+# no longer a classifier input — empty values are substituted with a
+# per-device Anonymous-<short-id> fallback above. ALTITUDE has no
+# fallback: mlat-client gets `--alt ""` if we let an empty value
+# through and would silently fail at connect time; fail loud at
+# classify time so the state file + journalctl tell the operator
+# what's actually missing.
 _mlat_classify() {
     case "$MLAT_PRIVATE" in
         true|false) ;;
@@ -164,6 +167,7 @@ _mlat_classify() {
     esac
     if [[ "$MLAT_ENABLED" != "true" ]]; then printf 'disabled mlat_enabled_false\n'; return; fi
     if [[ "$GEO_CONFIGURED" != "true" ]]; then printf 'disabled geo_not_configured\n'; return; fi
+    if [[ -z "$ALTITUDE" ]]; then printf 'misconfigured altitude_empty\n'; return; fi
     printf 'enabled ok\n'
 }
 
@@ -180,7 +184,8 @@ airplanes_write_state "$STATE_FILE" \
     "mlat_private=${MLAT_PRIVATE:-}" \
     "geo_configured=${GEO_CONFIGURED:-}" \
     "latitude=${LATITUDE:-}" \
-    "longitude=${LONGITUDE:-}" || true
+    "longitude=${LONGITUDE:-}" \
+    "altitude=${ALTITUDE:-}" || true
 
 case "$STATE" in
     disabled)
@@ -194,6 +199,9 @@ case "$STATE" in
         case "$REASON" in
             mlat_private_invalid)
                 echo "MLAT_PRIVATE must be 'true' or 'false' (got: '${MLAT_PRIVATE:-}'); refusing to start mlat-client." >&2
+                ;;
+            altitude_empty)
+                echo "MLAT_ENABLED=true but ALTITUDE is empty; refusing to start mlat-client." >&2
                 ;;
             *)
                 echo "Misconfigured ($REASON); refusing to start mlat-client." >&2

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -273,6 +273,7 @@ _render_mlat_misconfig_reason() {
     local label="MLAT service"
     case "$reason" in
         mlat_private_invalid) status_line fail "$label" "MLAT_PRIVATE must be 'true' or 'false' in feed.env" ;;
+        altitude_empty)       status_line fail "$label" "ALTITUDE is empty (set the antenna altitude, e.g. ALTITUDE=120m)" ;;
         *)                    status_line fail "$label" "misconfigured ($reason)" ;;
     esac
 }

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -324,6 +324,16 @@ STUB
     [[ "$output" == *"MLAT_PRIVATE must be 'true' or 'false'"* ]]
 }
 
+@test "mlat_status_line: ActiveState=failed + exit 64 + misconfigured altitude_empty → actionable" {
+    write_mlat_state misconfigured altitude_empty
+    stub_systemctl_active_state failed 64
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'ALTITUDE is empty'* ]]
+}
+
 @test "mlat_status_line: ActiveState=activating + enabled → 'starting up'" {
     write_mlat_state enabled ok
     stub_systemctl_active_state activating

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -570,6 +570,7 @@ write_feed_env() {
     grep -qx 'mlat_user=alice' "$root/run/airplanes-mlat/state"
     grep -qx 'latitude=52' "$root/run/airplanes-mlat/state"
     grep -qx 'longitude=13' "$root/run/airplanes-mlat/state"
+    grep -qx 'altitude=35m' "$root/run/airplanes-mlat/state"
     grep -qE '^decided_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$root/run/airplanes-mlat/state"
     # mlat-client was invoked.
     [ -f "$arg_log" ]
@@ -924,6 +925,59 @@ EOF
     [[ "$output" == *"Update Webconfig"* ]]
     # State file is not written: we exit before classifier runs.
     [ ! -f "$root/run/airplanes-mlat/state" ]
+}
+
+@test "airplanes-mlat.sh exits 64 with state=misconfigured when ALTITUDE empty + MLAT_ENABLED=true" {
+    # mlat-client requires --alt; passing an empty value silently fails at
+    # connect time. The classifier fails loud here so the operator sees
+    # reason=altitude_empty in the state file + journal and knows what
+    # to fix.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=""' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 64 ]
+    grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=altitude_empty' "$root/run/airplanes-mlat/state"
+    grep -qx 'altitude=' "$root/run/airplanes-mlat/state"
+    [[ "$output" == *"ALTITUDE is empty"* ]]
+}
+
+@test "airplanes-mlat.sh: geo_not_configured wins over empty ALTITUDE (disabled, not misconfigured)" {
+    # If the feeder hasn't been configured (GEO_CONFIGURED false, either
+    # explicit or derived from the (0,0) placeholder pair), it's the
+    # default fresh-feeder state — state=disabled, reason=geo_not_configured.
+    # ALTITUDE empty here is a side-effect of being unconfigured, not an
+    # operator misconfiguration to scream about.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=0' \
+        'LONGITUDE=0' \
+        'ALTITUDE=""' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.live:31090"'
+
+    run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh exits 64 with reason=mlat_private_invalid for hand-edited bad MLAT_PRIVATE" {


### PR DESCRIPTION
An empty `ALTITUDE` in `/etc/airplanes/feed.env` used to slip through `airplanes-mlat.sh`'s classifier and reach mlat-client as `--alt ""`, which errors out at connect time without a clear signal. Add an `altitude_empty` strict-fail to the classifier so the daemon exits 64 (matched by `RestartPreventExitStatus=64`) with a journal message and a `reason=altitude_empty` line in `/run/airplanes-mlat/state`. `apl-feed status` renders the same actionable message under the MLAT service line.

Ordered after the lat/lon-zero (disabled) checks so a fresh, unconfigured feeder still shows as `disabled` rather than misconfigured. `ALTITUDE=0` is intentionally allowed (sea-level antennas are real); only `""` triggers the fail.

The state file also gains an additive `altitude=` line, parallel to the existing `latitude=`/`longitude=` fields. State-file consumers ignore unknown keys, so no schema-version bump.
