### PR TITLE
Add apl-feed mlat setup/user/geo subcommands; gate enable on geo

### DIFF
--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -15,6 +15,35 @@ resolve_lib_dir() {
 
 APL_FEED_LIB_DIR="${APL_FEED_LIB_DIR:-$(resolve_lib_dir)}"
 
+# Resolve the daemon-lib directory ($IPATH/lib in production, ../lib in the
+# repo checkout) so apl-feed can source pure-function libs like
+# configure-validators.sh that ship alongside the daemons.
+resolve_daemon_lib_dir() {
+    local script_dir
+    script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -d "$script_dir/lib" ]]; then
+        printf '%s\n' "$script_dir/lib"
+    else
+        printf '%s\n' '/usr/local/share/airplanes/lib'
+    fi
+}
+APL_FEED_DAEMON_LIB_DIR="${APL_FEED_DAEMON_LIB_DIR:-$(resolve_daemon_lib_dir)}"
+
+# Pure-function validators shared with configure.sh. Sourced defensively
+# (mirrors apl-feed/status.sh's state-reader fallback) so a partial install
+# missing the lib produces a clear error at first use rather than failing
+# every CLI invocation.
+if [[ -r "$APL_FEED_DAEMON_LIB_DIR/configure-validators.sh" ]]; then
+    # shellcheck source=scripts/lib/configure-validators.sh
+    source "$APL_FEED_DAEMON_LIB_DIR/configure-validators.sh"
+else
+    valid_latitude()     { echo "configure-validators.sh missing at $APL_FEED_DAEMON_LIB_DIR; reinstall feed" >&2; return 2; }
+    valid_longitude()    { valid_latitude "$@"; }
+    valid_altitude()     { valid_latitude "$@"; }
+    normalize_altitude() { valid_latitude "$@"; }
+    sanitize_mlat_user() { valid_latitude "$@"; }
+fi
+
 # shellcheck source=scripts/apl-feed/common.sh
 source "$APL_FEED_LIB_DIR/common.sh"
 # shellcheck source=scripts/apl-feed/http.sh

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -37,6 +37,10 @@ Usage:
   apl-feed id set [--force]
   apl-feed mlat enable
   apl-feed mlat disable
+  apl-feed mlat setup
+  apl-feed mlat user <name>
+  apl-feed mlat user --clear
+  apl-feed mlat geo <lat> <lon> <alt>
   apl-feed mlat private enable
   apl-feed mlat private disable
   apl-feed 978 enable [--serial SERIAL] [--gain GAIN]

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -315,6 +315,46 @@ _mlat_rewrite_feed_env_geo() {
     mv -f "$tmp" "$feed_env"
 }
 
