### PR TITLE
Fix apl-feed import legacy-config to always target /etc/airplanes/feed.env

### DIFF
--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -49,7 +49,7 @@ Usage:
   apl-feed 978 status
   apl-feed apply [--no-restart] [--lock-timeout SECS]
   apl-feed schema
-  apl-feed import legacy-config <path>
+  apl-feed import legacy-config [--no-restart] <path>
   apl-feed backup <file>
   apl-feed restore <file>
   apl-feed restore --check <file>

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -72,8 +72,12 @@ apl_feed_import_legacy_config() {
                 ;;
             --)
                 shift
-                [[ -n "$1" ]] && path="$1"
-                shift || true
+                if [[ -n "${1:-}" ]]; then
+                    [[ -z "$path" ]] || die "import legacy-config takes exactly one path"
+                    path="$1"
+                    shift
+                fi
+                break
                 ;;
             -*) die "unknown flag for import legacy-config: $1" ;;
             *)
@@ -195,18 +199,28 @@ apl_feed_import_legacy_config() {
     feed_env_file="$(root_path '/etc/airplanes/feed.env')"
     lock_file="$(feed_env_lock_path)"
 
-    # apl_feed_apply rejects on missing feed.env. The legacy boot path
-    # may be invoked before any feed.env exists at all (e.g. on the
-    # first reboot after a bridge update) — pre-create an empty file so
-    # the library has somewhere to merge into.
-    if [[ ! -f "$feed_env_file" ]]; then
-        mkdir -p "$(dirname "$feed_env_file")"
-        : > "$feed_env_file"
-    fi
-
+    # No recognised keys in the source: nothing to write. Return BEFORE
+    # creating any file on disk — leaving an empty canonical feed.env
+    # behind would defeat the bridged-legacy fallback in feed_env_path()
+    # (status readers would see empty canonical state instead of falling
+    # back to the still-populated /boot/airplanes-config.txt).
     if (( ${#payload[@]} == 0 )); then
         echo "import legacy-config: no recognised keys in $path"
         return 0
+    fi
+
+    # apl_feed_apply rejects on missing feed.env. The legacy boot path
+    # may be invoked before any feed.env exists at all (e.g. on the
+    # first reboot after a bridge update) — pre-create an empty file so
+    # the library has somewhere to merge into. Track whether we created
+    # it so a rejected/filesystem_error apply can remove it instead of
+    # leaving an empty file behind that would suppress the legacy
+    # fallback for status readers.
+    local pre_created=0
+    if [[ ! -f "$feed_env_file" ]]; then
+        mkdir -p "$(dirname "$feed_env_file")"
+        : > "$feed_env_file"
+        pre_created=1
     fi
 
     local -a args=()
@@ -228,6 +242,18 @@ apl_feed_import_legacy_config() {
     IMPORT_APPLY_RC=0
     apl_feed_apply "${args[@]}" || IMPORT_APPLY_RC=$?
 
+    # Clean up a pre-created empty feed.env on any non-success path so the
+    # legacy fallback in feed_env_path() stays available. Only safe when
+    # we created it AND it is still empty — a concurrent writer that
+    # populated the file (under the apply lock) must not lose their
+    # write here.
+    local _import_cleanup_pre_created=0
+    if (( pre_created )) \
+        && [[ "$APL_APPLY_STATUS" != "applied" && "$APL_APPLY_STATUS" != "no_change" ]] \
+        && [[ -f "$feed_env_file" && ! -s "$feed_env_file" ]]; then
+        _import_cleanup_pre_created=1
+    fi
+
     case "$APL_APPLY_STATUS" in
         applied)
             echo "import legacy-config: applied ${#APL_APPLY_CHANGED[@]} key(s)"
@@ -242,10 +268,12 @@ apl_feed_import_legacy_config() {
             for rk in "${!APL_APPLY_ERRORS[@]}"; do
                 echo "import legacy-config: $rk: ${APL_APPLY_ERRORS[$rk]}" >&2
             done
+            (( _import_cleanup_pre_created )) && rm -f "$feed_env_file"
             return 1
             ;;
         *)
             echo "import legacy-config: apply ${APL_APPLY_STATUS:-failed}: ${APL_APPLY_ERROR_MESSAGE:-}" >&2
+            (( _import_cleanup_pre_created )) && rm -f "$feed_env_file"
             return 1
             ;;
     esac

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# `apl-feed import legacy-config <PATH>` — translate a legacy
+# `apl-feed import legacy-config [--no-restart] <PATH>` — translate a legacy
 # /boot/airplanes-config.txt-shaped file into the canonical feed.env
-# schema and write it via apl_feed_apply.
+# schema and write it via apl_feed_apply. Always targets the canonical
+# /etc/airplanes/feed.env path on the host (never the source path),
+# so a bridged-legacy box ends up with a real feed.env the new daemons
+# can source.
 #
 # Used by `airplanes-first-run` on the legacy-bridge image stack so a
 # legacy webconfig save (which still writes to /boot/airplanes-config.txt)
@@ -9,6 +12,13 @@
 # new image. Legacy-key parsing lives here so feed/ remains the sole
 # owner of the feed.env schema; airplanes-first-run becomes a thin shim
 # that detects the boot file and shells in.
+#
+# `--no-restart` suppresses the post-write service restart. airplanes-
+# first-run passes this because the legacy services have
+# `After=airplanes-first-run.service`; restarting them from inside first-
+# run would either race (Type=simple) or deadlock (Type=oneshot). The
+# caller (the webconfig save path, or systemd at boot) restarts on its
+# own schedule.
 #
 # Legacy → canonical mapping:
 #   LATITUDE / LONGITUDE / ALTITUDE          preserved as-is
@@ -52,9 +62,14 @@ _apl_feed_import_extract() {
 
 apl_feed_import_legacy_config() {
     local path=""
+    local no_restart=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -h|--help) usage; return 0 ;;
+            --no-restart)
+                no_restart=1
+                shift
+                ;;
             --)
                 shift
                 [[ -n "$1" ]] && path="$1"
@@ -170,8 +185,14 @@ apl_feed_import_legacy_config() {
         esac
     fi
 
+    # Import always writes to the canonical /etc/airplanes/feed.env, never
+    # via the feed_env_path() reader fallback. That fallback is for status
+    # readers on bridged-legacy boxes (airplanes-feeder binary present, no
+    # feed.env yet) and resolves to /boot/airplanes-config.txt — which for
+    # this writer would mean translating the source file into itself,
+    # never creating the canonical feed.env the new daemons consume.
     local feed_env_file lock_file
-    feed_env_file="$(feed_env_path)"
+    feed_env_file="$(root_path '/etc/airplanes/feed.env')"
     lock_file="$(feed_env_lock_path)"
 
     # apl_feed_apply rejects on missing feed.env. The legacy boot path
@@ -190,9 +211,15 @@ apl_feed_import_legacy_config() {
 
     local -a args=()
     args+=(--feed-env "$feed_env_file" --lock-file "$lock_file")
-    if [[ "$ROOT" != "/" ]]; then
+    # Skip restarts in three cases: explicit --no-restart from the caller
+    # (airplanes-first-run passes this so the same script doesn't try to
+    # restart units that have After=airplanes-first-run.service), or when
+    # ROOT != "/" (build-mode / tests).
+    if (( no_restart )) || [[ "$ROOT" != "/" ]]; then
         args+=(--no-restart)
-        echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+        if [[ "$ROOT" != "/" ]]; then
+            echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+        fi
     fi
     for k in "${!payload[@]}"; do
         args+=("$k=${payload[$k]}")

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -215,3 +215,67 @@ EOF
     [ "$IMPORT_RC" -eq 0 ]
     ! grep -q 'rm -rf' "$ROOT_DIR/etc/airplanes/feed.env"
 }
+
+@test "bridged-legacy box: writes canonical /etc/airplanes/feed.env, not boot config" {
+    # Reproduce the production shape that broke before: airplanes-feeder
+    # binary is present (bridge installed it), /etc/airplanes/feed.env
+    # does NOT exist yet, /boot/airplanes-config.txt does. feed_env_path()
+    # in this shape returns /boot/airplanes-config.txt as a status-reader
+    # fallback — but the import writer must always target the canonical
+    # path so the new daemons get a real feed.env to source.
+    rm -rf "$ROOT_DIR/etc/airplanes"
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+
+    cat > "$ROOT_DIR/boot/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+MLAT_MARKER=no
+EOF
+    local source_before
+    source_before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"
+
+    import "$ROOT_DIR/boot/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+
+    # Canonical target exists with imported values …
+    [ -f "$ROOT_DIR/etc/airplanes/feed.env" ]
+    grep -q '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_ENABLED=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+
+    # … and the source legacy file is untouched.
+    [ "$source_before" = "$(cat "$ROOT_DIR/boot/airplanes-config.txt")" ]
+    ! grep -q '^MLAT_USER=' "$ROOT_DIR/boot/airplanes-config.txt"
+}
+
+@test "--no-restart flag is plumbed through to apl_feed_apply" {
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    # Stub the apply call to capture its argv. The default ROOT in this
+    # test fixture (mktemp) already implicitly passes --no-restart, so we
+    # verify the explicit flag survives even when no implicit path
+    # rewrites would already inject it.
+    APPLY_ARGS_LOG="$ROOT_DIR/apply.argv"
+    : > "$APPLY_ARGS_LOG"
+    apl_feed_apply() {
+        printf '%s\n' "$*" >> "$APPLY_ARGS_LOG"
+        APL_APPLY_STATUS=no_change
+        return 0
+    }
+
+    import --no-restart "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+
+    # Single restart token in the recorded args is sufficient — implicit
+    # ROOT != / would inject one anyway, so we don't assert count, only
+    # presence.
+    grep -q -- '--no-restart' "$APPLY_ARGS_LOG"
+}

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -167,11 +167,15 @@ EOF
     [[ "$output" == *'not found'* ]]
 }
 
-@test "empty file: no recognised keys" {
+@test "empty file: no recognised keys, no canonical feed.env created" {
+    rm -rf "$ROOT_DIR/etc/airplanes"
     : > "$ROOT_DIR/airplanes-config.txt"
     run apl_feed_import_legacy_config "$ROOT_DIR/airplanes-config.txt"
     [ "$status" -eq 0 ]
     [[ "$output" == *'no recognised keys'* ]]
+    # No payload → must not create canonical feed.env, so feed_env_path()'s
+    # bridged-legacy fallback stays available for status readers.
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
 }
 
 @test "idempotent: rerun on identical input returns no_change" {
@@ -278,4 +282,83 @@ EOF
     # ROOT != / would inject one anyway, so we don't assert count, only
     # presence.
     grep -q -- '--no-restart' "$APPLY_ARGS_LOG"
+}
+
+@test "host-root: explicit --no-restart is passed, default is not" {
+    # The previous test confirmed --no-restart survives when the implicit
+    # path (ROOT != /) would also inject it. Here we pin the production
+    # shape: ROOT="/" suppresses the implicit inject, so the explicit
+    # flag (or its absence) is observable on its own.
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    APPLY_ARGS_LOG="$ROOT_DIR/apply.argv"
+    : > "$APPLY_ARGS_LOG"
+    apl_feed_apply() {
+        printf '%s\n' "$*" >> "$APPLY_ARGS_LOG"
+        APL_APPLY_STATUS=no_change
+        return 0
+    }
+    # Stub root_path so the import still resolves the target inside
+    # ROOT_DIR while ROOT is set to "/" to flip off the implicit
+    # --no-restart inject.
+    root_path() { printf '%s\n' "$ROOT_DIR$1"; }
+    ROOT="/"
+
+    : > "$APPLY_ARGS_LOG"
+    import --no-restart "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -q -- '--no-restart' "$APPLY_ARGS_LOG"
+
+    : > "$APPLY_ARGS_LOG"
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    ! grep -q -- '--no-restart' "$APPLY_ARGS_LOG"
+}
+
+@test "rejected apply does not leave empty canonical feed.env behind" {
+    rm -rf "$ROOT_DIR/etc/airplanes"
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    # Force the library to reject so we exercise the cleanup path.
+    apl_feed_apply() {
+        APL_APPLY_STATUS=rejected
+        APL_APPLY_ERRORS=()
+        APL_APPLY_ERRORS[MLAT_USER]="synthetic rejection"
+        return 2
+    }
+
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -ne 0 ]
+    # Pre-created empty canonical file must be cleaned up so the bridged-
+    # legacy fallback (feed_env_path() → /boot/airplanes-config.txt) stays
+    # available to status readers.
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+}
+
+@test "apl-feed import legacy-config --  is set-u-safe with no path" {
+    # Regression for the unquoted $1 deref after shift past --. Production
+    # apl-feed.sh runs under set -euo pipefail; this test simulates that
+    # discipline in a sub-shell.
+    run bash -c '
+set -euo pipefail
+source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/configure-validators.sh"
+source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-keys.sh"
+source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-apply.sh"
+source "'"$BATS_TEST_DIRNAME"'/../scripts/apl-feed/common.sh"
+source "'"$BATS_TEST_DIRNAME"'/../scripts/apl-feed/import.sh"
+ROOT='"$ROOT_DIR"'
+apl_feed_import_legacy_config -- 2>&1 || rc=$?
+echo "rc=${rc:-0}"
+'
+    [[ "$output" == *'usage:'* || "$output" == *'not found'* || "$output" == *'rc='* ]]
+    # The critical check: no "unbound variable" error.
+    ! [[ "$output" == *'unbound variable'* ]]
 }


### PR DESCRIPTION
On a bridged-legacy box (airplanes-feeder binary present, no /etc/airplanes/feed.env yet, /boot/airplanes-config.txt populated by the legacy webconfig), feed_env_path() returns /boot/airplanes-config.txt — its status-reader fallback shape — so apl_feed_import_legacy_config was passing the source file as the apply target. The import would have rewritten the legacy boot file in canonical form and never produced the /etc/airplanes/feed.env that the new daemons source. Import now resolves the target with an explicit root_path '/etc/airplanes/feed.env' so the writer always lands on the canonical path.

Adds --no-restart so callers that already own service restart (airplanes-first-run on the legacy bridge, future installers chaining apply calls) can skip the inner restart. Without this an inner restart races or deadlocks against units that have After=airplanes-first-run.service.

Addresses #3