### PR TITLE
Make 978 opt-in and add apl-feed 978 CLI

### DIFF
--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -39,13 +39,19 @@ INPUT_IP=$(echo $INPUT | cut -d: -f1)
 INPUT_PORT=$(echo $INPUT | cut -d: -f2)
 SOURCE="--net-connector $INPUT_IP,$INPUT_PORT,beast_in,silent_fail"
 
-if [[ -z $UAT_INPUT ]]; then
-    UAT_INPUT="127.0.0.1:30978"
+# 978 is opt-in: empty/unset UAT_INPUT means "don't even wire up the
+# uat_in net-connector." The previous always-on default ("127.0.0.1:30978")
+# meant a 1090-only feeder still asked the feeder binary to keep an idle
+# connector around (silent_fail kept it harmless on the wire), but it also
+# hid the user's intent and tripped the image-side dump978-fa wrapper into
+# a restart loop on hardware without a 978 SDR. Opt in via `apl-feed 978
+# enable` (CLI) or the 978 section in webconfig (image users).
+UAT_SOURCE=""
+if [[ -n ${UAT_INPUT-} ]]; then
+    UAT_IP=$(echo $UAT_INPUT | cut -d: -f1)
+    UAT_PORT=$(echo $UAT_INPUT | cut -d: -f2)
+    UAT_SOURCE="--net-connector $UAT_IP,$UAT_PORT,uat_in,silent_fail"
 fi
-
-UAT_IP=$(echo $UAT_INPUT | cut -d: -f1)
-UAT_PORT=$(echo $UAT_INPUT | cut -d: -f2)
-UAT_SOURCE="--net-connector $UAT_IP,$UAT_PORT,uat_in,silent_fail"
 
 REDUCE_INTERVAL="${REDUCE_INTERVAL:-0.5}"
 JSON_OPTIONS="${JSON_OPTIONS:-"--max-range 450 --json-location-accuracy 2 --range-outline-hours 24"}"

--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -29,6 +29,8 @@ source "$APL_FEED_LIB_DIR/status.sh"
 source "$APL_FEED_LIB_DIR/backup.sh"
 # shellcheck source=scripts/apl-feed/mlat.sh
 source "$APL_FEED_LIB_DIR/mlat.sh"
+# shellcheck source=scripts/apl-feed/uat.sh
+source "$APL_FEED_LIB_DIR/uat.sh"
 
 main() {
     local cmd="${1:-}"
@@ -56,6 +58,10 @@ main() {
         mlat)
             shift
             dispatch_mlat "$@"
+            ;;
+        978)
+            shift
+            dispatch_uat "$@"
             ;;
         -h|--help|'')
             usage

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -39,6 +39,10 @@ Usage:
   apl-feed mlat disable
   apl-feed mlat private enable
   apl-feed mlat private disable
+  apl-feed 978 enable [--serial SERIAL] [--gain GAIN]
+  apl-feed 978 disable
+  apl-feed 978 setup
+  apl-feed 978 status
   apl-feed backup <file>
   apl-feed restore <file>
   apl-feed restore --check <file>