+# Setup-only seven-key transaction. Writes
+# LATITUDE/LONGITUDE/ALTITUDE/GEO_CONFIGURED/MLAT_USER/MLAT_ENABLED/MLAT_PRIVATE
+# in a single rewrite so a wizard run either commits the full new state or
+# fails before touching disk. Preflights every migration marker so we don't
+# enter the rewrite and then die halfway.
+_mlat_rewrite_feed_env_setup() {
+    local feed_env="$1" new_lat="$2" new_lon="$3" new_alt="$4" new_geo="$5"
+    local new_user="$6" new_enabled="$7" new_private="$8"
+
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+    local key
+    for key in MLAT_USER MLAT_ENABLED MLAT_PRIVATE GEO_CONFIGURED; do
+        if ! grep -qE "^${key}=" "$feed_env"; then
+            die "feed.env at $feed_env appears unmigrated (no ${key}= line); run \`sudo /usr/local/share/airplanes/update.sh\` first"
+        fi
+    done
+
+    local tmp escaped
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    grep -vE '^(LATITUDE|LONGITUDE|ALTITUDE|GEO_CONFIGURED|MLAT_USER|MLAT_ENABLED|MLAT_PRIVATE)=' "$feed_env" > "$tmp" || true
+    # MLAT_USER may contain operator-supplied characters even after our
+    # regex check — escape the same way migrate_user_to_mlat_split does.
+    escaped="${new_user//\\/\\\\}"
+    escaped="${escaped//\$/\\\$}"
+    escaped="${escaped//\`/\\\`}"
+    escaped="${escaped//\"/\\\"}"
+    {
+        printf 'LATITUDE="%s"\n'  "$new_lat"
+        printf 'LONGITUDE="%s"\n' "$new_lon"
+        printf 'ALTITUDE="%s"\n'  "$new_alt"
+        printf 'GEO_CONFIGURED=%s\n' "$new_geo"
+        printf 'MLAT_USER="%s"\n'   "$escaped"
+        printf 'MLAT_ENABLED=%s\n'  "$new_enabled"
+        printf 'MLAT_PRIVATE=%s\n'  "$new_private"
+    } >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
 apl_feed_mlat_user() {
     local clear=0 name="" name_set=0
     while [[ $# -gt 0 ]]; do
@@ -416,8 +456,8 @@ apl_feed_mlat_geo() {
 
 # Interactive setup. Collects every input first (cancel-aware via Ctrl-C
 # at any prompt; no partial writes), validates each before any disk mutation,
-# then performs a single atomic geo write + a single MLAT_USER write +
-# enable, with one final service restart. The `read -r -p` pattern matches
+# then commits the full new state in a single atomic seven-key rewrite, with
+# one final service restart. The `read -r -p` pattern matches
 # `apl-feed 978 setup` — no whiptail dependency on standalone-feed boxes.
 apl_feed_mlat_setup() {
     local opt_rc
@@ -434,6 +474,13 @@ apl_feed_mlat_setup() {
         die "mlat setup is interactive; for non-interactive use, run \`apl-feed mlat geo <lat> <lon> <alt>\` then \`apl-feed mlat user <name>\` (optional) then \`apl-feed mlat enable\`"
     fi
 
+    # Precheck that configure-validators.sh is actually present (not stubbed)
+    # so we don't drop the operator into a forever-loop where every input is
+    # "Invalid; try again" because the validator returned 2.
+    if ! valid_latitude "0" >/dev/null 2>&1; then
+        die "configure-validators.sh missing from \$APL_FEED_DAEMON_LIB_DIR; reinstall feed before running \`apl-feed mlat setup\`"
+    fi
+
     local feed_env
     feed_env="$(feed_env_path)"
     [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
@@ -446,11 +493,12 @@ apl_feed_mlat_setup() {
     echo
 
     local lat lon alt name reply
-    local current_lat current_lon current_alt current_user
+    local current_lat current_lon current_alt current_user current_private
     current_lat="$(feed_env_get LATITUDE 2>/dev/null || true)"
     current_lon="$(feed_env_get LONGITUDE 2>/dev/null || true)"
     current_alt="$(feed_env_get ALTITUDE 2>/dev/null || true)"
     current_user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+    current_private="$(feed_env_get MLAT_PRIVATE 2>/dev/null || true)"
 
     while :; do
         read -r -p "Latitude  (decimal, -90..90)${current_lat:+ [$current_lat]}: " lat
@@ -474,12 +522,31 @@ apl_feed_mlat_setup() {
         echo "  Invalid; try again (e.g. 120m or 400ft)." >&2
     done
 
+    # MLAT name prompt. Blank input keeps the current value only when the
+    # current value already passes the strict regex — otherwise the prompt
+    # forces the operator to either supply a valid name or `-` to clear.
+    # This prevents a legacy `sanitize_mlat_user`-mangled name (spaces,
+    # brackets) from quietly round-tripping through setup.
+    local current_user_valid=0
+    if [[ -z "$current_user" || "$current_user" =~ $_MLAT_USER_RE ]]; then
+        current_user_valid=1
+    fi
     while :; do
-        local default_user="${current_user:-<empty — daemon picks Anonymous-<short-feeder-id>>}"
-        read -r -p "MLAT name (1-64 chars in [A-Za-z0-9_-], blank to keep empty) [$default_user]: " name
+        local default_user_display
+        if (( current_user_valid )); then
+            default_user_display="${current_user:-<empty — daemon picks Anonymous-<short-feeder-id>>}"
+        else
+            default_user_display="<current \"$current_user\" is invalid; supply a new name or '-' to clear>"
+        fi
+        read -r -p "MLAT name (1-64 chars in [A-Za-z0-9_-], blank to keep current, '-' to clear) [$default_user_display]: " name
         if [[ -z "$name" ]]; then
-            name="$current_user"
-            break
+            if (( current_user_valid )); then
+                name="$current_user"
+                break
+            else
+                echo "  Current MLAT_USER is invalid; please type a new name or '-' to clear." >&2
+                continue
+            fi
         elif [[ "$name" == "-" ]]; then
             name=""
             break
@@ -491,17 +558,41 @@ apl_feed_mlat_setup() {
         fi
     done
 
-    local private="false"
-    read -r -p "Hide name on the public MLAT map? [y/N] " reply
-    case "${reply,,}" in
-        y|yes) private="true" ;;
+    # Privacy prompt. Default matches the current on-disk value so pressing
+    # Enter is idempotent — a feeder running MLAT_PRIVATE=true is not flipped
+    # back to public just because the operator re-ran setup and didn't read
+    # the prompt closely.
+    local private="${current_private:-false}"
+    case "$private" in
+        true|false) ;;
+        *) private="false" ;;
     esac
+    local privacy_prompt_default privacy_prompt_yes_no
+    if [[ "$private" == "true" ]]; then
+        privacy_prompt_default="Y"
+        privacy_prompt_yes_no="[Y/n]"
+    else
+        privacy_prompt_default="N"
+        privacy_prompt_yes_no="[y/N]"
+    fi
+    read -r -p "Hide name on the public MLAT map? $privacy_prompt_yes_no " reply
+    case "${reply,,}" in
+        ""|"${privacy_prompt_default,,}") ;;  # keep current default
+        y|yes) private="true" ;;
+        n|no)  private="false" ;;
+        *)
+            echo "  Unrecognized answer; keeping MLAT_PRIVATE=$private." >&2
+            ;;
+    esac
+
+    local norm_alt
+    norm_alt="$(normalize_altitude "$alt")"
 
     echo
     echo "About to write:"
     echo "  LATITUDE=$lat"
     echo "  LONGITUDE=$lon"
-    echo "  ALTITUDE=$(normalize_altitude "$alt")"
+    echo "  ALTITUDE=$norm_alt"
     echo "  GEO_CONFIGURED=true"
     echo "  MLAT_USER=\"$name\""
     echo "  MLAT_PRIVATE=$private"
@@ -512,18 +603,11 @@ apl_feed_mlat_setup() {
         *) echo "Aborted — no changes written."; return 0 ;;
     esac
 
-    # Pre-checks done. Mutate disk: geo first, then user, then private,
-    # then enable. Each helper grabs its own temp+rename critical section.
-    local norm_alt
-    norm_alt="$(normalize_altitude "$alt")"
-    _mlat_rewrite_feed_env_geo "$feed_env" "$lat" "$lon" "$norm_alt" "true"
-    _mlat_rewrite_feed_env_user "$feed_env" "$name"
-    _mlat_rewrite_feed_env_private "$feed_env" "$private"
-    # Enable last so an earlier failure can't leave a partially-configured
-    # MLAT_ENABLED=true state.
-    local current
-    current="$(feed_env_get MLAT_USER 2>/dev/null || true)"
-    _mlat_rewrite_feed_env "$feed_env" "$current" "true"
+    # Single seven-key transaction: pre-flight every migration marker, then
+    # one atomic rewrite. Avoids the half-configured state that a sequence
+    # of single-key rewrites would leave if any intermediate write failed.
+    _mlat_rewrite_feed_env_setup \
+        "$feed_env" "$lat" "$lon" "$norm_alt" "true" "$name" "true" "$private"
     echo "feed.env updated; MLAT enabled."
 
     if _mlat_restart_service; then

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 
-# MLAT enable/disable management. Operator-facing alternative to editing
-# /etc/airplanes/feed.env by hand.
+# MLAT enable/disable + configuration. Operator-facing alternative to
+# editing /etc/airplanes/feed.env by hand for users not on the new feeder
+# image (image users have the same surface in webconfig).
 #
-# The on-disk schema (since commit 2851612) treats MLAT_USER as a name and
-# MLAT_ENABLED as the state flag. These commands flip MLAT_ENABLED while
-# preserving MLAT_USER, so a disable→enable round-trip restores the
-# operator's previously-configured name.
+# The on-disk schema treats MLAT_USER as a name (free text in
+# [A-Za-z0-9_-]{1,64}; airplanes-mlat.sh falls back to
+# Anonymous-<short-feeder-id> at startup when empty) and MLAT_ENABLED as
+# the state flag. enable / disable flip MLAT_ENABLED while preserving
+# MLAT_USER; user / geo target the corresponding keys atomically.
 #
-# Empty MLAT_USER is filled in with "Anonymous" on enable so the runtime
-# (which strict-fails empty MLAT_USER + MLAT_ENABLED=true) never trips on
-# a name that was never set in non-interactive setup.
+# MLAT requires geo: enable refuses unless GEO_CONFIGURED=true AND
+# LATITUDE/LONGITUDE/ALTITUDE are all non-empty. The same gate is
+# enforced server-side by webconfig's apply-config and runtime-side by
+# airplanes-mlat.sh's classifier. The CLI gate exists so the operator
+# sees the error before systemd takes the daemon through enable → exit 64.
 
-DEFAULT_MLAT_NAME="Anonymous"
+# MLAT_USER strict shape — mirrors webconfig configspec.go's mlatUserRE.
+# CLI rejects mismatched input rather than mangling it via sanitize_mlat_user
+# (which silently rewrites disallowed characters to `_`).
+_MLAT_USER_RE='^[A-Za-z0-9_-]{1,64}$'
 
 # Skip the systemctl restart when running against a non-host filesystem
 # (--root /mnt/...) or under AIRPLANES_BUILD_MODE=1 (image build-time
@@ -116,13 +123,16 @@ apl_feed_mlat_enable() {
         esac
     done
 
-    local feed_env user
+    local feed_env
     feed_env="$(feed_env_path)"
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+    _mlat_require_geo "$feed_env"
+
+    local user
     user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
-    if [[ -z "$user" ]]; then
-        user="$DEFAULT_MLAT_NAME"
-        echo "MLAT_USER was empty; filling in with default \"$DEFAULT_MLAT_NAME\""
-    fi
+    # Empty MLAT_USER is legal: airplanes-mlat.sh substitutes
+    # Anonymous-<short-feeder-id> at daemon startup. Preserve the empty
+    # value rather than inlining a literal "Anonymous" here.
 
     _mlat_rewrite_feed_env "$feed_env" "$user" "true"
     echo "MLAT_ENABLED set to true in $feed_env"
@@ -205,6 +215,324 @@ apl_feed_mlat_private_disable() {
     fi
 }
 
+# Geo gate. MLAT requires real coordinates AND a non-empty altitude. The
+# canonical source-of-truth is GEO_CONFIGURED=true (set by configure.sh's
+# derive_geo_configured and by webconfig's apply-config auto-derive). The
+# explicit per-axis non-empty check is belt-and-braces against a feed.env
+# hand-edited into an inconsistent state (e.g. cleared LATITUDE while
+# GEO_CONFIGURED stayed true). Same business rule as the webconfig's
+# ValidateConsistency for MLAT_ENABLED=true.
+_mlat_require_geo() {
+    local feed_env="$1"
+    local geo lat lon alt
+    geo="$(feed_env_get GEO_CONFIGURED 2>/dev/null || true)"
+    lat="$(feed_env_get LATITUDE 2>/dev/null || true)"
+    lon="$(feed_env_get LONGITUDE 2>/dev/null || true)"
+    alt="$(feed_env_get ALTITUDE 2>/dev/null || true)"
+    if [[ "$geo" != "true" ]]; then
+        die "location not configured (GEO_CONFIGURED=${geo:-<unset>}); run \`sudo apl-feed mlat setup\` or \`sudo apl-feed mlat geo <lat> <lon> <alt>\` first"
+    fi
+    [[ -n "$lat" ]] || die "LATITUDE is empty in $feed_env; run \`sudo apl-feed mlat geo <lat> <lon> <alt>\`"
+    [[ -n "$lon" ]] || die "LONGITUDE is empty in $feed_env; run \`sudo apl-feed mlat geo <lat> <lon> <alt>\`"
+    [[ -n "$alt" ]] || die "ALTITUDE is empty in $feed_env; run \`sudo apl-feed mlat geo <lat> <lon> <alt>\`"
+}
+
+# Mirror feed/configure.sh:derive_geo_configured — both axes numerically
+# zero (or empty) → "false", anything else → "true". The Atlantic (0,0)
+# point is uninhabited so the false-negative blast radius is empty.
+_mlat_geo_axis_unset_or_zero() {
+    [[ -z "$1" ]] && return 0
+    [[ "$1" =~ ^[+-]?0+(\.0+)?$ ]] && return 0
+    return 1
+}
+_mlat_derive_geo_configured() {
+    local lat="$1" lon="$2"
+    if _mlat_geo_axis_unset_or_zero "$lat" && _mlat_geo_axis_unset_or_zero "$lon"; then
+        printf 'false'
+    else
+        printf 'true'
+    fi
+}
+
+# Reject every byte in webconfig configspec.go's universalReject set so a
+# CLI-written value can never reach disk in a form that would re-trip
+# shell-source by airplanes-feed.sh / airplanes-mlat.sh.
+_mlat_check_universal() {
+    local key="$1" value="$2"
+    if [[ "$value" =~ [\"\\\$\`\;\&\|\<\>\#\'$'\n'$'\r'] ]]; then
+        die "$key contains a forbidden shell metacharacter"
+    fi
+}
+
+# Atomic single-key rewrite for MLAT_USER. Mirrors _mlat_rewrite_feed_env's
+# pattern but touches only the MLAT_USER line — leaves MLAT_ENABLED alone.
+_mlat_rewrite_feed_env_user() {
+    local feed_env="$1" new_user="$2"
+
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+    if ! grep -qE '^MLAT_USER=' "$feed_env"; then
+        die "feed.env at $feed_env appears unmigrated (no MLAT_USER= line); run \`sudo /usr/local/share/airplanes/update.sh\` first"
+    fi
+
+    local tmp escaped
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    grep -vE '^MLAT_USER=' "$feed_env" > "$tmp" || true
+    # Same escape rule as _mlat_rewrite_feed_env / migrate_user_to_mlat_split.
+    escaped="${new_user//\\/\\\\}"
+    escaped="${escaped//\$/\\\$}"
+    escaped="${escaped//\`/\\\`}"
+    escaped="${escaped//\"/\\\"}"
+    printf 'MLAT_USER="%s"\n' "$escaped" >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
+# Atomic four-key rewrite for LATITUDE / LONGITUDE / ALTITUDE /
+# GEO_CONFIGURED. Same migration-marker guard as the MLAT helpers — refuses
+# to write into an unmigrated feed.env.
+_mlat_rewrite_feed_env_geo() {
+    local feed_env="$1" new_lat="$2" new_lon="$3" new_alt="$4" new_geo="$5"
+
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+    if ! grep -qE '^GEO_CONFIGURED=' "$feed_env"; then
+        die "feed.env at $feed_env appears unmigrated (no GEO_CONFIGURED= line); run \`sudo /usr/local/share/airplanes/update.sh\` first"
+    fi
+
+    local tmp
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    grep -vE '^(LATITUDE|LONGITUDE|ALTITUDE|GEO_CONFIGURED)=' "$feed_env" > "$tmp" || true
+    # lat/lon/alt are pre-validated numeric / regex-matching strings; no
+    # shell-escape needed. GEO_CONFIGURED is a literal true|false.
+    {
+        printf 'LATITUDE="%s"\n'  "$new_lat"
+        printf 'LONGITUDE="%s"\n' "$new_lon"
+        printf 'ALTITUDE="%s"\n'  "$new_alt"
+        printf 'GEO_CONFIGURED=%s\n' "$new_geo"
+    } >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
+}
+
+apl_feed_mlat_user() {
+    local clear=0 name="" name_set=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --clear)
+                clear=1
+                shift ;;
+            *)
+                local opt_rc
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0)
+                        if (( name_set )); then
+                            die "mlat user takes a single positional name; got extra arg: $1"
+                        fi
+                        name="$1"
+                        name_set=1
+                        shift ;;
+                esac
+                ;;
+        esac
+    done
+
+    if (( clear )); then
+        (( name_set )) && die "mlat user: --clear and a positional name are mutually exclusive"
+    else
+        (( name_set )) || die "mlat user: provide a name or use --clear"
+        [[ "$name" =~ $_MLAT_USER_RE ]] || die "MLAT_USER must match [A-Za-z0-9_-]{1,64}; reject \"$name\""
+        _mlat_check_universal MLAT_USER "$name"
+    fi
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    _mlat_rewrite_feed_env_user "$feed_env" "$name"
+    if (( clear )); then
+        echo "MLAT_USER cleared in $feed_env (daemon will use Anonymous-<short-feeder-id> when MLAT is enabled)"
+    else
+        echo "MLAT_USER set to \"$name\" in $feed_env"
+    fi
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done"
+    else
+        return 1
+    fi
+}
+
+apl_feed_mlat_geo() {
+    local positional=()
+    while [[ $# -gt 0 ]]; do
+        # Negative numbers like `-0`, `-12.34`, `-.5` are positional even
+        # though they begin with `-`. Match before the flag dispatch so a
+        # caller can pass them without quoting tricks or `--`.
+        case "$1" in
+            -[0-9]*|-.[0-9]*)
+                positional+=("$1"); shift ;;
+            --|-h|--help|--root|--server-url|--max-retry-time)
+                local opt_rc
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0) die "unknown flag for mlat geo: $1" ;;
+                esac
+                ;;
+            -*)
+                die "unknown flag for mlat geo: $1" ;;
+            *)
+                positional+=("$1")
+                shift ;;
+        esac
+    done
+
+    (( ${#positional[@]} == 3 )) || die "mlat geo requires exactly three positional args: <lat> <lon> <alt>"
+    local lat="${positional[0]}" lon="${positional[1]}" alt="${positional[2]}"
+
+    valid_latitude  "$lat"  || die "LATITUDE must be a decimal number in (-90, 90)"
+    valid_longitude "$lon"  || die "LONGITUDE must be a decimal number in (-180, 180)"
+    valid_altitude  "$alt"  || die "ALTITUDE must be an integer with optional ft or m suffix"
+    _mlat_check_universal LATITUDE  "$lat"
+    _mlat_check_universal LONGITUDE "$lon"
+    _mlat_check_universal ALTITUDE  "$alt"
+
+    local norm_alt geo
+    norm_alt="$(normalize_altitude "$alt")"
+    geo="$(_mlat_derive_geo_configured "$lat" "$lon")"
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    _mlat_rewrite_feed_env_geo "$feed_env" "$lat" "$lon" "$norm_alt" "$geo"
+    echo "LATITUDE=\"$lat\" LONGITUDE=\"$lon\" ALTITUDE=\"$norm_alt\" GEO_CONFIGURED=$geo in $feed_env"
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done"
+    else
+        return 1
+    fi
+}
+
+# Interactive setup. Collects every input first (cancel-aware via Ctrl-C
+# at any prompt; no partial writes), validates each before any disk mutation,
+# then performs a single atomic geo write + a single MLAT_USER write +
+# enable, with one final service restart. The `read -r -p` pattern matches
+# `apl-feed 978 setup` — no whiptail dependency on standalone-feed boxes.
+apl_feed_mlat_setup() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for mlat setup: $1" ;;
+        esac
+    done
+
+    if [[ ! -t 0 ]]; then
+        die "mlat setup is interactive; for non-interactive use, run \`apl-feed mlat geo <lat> <lon> <alt>\` then \`apl-feed mlat user <name>\` (optional) then \`apl-feed mlat enable\`"
+    fi
+
+    local feed_env
+    feed_env="$(feed_env_path)"
+    [[ -f "$feed_env" ]] || die "feed.env not found at $feed_env; run setup first"
+
+    echo
+    echo "Configure MLAT (multilateration) reception."
+    echo "  MLAT needs your antenna position. The values you enter are used as"
+    echo "  mlat-client's --lat/--lon/--alt. Real coordinates are required;"
+    echo "  the Atlantic (0,0) placeholder will not be accepted."
+    echo
+
+    local lat lon alt name reply
+    local current_lat current_lon current_alt current_user
+    current_lat="$(feed_env_get LATITUDE 2>/dev/null || true)"
+    current_lon="$(feed_env_get LONGITUDE 2>/dev/null || true)"
+    current_alt="$(feed_env_get ALTITUDE 2>/dev/null || true)"
+    current_user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+
+    while :; do
+        read -r -p "Latitude  (decimal, -90..90)${current_lat:+ [$current_lat]}: " lat
+        lat="${lat:-$current_lat}"
+        valid_latitude "$lat" && break
+        echo "  Invalid; try again (e.g. 52.51666)." >&2
+    done
+    while :; do
+        read -r -p "Longitude (decimal, -180..180)${current_lon:+ [$current_lon]}: " lon
+        lon="${lon:-$current_lon}"
+        valid_longitude "$lon" && break
+        echo "  Invalid; try again (e.g. 13.37777)." >&2
+    done
+    if [[ "$(_mlat_derive_geo_configured "$lat" "$lon")" != "true" ]]; then
+        die "lat=$lat lon=$lon: refusing to enable MLAT at the Atlantic (0,0) placeholder"
+    fi
+    while :; do
+        read -r -p "Altitude  (integer; m or ft suffix, e.g. 120m, 400ft)${current_alt:+ [$current_alt]}: " alt
+        alt="${alt:-$current_alt}"
+        valid_altitude "$alt" && break
+        echo "  Invalid; try again (e.g. 120m or 400ft)." >&2
+    done
+
+    while :; do
+        local default_user="${current_user:-<empty — daemon picks Anonymous-<short-feeder-id>>}"
+        read -r -p "MLAT name (1-64 chars in [A-Za-z0-9_-], blank to keep empty) [$default_user]: " name
+        if [[ -z "$name" ]]; then
+            name="$current_user"
+            break
+        elif [[ "$name" == "-" ]]; then
+            name=""
+            break
+        elif [[ "$name" =~ $_MLAT_USER_RE ]]; then
+            _mlat_check_universal MLAT_USER "$name"
+            break
+        else
+            echo "  Invalid; try again (or blank to keep current, or '-' to clear)." >&2
+        fi
+    done
+
+    local private="false"
+    read -r -p "Hide name on the public MLAT map? [y/N] " reply
+    case "${reply,,}" in
+        y|yes) private="true" ;;
+    esac
+
+    echo
+    echo "About to write:"
+    echo "  LATITUDE=$lat"
+    echo "  LONGITUDE=$lon"
+    echo "  ALTITUDE=$(normalize_altitude "$alt")"
+    echo "  GEO_CONFIGURED=true"
+    echo "  MLAT_USER=\"$name\""
+    echo "  MLAT_PRIVATE=$private"
+    echo "  MLAT_ENABLED=true"
+    read -r -p "Proceed? [Y/n] " reply
+    case "${reply,,}" in
+        ""|y|yes) ;;
+        *) echo "Aborted — no changes written."; return 0 ;;
+    esac
+
+    # Pre-checks done. Mutate disk: geo first, then user, then private,
+    # then enable. Each helper grabs its own temp+rename critical section.
+    local norm_alt
+    norm_alt="$(normalize_altitude "$alt")"
+    _mlat_rewrite_feed_env_geo "$feed_env" "$lat" "$lon" "$norm_alt" "true"
+    _mlat_rewrite_feed_env_user "$feed_env" "$name"
+    _mlat_rewrite_feed_env_private "$feed_env" "$private"
+    # Enable last so an earlier failure can't leave a partially-configured
+    # MLAT_ENABLED=true state.
+    local current
+    current="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+    _mlat_rewrite_feed_env "$feed_env" "$current" "true"
+    echo "feed.env updated; MLAT enabled."
+
+    if _mlat_restart_service; then
+        echo "Restarting airplanes-mlat.service ... done"
+    else
+        return 1
+    fi
+}
+
 dispatch_mlat_private() {
     local sub="${1:-}"
     [[ -n "$sub" ]] || die "mlat private requires a subcommand (enable|disable)"
@@ -219,11 +547,14 @@ dispatch_mlat_private() {
 
 dispatch_mlat() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable|private)"
+    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable|setup|user|geo|private)"
     shift || true
     case "$sub" in
         enable)  apl_feed_mlat_enable  "$@" ;;
         disable) apl_feed_mlat_disable "$@" ;;
