### PR TITLE
feat(apl-feed): add import legacy-config subcommand

### DIFF
--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -95,6 +95,8 @@ source "$APL_FEED_LIB_DIR/uat.sh"
 source "$APL_FEED_LIB_DIR/apply.sh"
 # shellcheck source=scripts/apl-feed/schema.sh
 source "$APL_FEED_LIB_DIR/schema.sh"
+# shellcheck source=scripts/apl-feed/import.sh
+source "$APL_FEED_LIB_DIR/import.sh"
 
 main() {
     local cmd="${1:-}"
@@ -134,6 +136,10 @@ main() {
         schema)
             shift
             apl_feed_schema_cli "$@"
+            ;;
+        import)
+            shift
+            dispatch_import "$@"
             ;;
         -h|--help|'')
             usage

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -49,6 +49,7 @@ Usage:
   apl-feed 978 status
   apl-feed apply [--no-restart] [--lock-timeout SECS]
   apl-feed schema
+  apl-feed import legacy-config <path>
   apl-feed backup <file>
   apl-feed restore <file>
   apl-feed restore --check <file>

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# `apl-feed import legacy-config <PATH>` — translate a legacy
+# /boot/airplanes-config.txt-shaped file into the canonical feed.env
+# schema and write it via apl_feed_apply.
+#
+# Used by `airplanes-first-run` on the legacy-bridge image stack so a
+# legacy webconfig save (which still writes to /boot/airplanes-config.txt)
+# produces a canonical feed.env via the same writer webconfig uses on the
+# new image. Legacy-key parsing lives here so feed/ remains the sole
+# owner of the feed.env schema; airplanes-first-run becomes a thin shim
+# that detects the boot file and shells in.
+#
+# Legacy → canonical mapping:
+#   LATITUDE / LONGITUDE / ALTITUDE          preserved as-is
+#   USER=<name>  / USER=""                    MLAT_USER=<name>, MLAT_ENABLED=true
+#   USER=0 / USER=disable                     MLAT_USER="",     MLAT_ENABLED=false
+#   MLAT_MARKER=no                            MLAT_PRIVATE=true   (inverted polarity)
+#   MLAT_MARKER=<other>                       MLAT_PRIVATE=false
+#   PRIVACY=yes|true|1                        MLAT_PRIVATE=true
+#   PRIVACY=<other>                           MLAT_PRIVATE=false
+#   GAIN                                      preserved as-is
+#   UAT_INPUT / DUMP978_SDR_SERIAL / DUMP978_GAIN   preserved as-is
+#
+# Permissive by design: an unparseable legacy value is silently dropped
+# rather than failing the import — the failure mode on a legacy box
+# should never leave feed.env empty when a partial config was available.
+# apl_feed_apply still applies the universal-reject scan, so unsafe
+# values can't slip through.
+
+# Safe single-key extraction from an env-style file. Mirrors
+# update-migrations.sh:_extract_env_value (which we can't source from
+# here because that lib pulls in update-time deps). Last occurrence
+# wins. Strips trailing CR + comment-after-bare-value + outer quotes.
+_apl_feed_import_extract() {
+    local path="$1" key="$2" raw line value
+    raw="$(grep -E "^${key}=" "$path" 2>/dev/null | tail -n 1)" || true
+    [[ -z "$raw" ]] && return 0
+    line="${raw#${key}=}"
+    line="${line%$'\r'}"
+    # Quote-aware: KEY="value" / KEY='value' / KEY=value-with-trailing-ws.
+    if [[ "$line" =~ ^\"([^\"]*)\"[[:space:]]*$ ]]; then
+        value="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^\'([^\']*)\'[[:space:]]*$ ]]; then
+        value="${BASH_REMATCH[1]}"
+    else
+        # Bare value: strip trailing whitespace + ` # …` comment.
+        value="${line%%#*}"
+        value="${value%"${value##*[![:space:]]}"}"
+    fi
+    printf '%s' "$value"
+}
+
+apl_feed_import_legacy_config() {
+    local path=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help) usage; return 0 ;;
+            --)
+                shift
+                [[ -n "$1" ]] && path="$1"
+                shift || true
+                ;;
+            -*) die "unknown flag for import legacy-config: $1" ;;
+            *)
+                local opt_rc
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0)
+                        if [[ -z "$path" ]]; then
+                            path="$1"
+                            shift
+                        else
+                            die "import legacy-config takes exactly one path"
+                        fi
+                        ;;
+                esac
+                ;;
+        esac
+    done
+
+    [[ -n "$path" ]] || die "usage: apl-feed import legacy-config <path>"
+    [[ -f "$path" ]] || die "$path not found"
+
+    local -A payload=()
+    local v
+
+    # Geo + gain + 978 keys: passthrough.
+    local k
+    for k in LATITUDE LONGITUDE ALTITUDE GAIN UAT_INPUT DUMP978_SDR_SERIAL DUMP978_GAIN; do
+        v="$(_apl_feed_import_extract "$path" "$k")"
+        if [[ -n "$v" ]]; then
+            payload[$k]="$v"
+        fi
+    done
+
+    # USER → MLAT_USER + MLAT_ENABLED.
+    if grep -qE '^USER=' "$path"; then
+        local user_value
+        user_value="$(_apl_feed_import_extract "$path" USER)"
+        case "$user_value" in
+            0|disable)
+                payload[MLAT_USER]=""
+                payload[MLAT_ENABLED]="false"
+                ;;
+            '')
+                payload[MLAT_USER]=""
+                payload[MLAT_ENABLED]="true"
+                ;;
+            *)
+                # Strict regex — silently drop on shape mismatch so an
+                # illegible legacy username doesn't fail the whole import.
+                if [[ "$user_value" =~ ^[A-Za-z0-9_-]{1,64}$ ]]; then
+                    payload[MLAT_USER]="$user_value"
+                    payload[MLAT_ENABLED]="true"
+                fi
+                ;;
+        esac
+    fi
+
+    # MLAT_USER passthrough (already-canonical legacy file).
+    if grep -qE '^MLAT_USER=' "$path"; then
+        v="$(_apl_feed_import_extract "$path" MLAT_USER)"
+        if [[ -z "$v" || "$v" =~ ^[A-Za-z0-9_-]{1,64}$ ]]; then
+            payload[MLAT_USER]="$v"
+        fi
+    fi
+    if grep -qE '^MLAT_ENABLED=' "$path"; then
+        v="$(_apl_feed_import_extract "$path" MLAT_ENABLED)"
+        case "$v" in
+            true|false) payload[MLAT_ENABLED]="$v" ;;
+        esac
+    fi
+
+    # MLAT_MARKER → MLAT_PRIVATE (inverted polarity: "no" = privacy ON).
+    if grep -qE '^MLAT_MARKER=' "$path"; then
+        local marker
+        marker="$(_apl_feed_import_extract "$path" MLAT_MARKER)"
+        case "$marker" in
+            no) payload[MLAT_PRIVATE]="true" ;;
+            *)  payload[MLAT_PRIVATE]="false" ;;
+        esac
+    fi
+    # PRIVACY → MLAT_PRIVATE. Wins over MLAT_MARKER when both are present.
+    if grep -qE '^PRIVACY=' "$path"; then
+        local privacy
+        privacy="$(_apl_feed_import_extract "$path" PRIVACY)"
+        case "$privacy" in
+            yes|true|1) payload[MLAT_PRIVATE]="true" ;;
+            *)          payload[MLAT_PRIVATE]="false" ;;
+        esac
+    fi
+    # MLAT_PRIVATE passthrough wins over both.
+    if grep -qE '^MLAT_PRIVATE=' "$path"; then
+        v="$(_apl_feed_import_extract "$path" MLAT_PRIVATE)"
+        case "$v" in
+            true|false) payload[MLAT_PRIVATE]="$v" ;;
+        esac
+    fi
+
+    # GEO_CONFIGURED inference: pulled from the merged lat/lon. The
+    # library auto-derives this too, but the legacy import may carry
+    # an explicit value (e.g. when called recursively on a feed.env that
+    # was already migrated once).
+    if grep -qE '^GEO_CONFIGURED=' "$path"; then
+        v="$(_apl_feed_import_extract "$path" GEO_CONFIGURED)"
+        case "$v" in
+            true|false) payload[GEO_CONFIGURED]="$v" ;;
+        esac
+    fi
+
+    local feed_env_file lock_file
+    feed_env_file="$(feed_env_path)"
+    lock_file="$(feed_env_lock_path)"
+
+    # apl_feed_apply rejects on missing feed.env. The legacy boot path
+    # may be invoked before any feed.env exists at all (e.g. on the
+    # first reboot after a bridge update) — pre-create an empty file so
+    # the library has somewhere to merge into.
+    if [[ ! -f "$feed_env_file" ]]; then
+        mkdir -p "$(dirname "$feed_env_file")"
+        : > "$feed_env_file"
+    fi
+
+    if (( ${#payload[@]} == 0 )); then
+        echo "import legacy-config: no recognised keys in $path"
+        return 0
+    fi
+
+    local -a args=()
+    args+=(--feed-env "$feed_env_file" --lock-file "$lock_file")
+    if [[ "$ROOT" != "/" ]]; then
+        args+=(--no-restart)
+        echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+    fi
+    for k in "${!payload[@]}"; do
+        args+=("$k=${payload[$k]}")
+    done
+
+    IMPORT_APPLY_RC=0
+    apl_feed_apply "${args[@]}" || IMPORT_APPLY_RC=$?
+
+    case "$APL_APPLY_STATUS" in
+        applied)
+            echo "import legacy-config: applied ${#APL_APPLY_CHANGED[@]} key(s)"
+            return 0
+            ;;
+        no_change)
+            echo "import legacy-config: no change"
+            return 0
+            ;;
+        rejected)
+            local rk
+            for rk in "${!APL_APPLY_ERRORS[@]}"; do
+                echo "import legacy-config: $rk: ${APL_APPLY_ERRORS[$rk]}" >&2
+            done
+            return 1
+            ;;
+        *)
+            echo "import legacy-config: apply ${APL_APPLY_STATUS:-failed}: ${APL_APPLY_ERROR_MESSAGE:-}" >&2
+            return 1
+            ;;
+    esac
+}
+
+dispatch_import() {
+    local sub="${1:-}"
+    [[ -n "$sub" ]] || die "import requires a subcommand (legacy-config)"
+    shift || true
+    case "$sub" in
+        legacy-config) apl_feed_import_legacy_config "$@" ;;
+        -h|--help) usage ;;
+        *) die "unknown import subcommand: $sub" ;;
+    esac
+}

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+
+# Tests for `apl-feed import legacy-config <path>` — translates a legacy
+# /boot/airplanes-config.txt-shaped file into the canonical feed.env
+# schema and routes the write through apl_feed_apply.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    mkdir -p "$STUB_DIR" "$ROOT_DIR/etc/airplanes"
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/configure-validators.sh"
+    # shellcheck source=../scripts/lib/feed-env-keys.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-keys.sh"
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/import.sh
+    source "$LIB_DIR/import.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    APL_TEST_LOCK_FILE="$ROOT_DIR/feed-env.lock"
+    feed_env_lock_path() { printf '%s\n' "$APL_TEST_LOCK_FILE"; }
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+import() {
+    IMPORT_RC=0
+    apl_feed_import_legacy_config "$@" || IMPORT_RC=$?
+}
+
+@test "USER=alice → MLAT_USER + MLAT_ENABLED=true" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -q '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_ENABLED=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^LATITUDE="52.5"$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "USER=0 → MLAT_USER empty + MLAT_ENABLED=false" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=0
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -q '^MLAT_USER=""$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_ENABLED=(false|"false")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "USER=disable behaves like USER=0" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=disable
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^MLAT_ENABLED=(false|"false")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "MLAT_MARKER=no → MLAT_PRIVATE=true (inverted polarity)" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+MLAT_MARKER=no
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "MLAT_MARKER=yes → MLAT_PRIVATE=false" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+MLAT_MARKER=yes
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^MLAT_PRIVATE=(false|"false")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "PRIVACY=yes wins over MLAT_MARKER=yes" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+MLAT_MARKER=yes
+PRIVACY=yes
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "GEO auto-derived from coords (non-zero → true)" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^GEO_CONFIGURED=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "GEO auto-derived from coords (0/0 → false)" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=0
+LONGITUDE=0
+ALTITUDE=120m
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^GEO_CONFIGURED=(false|"false")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "missing feed.env is auto-created" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    [ -f "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "missing path: dies" {
+    run apl_feed_import_legacy_config "$ROOT_DIR/nope.txt"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'not found'* ]]
+}
+
+@test "empty file: no recognised keys" {
+    : > "$ROOT_DIR/airplanes-config.txt"
+    run apl_feed_import_legacy_config "$ROOT_DIR/airplanes-config.txt"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'no recognised keys'* ]]
+}
+
+@test "idempotent: rerun on identical input returns no_change" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    : > "$SYSTEMCTL_LOG"
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+}
+
+@test "invalid USER (shape-mismatch) silently dropped" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=bad user with spaces
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    # MLAT_USER not present in payload → not in output.
+    ! grep -q '^MLAT_USER=' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "unsafe value (shell metachar in MLAT_USER) rejected by library" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<'EOF'
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+MLAT_USER=alice;rm -rf /
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    # The import filter drops the invalid MLAT_USER because the regex
+    # check matches the strict canonical pattern only — semicolons are
+    # excluded. The library never sees the bad value.
+    [ "$IMPORT_RC" -eq 0 ]
+    ! grep -q 'rm -rf' "$ROOT_DIR/etc/airplanes/feed.env"
+}

--- a/update.sh
+++ b/update.sh
@@ -520,6 +520,7 @@ historical_apl_feed_modules=(
     common.sh
     http.sh
     id.sh
+    import.sh
     mlat.sh
     schema.sh
     status.sh


### PR DESCRIPTION
Translates a legacy `/boot/airplanes-config.txt` (USER / MLAT_MARKER / PRIVACY shaped) into the canonical feed.env schema and writes it via `apl_feed_apply`. Legacy-key parsing lives in feed/ so the schema stays single-owned; the legacy bridge in airplanes-update (and the new image's airplanes-first-run shim) becomes a thin caller that shells in when present.

Permissive by design — an unparseable legacy value is silently dropped rather than failing the whole import, so a partial config still produces a valid (if smaller) feed.env on first boot. The universal-reject scan from `apl_feed_apply` still catches genuinely-unsafe values; the strict MLAT_USER regex catches shape-mismatched names before they reach the library.

Addresses [DEV-375]

[DEV-375]: https://airplanes-live.atlassian.net/browse/DEV-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