--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+
+# 978 UAT enable/disable management. Operator-facing alternative to editing
+# /etc/airplanes/feed.env by hand for users not on the new feeder image
+# (image users have the same surface in webconfig).
+#
+# UAT is opt-in: an empty UAT_INPUT means "no 978 connector wired at all".
+# Enable writes UAT_INPUT="127.0.0.1:30978" (the well-known local
+# dump978-fa endpoint, the only value accepted by airplanes-978.sh and
+# webconfig's validator) and optionally pins DUMP978_SDR_SERIAL /
+# DUMP978_GAIN — both wrapper fallbacks (978 / 42.1) are sensible
+# defaults that get used when the keys are absent, so emitting them is
+# only required when the operator wants a different SDR serial or gain.
+
+DEFAULT_DUMP978_SDR_SERIAL="978"
+DEFAULT_DUMP978_GAIN="42.1"
+LOCAL_UAT_ENDPOINT="127.0.0.1:30978"
+
+# Image-only systemd units. On a standalone-feed install these don't exist;
+# _uat_unit_exists gates each restart so the CLI works the same way on both.
+# `airplanes-feed.service` is always restarted (it reads UAT_INPUT from feed.env
+# and must re-render its argv on toggle).
+_UAT_OPTIONAL_UNITS=(dump978-fa.service airplanes-978.service)
+_UAT_ALWAYS_UNITS=(airplanes-feed.service)
+
+# Same skip rules as _mlat_should_skip_restart — keep the two helpers in
+# lockstep so a future change to the "skip systemctl" predicate applies
+# uniformly. Returns 0 (skip) or 1 (proceed).
+_uat_should_skip_restart() {
+    if [[ "$ROOT" != "/" ]]; then
+        echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+        return 0
+    fi
+    case "${AIRPLANES_BUILD_MODE:-}" in
+        1|true|yes)
+            echo "Skipping service restart (AIRPLANES_BUILD_MODE set)" >&2
+            return 0
+            ;;
+    esac
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+# Probe whether a given systemd unit file is installed on the host. Used
+# to skip restart of image-only units on standalone-feed installs. `cat`
+# returns rc 0 if the unit's drop-in stack is readable, non-zero otherwise.
+_uat_unit_exists() {
+    local unit="$1"
+    systemctl cat -- "$unit" >/dev/null 2>&1
+}
+
+_uat_restart_services() {
+    if _uat_should_skip_restart; then
+        return 0
+    fi
+    local unit any_failed=0
+    for unit in "${_UAT_ALWAYS_UNITS[@]}"; do
+        if ! systemctl restart "$unit" 2>&1; then
+            echo "service restart failed for $unit; recent journal output:" >&2
+            journalctl -u "$unit" -n 10 --no-pager 2>/dev/null >&2 || true
+            any_failed=1
+        fi
+    done
+    for unit in "${_UAT_OPTIONAL_UNITS[@]}"; do
+        if _uat_unit_exists "$unit"; then
+            if ! systemctl restart "$unit" 2>&1; then
+                echo "service restart failed for $unit; recent journal output:" >&2
+                journalctl -u "$unit" -n 10 --no-pager 2>/dev/null >&2 || true
+                any_failed=1
+            fi
+        fi
+    done
+    return "$any_failed"
+}
+
+# Validators. Mirror image-side configspec.go shapes so a value accepted
+# here will also pass webconfig's check on the same feeder. The image's
+# bash wrapper (dump978-fa.sh) reads these via shell sourcing of feed.env,
+# so we additionally reject every byte in universalReject to prevent shell
+# injection on a feeder that's later updated to a webconfig-shipping image.
+_uat_check_universal() {
+    local key="$1" value="$2"
+    # Char-class match. Bash's =~ uses ERE; bracket expressions tolerate
+    # most metas as literals. Newline/CR are added via $'…' so they appear
+    # as actual bytes in the class, not as escape sequences. Null byte is
+    # not separately matched — bash variables can't hold \0 (the read
+    # truncates at it), so an injected NUL never reaches this function.
+    if [[ "$value" =~ [\"\\\$\`\;\&\|\<\>\#\'$'\n'$'\r'] ]]; then
+        die "$key contains a forbidden shell metacharacter"
+    fi
+}
+
+# DUMP978_SDR_SERIAL: empty or [0-9A-Za-z_-]{1,32} (matches dump978SerialRE
+# in configspec.go).
+_uat_validate_serial() {
+    local v="$1"
+    [[ -z "$v" ]] && return 0
+    [[ "$v" =~ ^[0-9A-Za-z_-]{1,32}$ ]] || die "DUMP978_SDR_SERIAL must match [0-9A-Za-z_-]{1,32} or be empty"
+    _uat_check_universal DUMP978_SDR_SERIAL "$v"
+}
+
+# DUMP978_GAIN: numeric 0..60. dump978-fa's --sdr-gain takes a numeric dB
+# value; readsb's auto/min/max strings are NOT accepted by FA's binary, so
+# we reject them even though the readsb-side GAIN validator allows them.
+_uat_validate_gain() {
+    local v="$1"
+    [[ "$v" =~ ^-?[0-9]+(\.[0-9]+)?$ ]] || die "DUMP978_GAIN must be a number in [0, 60]"
+    # Use awk so we don't depend on bc.
+    awk -v g="$v" 'BEGIN{ if (g < 0 || g > 60) exit 1; exit 0 }' \
+        || die "DUMP978_GAIN must be in [0, 60]"
+    _uat_check_universal DUMP978_GAIN "$v"
+}
+
+# Non-mutating USB serial probe. Mirrors the image wrapper's probe so the
+# CLI and the wrapper agree on what "matches" means. Returns 0 when at
+# least one /sys/bus/usb/devices/*/serial file contains the requested
+# value. Test-overridable via APL_FEED_UAT_USB_SERIAL_GLOB.
+: "${APL_FEED_UAT_USB_SERIAL_GLOB:=/sys/bus/usb/devices/*/serial}"
+_uat_probe_serial() {
+    local want="$1" f have
+    [[ -n "$want" ]] || return 1
+    # shellcheck disable=SC2086
+    for f in $APL_FEED_UAT_USB_SERIAL_GLOB; do
+        [[ -r "$f" ]] || continue
+        have="$(cat "$f" 2>/dev/null)" || continue
+        [[ "$have" == "$want" ]] && return 0
+    done
+    return 1
+}
+
+# Atomic rewrite of feed.env. Reads three keys from positional args
+# ("UAT_INPUT", "DUMP978_SDR_SERIAL", "DUMP978_GAIN") in order. Pass an
+# empty string for any key you want to ERASE; pass the literal "-" to
+# leave the existing line untouched. (The bash `[[ -v ... ]]` form would
+# be cleaner but `-` is simpler to read in callers.)
+_uat_rewrite_feed_env() {
+    local feed_env="$1" new_uat="$2" new_serial="$3" new_gain="$4"
+
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+
+    local tmp drop_re='^(UAT_INPUT|DUMP978_SDR_SERIAL|DUMP978_GAIN)='
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    # Preserve any keys we're NOT touching. The `-` sentinel means "leave
+    # the old line as-is"; absent values in feed.env stay absent. Build the
+    # drop regex on the fly so untouched keys don't get rewritten.
+    local pattern=()
+    [[ "$new_uat"    != "-" ]] && pattern+=("UAT_INPUT")
+    [[ "$new_serial" != "-" ]] && pattern+=("DUMP978_SDR_SERIAL")
+    [[ "$new_gain"   != "-" ]] && pattern+=("DUMP978_GAIN")
+    if (( ${#pattern[@]} == 0 )); then
+        # Nothing to change — write the file back verbatim.
+        cat "$feed_env" > "$tmp"
+    else
+        local re
+        re="^($(IFS='|'; printf '%s' "${pattern[*]}"))="
+        grep -vE "$re" "$feed_env" > "$tmp" || true
+    fi
+    # Append the new keys in canonical order. Empty value → emit `KEY=""`
+    # (the wrapper reads ${VAR-} so an empty string is the "user-cleared"
+    # signal and is preserved across rewrites). Skip the `-` sentinel.
+    if [[ "$new_uat" != "-" ]]; then
+        printf 'UAT_INPUT="%s"\n' "$new_uat" >> "$tmp"
+    fi
+    if [[ "$new_serial" != "-" ]]; then
+        printf 'DUMP978_SDR_SERIAL="%s"\n' "$new_serial" >> "$tmp"
+    fi
+    if [[ "$new_gain" != "-" ]]; then
+        printf 'DUMP978_GAIN="%s"\n' "$new_gain" >> "$tmp"
+    fi
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
+apl_feed_uat_enable() {
+    local serial="-" gain="-"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --serial)
+                [[ $# -ge 2 ]] || die "--serial requires VALUE"
+                serial="$2"; shift 2 ;;
+            --gain)
+                [[ $# -ge 2 ]] || die "--gain requires VALUE"
+                gain="$2"; shift 2 ;;
+            *)
+                local opt_rc
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0) die "unknown flag for 978 enable: $1" ;;
+                esac
+                ;;
+        esac
+    done
+
+    [[ "$serial" != "-" ]] && _uat_validate_serial "$serial"
+    [[ "$gain"   != "-" ]] && _uat_validate_gain "$gain"
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    _uat_rewrite_feed_env "$feed_env" "$LOCAL_UAT_ENDPOINT" "$serial" "$gain"
+    echo "UAT_INPUT set to \"$LOCAL_UAT_ENDPOINT\" in $feed_env"
+    [[ "$serial" != "-" ]] && echo "DUMP978_SDR_SERIAL set to \"$serial\""
+    [[ "$gain"   != "-" ]] && echo "DUMP978_GAIN set to \"$gain\""
+    if _uat_restart_services; then
+        echo "Restarting 978 services ... done"
+    else
+        return 1
+    fi
+}
+
+apl_feed_uat_disable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for 978 disable: $1" ;;
+        esac
+    done
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    _uat_rewrite_feed_env "$feed_env" "" "-" "-"
+    echo "UAT_INPUT cleared in $feed_env (978 disabled)"
+    if _uat_restart_services; then
+        echo "Restarting 978 services ... done"
+    else
+        return 1
+    fi
+}
+
+# Interactive setup wizard. Prompts the operator through SDR serial + gain
+# with defaults, runs the same probe the image wrapper uses if available,
+# and surfaces a non-fatal warning on miss (the user might be configuring
+# a dongle they haven't plugged in yet).
+apl_feed_uat_setup() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for 978 setup: $1" ;;
+        esac
+    done
+
+    if [[ ! -t 0 ]]; then
+        die "978 setup is interactive; pipe answers via apl-feed 978 enable [--serial S] [--gain G] for non-interactive use"
+    fi
+
+    echo
+    echo "Configure 978 UAT reception."
+    echo "  978 needs a second RTL-SDR dongle with its EEPROM serial set to a known string."
+    echo "  Convention: flash the dongle's serial with: sudo rtl_eeprom -s 00000978"
+    echo
+    local reply
+    read -r -p "Do you have a 978 SDR plugged in? [y/N] " reply
+    case "${reply,,}" in
+        y|yes) ;;
+        *)
+            echo "Aborted — re-run \`apl-feed 978 setup\` after plugging in the dongle."
+            return 0
+            ;;
+    esac
+
+    local serial gain
+    read -r -p "SDR serial [$DEFAULT_DUMP978_SDR_SERIAL]: " serial
+    serial="${serial:-$DEFAULT_DUMP978_SDR_SERIAL}"
+    _uat_validate_serial "$serial"
+
+    read -r -p "Gain (dB) [$DEFAULT_DUMP978_GAIN]: " gain
+    gain="${gain:-$DEFAULT_DUMP978_GAIN}"
+    _uat_validate_gain "$gain"
+
+    if _uat_probe_serial "$serial"; then
+        echo "Probe: found a USB device with serial=\"$serial\". Proceeding."
+    else
+        echo "WARNING: no USB device with serial=\"$serial\" detected." >&2
+        echo "         The 978 service will self-disable as no_hardware until the dongle is plugged in." >&2
+    fi
+
+    apl_feed_uat_enable --serial "$serial" --gain "$gain"
+}
+
+apl_feed_uat_status() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for 978 status: $1" ;;
+        esac
+    done
+
+    local uat serial gain
+    uat="$(feed_env_get UAT_INPUT 2>/dev/null || true)"
+    serial="$(feed_env_get DUMP978_SDR_SERIAL 2>/dev/null || true)"
+    gain="$(feed_env_get DUMP978_GAIN 2>/dev/null || true)"
+
+    if [[ -z "$uat" ]]; then
+        echo "978: disabled (UAT_INPUT is empty in feed.env)"
+    else
+        echo "978: enabled (UAT_INPUT=$uat)"
+    fi
+    echo "  DUMP978_SDR_SERIAL: ${serial:-<default 978>}"
+    echo "  DUMP978_GAIN:       ${gain:-<default 42.1>}"
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 0
+    fi
+    echo
+    local unit
+    for unit in "${_UAT_OPTIONAL_UNITS[@]}"; do
+        if _uat_unit_exists "$unit"; then
+            local active
+            active="$(systemctl is-active "$unit" 2>/dev/null || true)"
+            printf '  %-26s %s\n' "$unit" "${active:-unknown}"
+        else
+            printf '  %-26s %s\n' "$unit" "not installed (image-only)"
+        fi
+    done
+}
+
+dispatch_uat() {
+    local sub="${1:-}"
+    [[ -n "$sub" ]] || die "978 requires a subcommand (enable|disable|setup|status)"
+    shift || true
+    case "$sub" in
+        enable)  apl_feed_uat_enable  "$@" ;;
+        disable) apl_feed_uat_disable "$@" ;;
+        setup)   apl_feed_uat_setup   "$@" ;;
+        status)  apl_feed_uat_status  "$@" ;;
+        -h|--help) usage ;;
+        *) die "unknown 978 subcommand: $sub" ;;
+    esac
+}