+        setup)   apl_feed_mlat_setup   "$@" ;;
+        user)    apl_feed_mlat_user    "$@" ;;
+        geo)     apl_feed_mlat_geo     "$@" ;;
         private) dispatch_mlat_private "$@" ;;
         -h|--help) usage ;;
         *) die "unknown mlat subcommand: $sub" ;;

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -654,3 +654,59 @@ EOF
     [ "$status" -ne 0 ]
     [[ "$output" == *'exactly three positional args'* ]]
 }
+
+# --- setup helper (single 7-key transaction) ---
+
+@test "_mlat_rewrite_feed_env_setup writes all seven keys atomically; preserves unrelated" {
+    write_feed_env_with_private "alice" "false" "false"
+    local feed_env="$ROOT_DIR/etc/airplanes/feed.env"
+
+    _mlat_rewrite_feed_env_setup "$feed_env" \
+        "48.137" "11.575" "520m" "true" "bob-99" "true" "true"
+
+    grep -qx 'LATITUDE="48.137"'    "$feed_env"
+    grep -qx 'LONGITUDE="11.575"'   "$feed_env"
+    grep -qx 'ALTITUDE="520m"'      "$feed_env"
+    grep -qx 'GEO_CONFIGURED=true'  "$feed_env"
+    grep -qx 'MLAT_USER="bob-99"'   "$feed_env"
+    grep -qx 'MLAT_ENABLED=true'    "$feed_env"
+    grep -qx 'MLAT_PRIVATE=true'    "$feed_env"
+    # The unrelated INPUT key survives unchanged.
+    grep -qx 'INPUT="127.0.0.1:30005"' "$feed_env"
+}
+
+@test "_mlat_rewrite_feed_env_setup leaves no duplicate keys after rerun" {
+    write_feed_env_with_private "alice" "false" "false"
+    local feed_env="$ROOT_DIR/etc/airplanes/feed.env"
+
+    _mlat_rewrite_feed_env_setup "$feed_env" "1" "2" "3m" "true" "u1" "true" "false"
+    _mlat_rewrite_feed_env_setup "$feed_env" "4" "5" "6m" "true" "u2" "true" "true"
+
+    [ "$(grep -c '^LATITUDE='       "$feed_env")" -eq 1 ]
+    [ "$(grep -c '^LONGITUDE='      "$feed_env")" -eq 1 ]
+    [ "$(grep -c '^ALTITUDE='       "$feed_env")" -eq 1 ]
+    [ "$(grep -c '^GEO_CONFIGURED=' "$feed_env")" -eq 1 ]
+    [ "$(grep -c '^MLAT_USER='      "$feed_env")" -eq 1 ]
+    [ "$(grep -c '^MLAT_ENABLED='   "$feed_env")" -eq 1 ]
+    [ "$(grep -c '^MLAT_PRIVATE='   "$feed_env")" -eq 1 ]
+}
+
+@test "_mlat_rewrite_feed_env_setup refuses unmigrated feed.env (no MLAT_PRIVATE=)" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="alice"
+MLAT_ENABLED=false
+LATITUDE="0"
+LONGITUDE="0"
+ALTITUDE="0"
+GEO_CONFIGURED=false
+EOF
+    local feed_env="$ROOT_DIR/etc/airplanes/feed.env"
+
+    run _mlat_rewrite_feed_env_setup "$feed_env" "1" "2" "3m" "true" "u" "true" "true"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'no MLAT_PRIVATE='* ]]
+    # File untouched.
+    grep -qx 'MLAT_ENABLED=false' "$feed_env"
+}

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -14,6 +14,8 @@ setup() {
     export TMPDIR
 
     bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/configure-validators.sh"
     # shellcheck source=../scripts/apl-feed/common.sh
     source "$LIB_DIR/common.sh"
     # shellcheck source=../scripts/apl-feed/mlat.sh
@@ -47,6 +49,7 @@ MLAT_PRIVATE=false
 LATITUDE="52.52"
 LONGITUDE="13.40"
 ALTITUDE="35m"
+GEO_CONFIGURED=true
 EOF
 }
 
@@ -59,6 +62,42 @@ MLAT_PRIVATE=$3
 LATITUDE="52.52"
 LONGITUDE="13.40"
 ALTITUDE="35m"
+GEO_CONFIGURED=true
+EOF
+}
+
+# Variants used by GEO-gate tests on `apl_feed_mlat_enable`.
+write_feed_env_no_geo_flag() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="$1"
+MLAT_ENABLED=$2
+MLAT_PRIVATE=false
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+GEO_CONFIGURED=false
+EOF
+}
+
+write_feed_env_no_axis() {
+    # $1 user, $2 enabled, $3 axis-to-blank (LATITUDE|LONGITUDE|ALTITUDE)
+    local user="$1" enabled="$2" blank="$3"
+    local lat='"52.52"' lon='"13.40"' alt='"35m"'
+    case "$blank" in
+        LATITUDE)  lat='""' ;;
+        LONGITUDE) lon='""' ;;
+        ALTITUDE)  alt='""' ;;
+    esac
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="$user"
+MLAT_ENABLED=$enabled
+MLAT_PRIVATE=false
+LATITUDE=$lat
+LONGITUDE=$lon
+ALTITUDE=$alt
+GEO_CONFIGURED=true
 EOF
 }
 
@@ -118,7 +157,7 @@ EOF
     grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
 }
 