--- a/test/script-install.sh
+++ b/test/script-install.sh
@@ -131,7 +131,9 @@ test -f /lib/systemd/system/airplanes-mlat.service
 test -f /etc/airplanes/feeder-claim-secret
 test "$(readlink /etc/default/airplanes)" = "/etc/airplanes/feed.env"
 grep -q 'systemctl restart airplanes-feed' /tmp/systemctl.log
-# UAT_INPUT default lives in the installed daemon wrapper now (was in
-# feed.env). airplanes-feed silent_fails on the UAT connector so the
-# default is harmless on feeders without 978 hardware.
-grep -q 'UAT_INPUT="127.0.0.1:30978"' /usr/local/share/airplanes/airplanes-feed.sh
+# 978 is opt-in: UAT_INPUT must not default to anything in feed.env (the
+# initial configure.sh-written file) NOR in the daemon wrapper. Operators
+# opt in via `apl-feed 978 enable` (CLI) or webconfig (image), and a fresh
+# install leaves the connector unwired.
+! grep -q 'UAT_INPUT="127.0.0.1:30978"' /etc/airplanes/feed.env
+! grep -q 'UAT_INPUT="127.0.0.1:30978"' /usr/local/share/airplanes/airplanes-feed.sh

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -1,0 +1,301 @@
+#!/usr/bin/env bats
+
+# Per-module tests for scripts/apl-feed/uat.sh. Mirrors test_apl_feed_mlat.bats
+# in shape: source common.sh + uat.sh, stub systemctl, point ROOT at a
+# scratch tree containing /etc/airplanes/feed.env.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    INSTALLED_UNITS_FILE="$ROOT_DIR/installed-units"
+    mkdir -p "$TMPDIR" "$STUB_DIR" "$ROOT_DIR/etc/airplanes"
+    export TMPDIR
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/uat.sh
+    source "$LIB_DIR/uat.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    # Default: dump978-fa + airplanes-978 units NOT installed (standalone-feed
+    # install). Tests can `mark_unit_installed dump978-fa.service` to flip
+    # to the image-host shape.
+    : > "$INSTALLED_UNITS_FILE"
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+case "\$1" in
+    cat)
+        unit="\${@: -1}"
+        if grep -Fxq "\$unit" "$INSTALLED_UNITS_FILE" 2>/dev/null; then
+            printf '# %s\n' "\$unit"
+            exit 0
+        fi
+        exit 1
+        ;;
+    is-active) echo active ;;
+    restart)
+        # If the unit isn't in the installed list, fail like real systemctl
+        # would. _uat_restart_services has separate handling for ALWAYS vs
+        # OPTIONAL units, but the OPTIONAL path gates on cat first.
+        unit="\${@: -1}"
+        if [[ "\$unit" == "airplanes-feed.service" ]]; then exit 0; fi
+        if grep -Fxq "\$unit" "$INSTALLED_UNITS_FILE" 2>/dev/null; then exit 0; fi
+        echo "Unit \$unit not found." >&2
+        exit 5
+        ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+
+    # USB probe surface for setup-tests that exercise _uat_probe_serial.
+    USB_ROOT="$ROOT_DIR/usb-devices"
+    mkdir -p "$USB_ROOT"
+    APL_FEED_UAT_USB_SERIAL_GLOB="$USB_ROOT/*/serial"
+    export APL_FEED_UAT_USB_SERIAL_GLOB
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+mark_unit_installed() {
+    printf '%s\n' "$1" >> "$INSTALLED_UNITS_FILE"
+}
+
+plug_sdr() {
+    local serial="$1" devname="${2:-usb1-dev0}"
+    mkdir -p "$USB_ROOT/$devname"
+    printf '%s' "$serial" > "$USB_ROOT/$devname/serial"
+}
+
+write_feed_env() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+MLAT_USER="Anonymous"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+EOF
+}
+
+# --- dispatch_uat ---
+
+@test "dispatch_uat: missing subcommand dies" {
+    run dispatch_uat
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'978 requires a subcommand'* ]]
+}
+
+@test "dispatch_uat: unknown subcommand dies" {
+    run dispatch_uat frobnitz
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'unknown 978 subcommand: frobnitz'* ]]
+}
+
+# --- 978 enable / disable round-trip ---
+
+@test "enable: writes UAT_INPUT and restarts airplanes-feed" {
+    write_feed_env
+    ROOT="/"  # exercise systemctl path; PATH-stub captures it
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_enable
+    [ "$status" -eq 0 ]
+    grep -q '^UAT_INPUT="127.0.0.1:30978"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-feed.service$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable: image-only units are restarted when present" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    mark_unit_installed dump978-fa.service
+    mark_unit_installed airplanes-978.service
+
+    run apl_feed_uat_enable
+    [ "$status" -eq 0 ]
+    grep -q '^systemctl restart dump978-fa.service$' "$SYSTEMCTL_LOG"
+    grep -q '^systemctl restart airplanes-978.service$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable: image-only units are skipped on standalone-feed host" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    # INSTALLED_UNITS_FILE is empty — neither dump978-fa nor airplanes-978
+    # is present. The restart for those must be skipped (not attempted).
+
+    run apl_feed_uat_enable
+    [ "$status" -eq 0 ]
+    ! grep -q '^systemctl restart dump978-fa.service$' "$SYSTEMCTL_LOG"
+    ! grep -q '^systemctl restart airplanes-978.service$' "$SYSTEMCTL_LOG"
+    grep -q '^systemctl restart airplanes-feed.service$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable --serial / --gain pin the wrapper defaults in feed.env" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_enable --serial "00000978" --gain "40.0"
+    [ "$status" -eq 0 ]
+    grep -q '^DUMP978_SDR_SERIAL="00000978"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^DUMP978_GAIN="40.0"$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "disable: clears UAT_INPUT, preserves DUMP978_SDR_SERIAL / DUMP978_GAIN" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    # Seed both knobs so we can confirm disable doesn't wipe them.
+    apl_feed_uat_enable --serial "00000978" --gain "40.0"
+    : > "$SYSTEMCTL_LOG"
+
+    run apl_feed_uat_disable
+    [ "$status" -eq 0 ]
+    grep -q '^UAT_INPUT=""$' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Disable uses the `-` sentinel so the serial/gain lines stay verbatim.
+    grep -q '^DUMP978_SDR_SERIAL="00000978"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^DUMP978_GAIN="40.0"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-feed.service$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable preserves unrelated keys (MLAT_USER, LATITUDE, etc.)" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_uat_enable --serial "978" --gain "42.1"
+
+    grep -q '^MLAT_USER="Anonymous"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_ENABLED=true$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_PRIVATE=false$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^LATITUDE="52.52"$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "enable twice is idempotent on UAT_INPUT (no duplicate line)" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_uat_enable
+    apl_feed_uat_enable
+    local count
+    count="$(grep -c '^UAT_INPUT=' "$ROOT_DIR/etc/airplanes/feed.env")"
+    [ "$count" -eq 1 ]
+}
+
+# --- validation ---
+
+@test "enable --serial with shell metacharacters dies" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_enable --serial 'evil;rm -rf /'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'DUMP978_SDR_SERIAL'* ]]
+    # feed.env must NOT have been touched.
+    ! grep -q '^DUMP978_SDR_SERIAL=' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q '^UAT_INPUT="127.0.0.1:30978"$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "enable --serial that's too long dies" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_enable --serial "$(printf 'a%.0s' {1..33})"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'DUMP978_SDR_SERIAL'* ]]
+}
+
+@test "enable --gain out of range dies" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_enable --gain "61"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'DUMP978_GAIN'* ]]
+
+    run apl_feed_uat_enable --gain "auto"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'DUMP978_GAIN'* ]]
+}
+
+@test "enable --serial accepts the canonical 8-char hex form" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_enable --serial "00000978"
+    [ "$status" -eq 0 ]
+    grep -q '^DUMP978_SDR_SERIAL="00000978"$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+# --- _uat_probe_serial ---
+
+@test "probe: returns 0 when /sys reports a matching serial" {
+    plug_sdr "978" "usb1-dev1"
+    run _uat_probe_serial "978"
+    [ "$status" -eq 0 ]
+}
+
+@test "probe: returns 1 when no device has the requested serial" {
+    plug_sdr "1090" "usb1-dev1"
+    run _uat_probe_serial "978"
+    [ "$status" -ne 0 ]
+}
+
+@test "probe: returns 1 when /sys is empty" {
+    run _uat_probe_serial "978"
+    [ "$status" -ne 0 ]
+}
+
+# --- status ---
+
+@test "status: reports disabled when UAT_INPUT is empty" {
+    write_feed_env  # has no UAT_INPUT line at all
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'978: disabled'* ]]
+}
+
+@test "status: reports enabled and shows the configured serial / gain" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    apl_feed_uat_enable --serial "00000978" --gain "40.0"
+
+    run apl_feed_uat_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'978: enabled'* ]]
+    [[ "$output" == *'DUMP978_SDR_SERIAL: 00000978'* ]]
+    [[ "$output" == *'DUMP978_GAIN:       40.0'* ]]
+}
+
+@test "status: marks image-only units as 'not installed' on standalone-feed" {
+    write_feed_env
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_uat_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'dump978-fa.service'*'not installed (image-only)'* ]]
+    [[ "$output" == *'airplanes-978.service'*'not installed (image-only)'* ]]
+}

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -38,6 +38,63 @@ RESULTS="--results beast,connect,localhost:30104"
 EOF
 }
 