-@test "enable with empty MLAT_USER fills in Anonymous default" {
+@test "enable preserves empty MLAT_USER — daemon Anonymous-<short-id> fallback owns the runtime name" {
     write_feed_env "" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
@@ -127,8 +166,7 @@ EOF
     run apl_feed_mlat_enable
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *'MLAT_USER was empty; filling in with default "Anonymous"'* ]]
-    grep -q '^MLAT_USER="Anonymous"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^MLAT_USER=""$' "$ROOT_DIR/etc/airplanes/feed.env"
     grep -q '^MLAT_ENABLED=true$' "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
@@ -353,4 +391,266 @@ EOF
     grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
     [ ! -f "$SYSTEMCTL_LOG" ] || ! grep -q 'restart' "$SYSTEMCTL_LOG"
     [[ "$output" == *'AIRPLANES_BUILD_MODE'* ]]
+}
+
+# --- mlat enable geo gate (α: belt-and-braces; canonical source GEO_CONFIGURED) ---
+
+@test "enable refuses when GEO_CONFIGURED=false" {
+    write_feed_env_no_geo_flag "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_enable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'location not configured'* ]]
+    [[ "$output" == *'apl-feed mlat setup'* ]]
+    # File untouched.
+    grep -qx 'MLAT_ENABLED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "enable refuses when GEO_CONFIGURED is missing" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+INPUT="127.0.0.1:30005"
+MLAT_USER="alice"
+MLAT_ENABLED=false
+MLAT_PRIVATE=false
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+EOF
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_enable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'location not configured'* ]]
+}
+
+@test "enable refuses when LATITUDE is empty (belt-and-braces)" {
+    write_feed_env_no_axis "alice" "false" LATITUDE
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_enable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'LATITUDE is empty'* ]]
+}
+
+@test "enable refuses when ALTITUDE is empty (belt-and-braces)" {
+    write_feed_env_no_axis "alice" "false" ALTITUDE
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_enable
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'ALTITUDE is empty'* ]]
+}
+
+# --- mlat user ---
+
+@test "mlat user <name>: writes MLAT_USER, preserves MLAT_ENABLED, restarts service" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_user bob-123
+
+    grep -qx 'MLAT_USER="bob-123"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_ENABLED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
+}
+
+@test "mlat user --clear: writes empty MLAT_USER" {
+    write_feed_env "alice" "true"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_user --clear
+
+    grep -qx 'MLAT_USER=""' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_ENABLED=true' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "mlat user: rejects name with space" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_user "alice rabbit"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'MLAT_USER must match'* ]]
+    grep -qx 'MLAT_USER="alice"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "mlat user: rejects name >64 chars" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    local long
+    long="$(printf 'a%.0s' {1..65})"
+    run apl_feed_mlat_user "$long"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'MLAT_USER must match'* ]]
+}
+
+@test "mlat user: rejects shell-metachar even when regex-passing" {
+    # The regex prevents most metas anyway, but assert that universal-reject
+    # catches the cross-cutting cases (\\ would actually fail the regex too).
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_user 'bad$name'
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'MLAT_USER must match'* ]] || [[ "$output" == *'forbidden shell metacharacter'* ]]
+}
+
+@test "mlat user: --clear with a positional name dies" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_user --clear bob
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'mutually exclusive'* ]]
+}
+
+@test "mlat user: no args dies" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_user
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'provide a name or use --clear'* ]]
+}
+
+# --- mlat geo ---
+
+@test "mlat geo writes four keys, derives GEO_CONFIGURED=true for non-zero coords, restarts" {
+    write_feed_env_no_geo_flag "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_geo 48.137 11.575 520m
+
+    grep -qx 'LATITUDE="48.137"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'LONGITUDE="11.575"' "$ROOT_DIR/etc/airplanes/feed.env"
+    # normalize_altitude is a no-op for the `m` suffix; only `ft` gets converted.
+    grep -qx 'ALTITUDE="520m"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'GEO_CONFIGURED=true' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
+}
+
+@test "mlat geo at (0, 0) derives GEO_CONFIGURED=false (Atlantic placeholder)" {
+    write_feed_env_no_geo_flag "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_geo 0 0 0m
+
+    grep -qx 'GEO_CONFIGURED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "mlat geo at (0.0, 0) still derives false (decimal-zero forms)" {
+    write_feed_env_no_geo_flag "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    apl_feed_mlat_geo 0.0 -0 0m
+
+    grep -qx 'GEO_CONFIGURED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "mlat geo rejects invalid latitude" {
+    write_feed_env_no_geo_flag "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_geo 91 0 0m
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'LATITUDE must be'* ]]
+    # File untouched.
+    grep -qx 'GEO_CONFIGURED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "mlat geo rejects wrong arg count" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    run apl_feed_mlat_geo 52.5 13.4
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'exactly three positional args'* ]]
+
+    run apl_feed_mlat_geo 52.5 13.4 120m extra
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'exactly three positional args'* ]]
+}
+
+# --- mlat setup ---
+
+@test "mlat setup: dies on non-TTY stdin with a guidance message" {
+    write_feed_env "alice" "false"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+
+    # bats's run captures stdin from a pipe so [[ -t 0 ]] is false.
+    run apl_feed_mlat_setup
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'mlat setup is interactive'* ]]
+    [[ "$output" == *'apl-feed mlat geo'* ]]
+}
+
+# --- dispatch_mlat new subcommands ---
+
+@test "dispatch_mlat user routes to apl_feed_mlat_user (no name → die)" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/mlat.sh'
+        dispatch_mlat user
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'provide a name or use --clear'* ]]
+}
+
+@test "dispatch_mlat geo routes to apl_feed_mlat_geo (no args → die)" {
+    run bash -c "
+        set -euo pipefail
+        source '$LIB_DIR/common.sh'
+        source '$LIB_DIR/mlat.sh'
+        dispatch_mlat geo
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'exactly three positional args'* ]]
 }

--- a/update.sh
+++ b/update.sh
@@ -483,6 +483,12 @@ install -d -m 0755 "$IPATH/lib"
 # and are NOT installed at $IPATH; copy selectively rather than wildcard.
 install -m 0644 "$GIT"/scripts/lib/state-writer.sh "$IPATH/lib"
 install -m 0644 "$GIT"/scripts/lib/state-reader.sh "$IPATH/lib"
+# configure-validators.sh is a pure-function lib (regex + range checks for
+# lat/lon/altitude/mlat-user). configure.sh consumes it at install time
+# under $GIT/scripts/lib; apl-feed sources it at runtime to share validation
+# with the interactive setup path. Installed at $IPATH/lib so the CLI works
+# the same on standalone-feed installs and image installs.
+install -m 0644 "$GIT"/scripts/lib/configure-validators.sh "$IPATH/lib"
 
 # Historical-ship manifests for the wildcard cp/install above. Each entry is
 # a script we have ever shipped to $IPATH (top-level) or $IPATH/apl-feed/.
@@ -512,6 +518,7 @@ historical_apl_feed_modules=(
     uat.sh
 )
 historical_daemon_libs=(
+    configure-validators.sh
     state-reader.sh
     state-writer.sh
 )


### PR DESCRIPTION
Operator-facing alternatives to hand-editing /etc/airplanes/feed.env for standalone-feed users. `apl-feed mlat setup` walks through lat/lon/alt + name + privacy interactively; `mlat user <name> | --clear` sets MLAT_USER atomically; `mlat geo <lat> <lon> <alt>` writes the four geo keys (including a derived GEO_CONFIGURED).

`apl-feed mlat enable` now refuses unless GEO_CONFIGURED=true with non-empty LAT/LON/ALT, matching the daemon classifier and the webconfig consistency rule. The legacy `Anonymous` inline-fill on empty MLAT_USER is dropped — `airplanes-mlat.sh`'s per-device `Anonymous-<short-feeder-id>` fallback owns the runtime name now.

`update.sh` also ships `scripts/lib/configure-validators.sh` to `$IPATH/lib/` so the CLI shares the same regex + range checks that `configure.sh` uses at install time.

Addresses [DEV-375].

[DEV-375]: https://airplanes-live.atlassian.net/browse/DEV-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