+@test "airplanes-feed.sh skips the uat_in connector when UAT_INPUT is empty (978 opt-in)" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/args-uat-off.log"
+    write_image_config "$root"
+    # Explicitly clear UAT_INPUT in the operator-data file. (The default
+    # fixture from write_image_config doesn't set it either, but being
+    # explicit makes the intent unmistakable to future readers.)
+    mkdir -p "$root/etc/airplanes"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+MLAT_USER="image-feeder"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+UAT_INPUT=""
+EOF
+    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$root/usr/bin/airplanes-feeder"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+    [ "$status" -eq 0 ]
+    if grep -q -- 'uat_in' "$arg_log"; then
+        return 1
+    fi
+}
+
+@test "airplanes-feed.sh adds the uat_in connector when UAT_INPUT is set" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/args-uat-on.log"
+    write_image_config "$root"
+    mkdir -p "$root/etc/airplanes"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+MLAT_USER="image-feeder"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+UAT_INPUT="127.0.0.1:30978"
+EOF
+    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$root/usr/bin/airplanes-feeder"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q -- '--net-connector 127.0.0.1,30978,uat_in,silent_fail' "$arg_log"
+}
+
 @test "airplanes-feed.sh uses image feed defaults without decoder NET_OPTIONS" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/args.log"

--- a/update.sh
+++ b/update.sh
@@ -486,6 +486,7 @@ historical_apl_feed_modules=(
     id.sh
     mlat.sh
     status.sh
+    uat.sh
 )
 historical_daemon_libs=(
     state-reader.sh


### PR DESCRIPTION
Two coordinated changes around 978 UAT.

airplanes-feed.sh no longer defaults UAT_INPUT to 127.0.0.1:30978 at daemon-start. When UAT_INPUT is empty the feeder binary is invoked without any uat_in connector, so a 1090-only feeder neither hides the operator's intent nor cues the image-side dump978-fa wrapper into restart-looping against absent hardware.

apl-feed gains a 978 subcommand (enable / disable / setup / status) that mirrors apl-feed mlat. Setup is an interactive wizard with sensible defaults (serial 978, gain 42.1) and a non-mutating /sys/bus/usb/devices probe that warns when the SDR is not yet plugged in. Image-only systemd units are skipped on standalone-feed hosts via systemctl cat. Validators match webconfig's, so a value accepted on the CLI also passes the image-side schema check.

Pairs with airplanes-live/image#93, which ships the producer-side hardware probe in dump978-fa.sh and surfaces the new no_hardware / peer_no_hardware states in webconfig and the console dashboard.