### PR TITLE
Route all feed.env writers through a canonical-only resolver

### DIFF
--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -130,6 +130,18 @@ feed_env_path() {
     root_path '/etc/airplanes/feed.env'
 }
 
+# Canonical write target for feed.env. Always /etc/airplanes/feed.env
+# under ROOT, regardless of what's currently on disk. Distinct from
+# feed_env_path() — which has a bridged-legacy fallback to
+# /boot/airplanes-config.txt for status readers when no canonical file
+# exists yet. Writers must NOT use that fallback: translating the legacy
+# source file into itself never produces the canonical feed.env that
+# the new daemons source. apl-feed/import.sh, apl-feed/mlat.sh, and
+# apl-feed/uat.sh all pass this to apl_feed_apply via --feed-env.
+feed_env_write_path() {
+    root_path '/etc/airplanes/feed.env'
+}
+
 feed_env_paths() {
     if [[ -f "$(root_path '/etc/airplanes/feed.env')" ]]; then
         root_path '/etc/airplanes/feed.env'

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -142,6 +142,45 @@ feed_env_write_path() {
     root_path '/etc/airplanes/feed.env'
 }
 
+# Bootstrap the canonical feed.env from a bridged-legacy boot config when
+# canonical is missing. Idempotent: no-op when canonical already exists.
+# Detection mirrors feed_env_path()'s legacy fallback: airplanes-feeder
+# binary installed (bridge ran) + /boot/airplanes-config.txt present.
+#
+# Without this, every apl-feed writer (mlat, uat, eventually configure
+# wrappers) would error out with "feed.env not found" on a bridged-legacy
+# box even though the legacy source carries all the operational keys.
+# Auto-bootstrap calls apl_feed_import_legacy_config (which must be in
+# scope — apl-feed.sh sources scripts/apl-feed/import.sh after common.sh
+# so this is satisfied in production) with --no-restart, since writer
+# callers own the post-write restart themselves.
+#
+# Errors from the bootstrap propagate to the caller so the writer can
+# decide whether to continue with a fresh canonical or abort. Returns 0
+# in the non-bridged-legacy case so a manual-install box with a missing
+# feed.env hits apl_feed_apply's normal filesystem_error path — the
+# operator there is expected to run setup/install first, not import.
+feed_env_ensure_canonical_for_write() {
+    local canonical
+    canonical="$(feed_env_write_path)"
+    [[ -f "$canonical" ]] && return 0
+
+    local boot_config feeder_binary
+    boot_config="$(root_path '/boot/airplanes-config.txt')"
+    feeder_binary="$(root_path '/usr/bin/airplanes-feeder')"
+    if [[ ! -x "$feeder_binary" || ! -f "$boot_config" ]]; then
+        return 0
+    fi
+
+    if ! declare -F apl_feed_import_legacy_config >/dev/null; then
+        echo "feed_env_ensure_canonical_for_write: apl_feed_import_legacy_config not in scope — source apl-feed/import.sh before invoking writers" >&2
+        return 0
+    fi
+
+    echo "Bootstrapping canonical feed.env from $boot_config" >&2
+    apl_feed_import_legacy_config --no-restart "$boot_config"
+}
+
 feed_env_paths() {
     if [[ -f "$(root_path '/etc/airplanes/feed.env')" ]]; then
         root_path '/etc/airplanes/feed.env'

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -155,11 +155,11 @@ feed_env_write_path() {
 # so this is satisfied in production) with --no-restart, since writer
 # callers own the post-write restart themselves.
 #
-# Errors from the bootstrap propagate to the caller so the writer can
-# decide whether to continue with a fresh canonical or abort. Returns 0
-# in the non-bridged-legacy case so a manual-install box with a missing
-# feed.env hits apl_feed_apply's normal filesystem_error path — the
-# operator there is expected to run setup/install first, not import.
+# Always returns 0 so bare callers under apl-feed.sh's `set -euo pipefail`
+# don't exit before _mlat_emit_result / _uat_emit_result can surface a
+# structured error. A failed bootstrap is logged to stderr; the caller's
+# subsequent apl_feed_apply then produces a structured filesystem_error
+# because canonical still doesn't exist — the user sees both lines.
 feed_env_ensure_canonical_for_write() {
     local canonical
     canonical="$(feed_env_write_path)"
@@ -178,7 +178,12 @@ feed_env_ensure_canonical_for_write() {
     fi
 
     echo "Bootstrapping canonical feed.env from $boot_config" >&2
-    apl_feed_import_legacy_config --no-restart "$boot_config"
+    local rc=0
+    apl_feed_import_legacy_config --no-restart "$boot_config" || rc=$?
+    if (( rc != 0 )); then
+        echo "feed_env_ensure_canonical_for_write: bootstrap import failed rc=$rc; the writer's apply will surface a structured filesystem_error next" >&2
+    fi
+    return 0
 }
 
 feed_env_paths() {

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -189,14 +189,11 @@ apl_feed_import_legacy_config() {
         esac
     fi
 
-    # Import always writes to the canonical /etc/airplanes/feed.env, never
-    # via the feed_env_path() reader fallback. That fallback is for status
-    # readers on bridged-legacy boxes (airplanes-feeder binary present, no
-    # feed.env yet) and resolves to /boot/airplanes-config.txt — which for
-    # this writer would mean translating the source file into itself,
-    # never creating the canonical feed.env the new daemons consume.
+    # feed_env_write_path() is canonical-only; never resolves to the
+    # bridged-legacy fallback /boot/airplanes-config.txt (which would
+    # mean translating the source file into itself).
     local feed_env_file lock_file
-    feed_env_file="$(root_path '/etc/airplanes/feed.env')"
+    feed_env_file="$(feed_env_write_path)"
     lock_file="$(feed_env_lock_path)"
 
     # No recognised keys in the source: nothing to write. Return BEFORE

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -65,7 +65,7 @@ _mlat_emit_result() {
 # can surface the structured error to the operator.
 _mlat_apply() {
     local -a args=()
-    args+=(--feed-env "$(feed_env_path)")
+    args+=(--feed-env "$(feed_env_write_path)")
     args+=(--lock-file "$(feed_env_lock_path)")
     if [[ "$ROOT" != "/" ]]; then
         args+=(--no-restart)

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -64,6 +64,7 @@ _mlat_emit_result() {
 # apl-feed.sh, so a non-zero return here would exit before _mlat_emit_result
 # can surface the structured error to the operator.
 _mlat_apply() {
+    feed_env_ensure_canonical_for_write
     local -a args=()
     args+=(--feed-env "$(feed_env_write_path)")
     args+=(--lock-file "$(feed_env_lock_path)")
@@ -120,6 +121,12 @@ apl_feed_mlat_enable() {
             0) die "unknown flag for mlat enable: $1" ;;
         esac
     done
+
+    # Bootstrap canonical feed.env first so the geo-gate below reads
+    # imported state on a bridged-legacy box rather than firing
+    # "feed.env not found" or "GEO_CONFIGURED=<unset>" against the
+    # never-canonicalised legacy file.
+    feed_env_ensure_canonical_for_write
 
     local feed_env
     feed_env="$(feed_env_path)"

--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -107,7 +107,7 @@ _uat_emit_result() {
 
 _uat_apply() {
     local -a args=()
-    args+=(--feed-env "$(feed_env_path)")
+    args+=(--feed-env "$(feed_env_write_path)")
     args+=(--lock-file "$(feed_env_lock_path)")
     if [[ "$ROOT" != "/" ]]; then
         args+=(--no-restart)

--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -106,6 +106,7 @@ _uat_emit_result() {
 }
 
 _uat_apply() {
+    feed_env_ensure_canonical_for_write
     local -a args=()
     args+=(--feed-env "$(feed_env_write_path)")
     args+=(--lock-file "$(feed_env_lock_path)")

--- a/test/test_apl_feed_bridged_legacy_bootstrap.bats
+++ b/test/test_apl_feed_bridged_legacy_bootstrap.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+# End-to-end regression for the bridged-legacy bootstrap path:
+# `apl-feed mlat enable` / `apl-feed mlat disable` / `apl-feed 978 enable`
+# / `apl-feed 978 disable` on a box where /usr/bin/airplanes-feeder is
+# present, /boot/airplanes-config.txt is populated by the legacy PHP
+# webconfig, and /etc/airplanes/feed.env does NOT yet exist. The writer
+# adapters call feed_env_ensure_canonical_for_write() before invoking
+# apl_feed_apply, which calls apl_feed_import_legacy_config to seed the
+# canonical file from the legacy source. apl_feed_apply is real here —
+# no stub — so the assertions verify actual canonical state after the
+# command, not just the resolver inputs.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    mkdir -p "$STUB_DIR"
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/configure-validators.sh"
+    # shellcheck source=../scripts/lib/feed-env-keys.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-keys.sh"
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/import.sh
+    source "$LIB_DIR/import.sh"
+    # shellcheck source=../scripts/apl-feed/mlat.sh
+    source "$LIB_DIR/mlat.sh"
+    # shellcheck source=../scripts/apl-feed/uat.sh
+    source "$LIB_DIR/uat.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    APL_TEST_LOCK_FILE="$ROOT_DIR/feed-env.lock"
+    feed_env_lock_path() { printf '%s\n' "$APL_TEST_LOCK_FILE"; }
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+case "\$1" in
+    is-active) echo active ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+
+    # Bridged-legacy shape: airplanes-feeder installed, no canonical
+    # feed.env, legacy boot config carrying operational keys.
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot" "$ROOT_DIR/etc/airplanes"
+    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    cat > "$ROOT_DIR/boot/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+MLAT_MARKER=no
+EOF
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+@test "mlat disable on bridged-legacy: bootstrap + canonical write, legacy untouched" {
+    local source_before
+    source_before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
+
+    apl_feed_mlat_disable
+
+    [ -f "$ROOT_DIR/etc/airplanes/feed.env" ]
+    grep -qE '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_ENABLED=(false|"false")$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^LATITUDE="?52\.5"?$' "$ROOT_DIR/etc/airplanes/feed.env"
+
+    # Source legacy file must be byte-unchanged: the writer must never
+    # rewrite the bridged-legacy reader-fallback target.
+    [ "$source_before" = "$(cat "$ROOT_DIR/boot/airplanes-config.txt")" ]
+}
+
+@test "mlat enable on bridged-legacy: bootstrap satisfies geo-gate" {
+    # Before the bootstrap helper landed, mlat enable on this shape died
+    # with "GEO_CONFIGURED=<unset>" before it ever reached the writer.
+    local source_before
+    source_before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"
+
+    apl_feed_mlat_enable
+
+    [ -f "$ROOT_DIR/etc/airplanes/feed.env" ]
+    grep -qE '^MLAT_ENABLED=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^GEO_CONFIGURED=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qE '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ "$source_before" = "$(cat "$ROOT_DIR/boot/airplanes-config.txt")" ]
+}
+
+@test "978 disable on bridged-legacy: bootstrap then write canonical UAT_INPUT" {
+    # Seed the fixture with a canonical UAT_INPUT so the bootstrap carries
+    # it through, then 978 disable clears it.
+    cat >> "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
+UAT_INPUT=127.0.0.1:30978
+EOF
+    local source_before
+    source_before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"
+
+    apl_feed_uat_disable
+
+    [ -f "$ROOT_DIR/etc/airplanes/feed.env" ]
+    grep -qE '^UAT_INPUT=""?$' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ "$source_before" = "$(cat "$ROOT_DIR/boot/airplanes-config.txt")" ]
+}
+
+@test "second invocation is idempotent: no double-bootstrap, canonical reused" {
+    apl_feed_mlat_disable
+    local feed_env_first
+    feed_env_first="$(cat "$ROOT_DIR/etc/airplanes/feed.env")"
+
+    # Second call reads canonical, no bootstrap needed.
+    apl_feed_mlat_disable
+
+    local feed_env_second
+    feed_env_second="$(cat "$ROOT_DIR/etc/airplanes/feed.env")"
+    [ "$feed_env_first" = "$feed_env_second" ]
+}

--- a/test/test_apl_feed_bridged_legacy_bootstrap.bats
+++ b/test/test_apl_feed_bridged_legacy_bootstrap.bats
@@ -130,3 +130,32 @@ EOF
     feed_env_second="$(cat "$ROOT_DIR/etc/airplanes/feed.env")"
     [ "$feed_env_first" = "$feed_env_second" ]
 }
+
+@test "bootstrap failure under set -e does not exit before structured error" {
+    # apl-feed.sh runs set -euo pipefail. A bare feed_env_ensure_canonical_
+    # for_write that returned non-zero on bootstrap failure would exit the
+    # script before _mlat_emit_result could surface the structured error
+    # to the operator. Verify the helper always returns 0 so the bare-call
+    # writers stay set-e-safe.
+    rm -rf "$ROOT_DIR/etc/airplanes"
+    # Stub the import to force a failure path.
+    apl_feed_import_legacy_config() { return 1; }
+
+    run bash -c '
+set -euo pipefail
+source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/configure-validators.sh"
+source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-keys.sh"
+source "'"$BATS_TEST_DIRNAME"'/../scripts/apl-feed/common.sh"
+ROOT='"$ROOT_DIR"'
+mkdir -p "$ROOT/usr/bin" "$ROOT/boot"
+: > "$ROOT/usr/bin/airplanes-feeder"
+chmod +x "$ROOT/usr/bin/airplanes-feeder"
+: > "$ROOT/boot/airplanes-config.txt"
+apl_feed_import_legacy_config() { return 1; }
+feed_env_ensure_canonical_for_write
+echo "survived: rc=$?"
+'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'survived: rc=0'* ]]
+    [[ "$output" == *'bootstrap import failed'* ]]
+}

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -146,6 +146,7 @@ EOF
     # Override feed_env_path to point inside ROOT_DIR (the helper resolves
     # off /etc/airplanes which would be the host's real path with ROOT='/').
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_disable
@@ -159,6 +160,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_enable
@@ -172,6 +174,7 @@ EOF
     write_feed_env "" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_enable
@@ -185,6 +188,7 @@ EOF
     write_feed_env "" "true"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_disable
@@ -199,6 +203,7 @@ EOF
     write_feed_env "william34-london" "true"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_disable
@@ -215,6 +220,7 @@ EOF
 @test "missing feed.env: enable dies with documented message" {
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
 
@@ -234,6 +240,7 @@ EOF
     AIRPLANES_BUILD_MODE=1
     export AIRPLANES_BUILD_MODE
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_disable
@@ -246,6 +253,7 @@ EOF
 @test "ROOT != / skips the systemctl restart (file edits still happen)" {
     write_feed_env "alice" "true"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_disable
@@ -284,6 +292,7 @@ EOF
     write_feed_env_with_private "alice" "true" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_private_enable
@@ -299,6 +308,7 @@ EOF
     write_feed_env_with_private "alice" "true" "true"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_private_disable
@@ -313,6 +323,7 @@ EOF
     write_feed_env_with_private "alice" "true" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_private_enable
@@ -328,6 +339,7 @@ EOF
 @test "private enable: missing feed.env dies with documented message" {
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     [ ! -e "$ROOT_DIR/etc/airplanes/feed.env" ]
 
@@ -343,6 +355,7 @@ EOF
     write_feed_env_with_private "alice" "true" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_private_enable
@@ -357,6 +370,7 @@ EOF
     AIRPLANES_BUILD_MODE=1
     export AIRPLANES_BUILD_MODE
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_private_enable
@@ -372,6 +386,7 @@ EOF
     write_feed_env_no_geo_flag "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_enable
@@ -395,6 +410,7 @@ ALTITUDE="35m"
 EOF
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_enable
@@ -407,6 +423,7 @@ EOF
     write_feed_env_no_axis "alice" "false" LATITUDE
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_enable
@@ -419,6 +436,7 @@ EOF
     write_feed_env_no_axis "alice" "false" ALTITUDE
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_enable
@@ -433,6 +451,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_user bob-123
@@ -446,6 +465,7 @@ EOF
     write_feed_env "alice" "true"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_user --clear
@@ -458,6 +478,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_user "alice rabbit"
@@ -471,6 +492,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     local long
@@ -487,6 +509,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_user 'bad$name'
@@ -499,6 +522,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_user --clear bob
@@ -511,6 +535,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_user
@@ -525,6 +550,7 @@ EOF
     write_feed_env_no_geo_flag "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_geo 48.137 11.575 520m
@@ -541,6 +567,7 @@ EOF
     write_feed_env_no_geo_flag "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_geo 0 0 0m
@@ -552,6 +579,7 @@ EOF
     write_feed_env_no_geo_flag "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_mlat_geo 0.0 -0 0m
@@ -563,6 +591,7 @@ EOF
     write_feed_env_no_geo_flag "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_geo 91 0 0m
@@ -577,6 +606,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_mlat_geo 52.5 13.4
@@ -594,6 +624,7 @@ EOF
     write_feed_env "alice" "false"
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     # bats's run captures stdin from a pipe so [[ -t 0 ]] is false.
@@ -626,6 +657,39 @@ EOF
     "
     [ "$status" -ne 0 ]
     [[ "$output" == *'exactly three positional args'* ]]
+}
+
+@test "bridged-legacy: _mlat_apply targets canonical feed.env, not boot config" {
+    # Reproduce the bridged-legacy reader-fallback shape: airplanes-feeder
+    # is installed, /boot/airplanes-config.txt exists, /etc/airplanes/
+    # feed.env does not. Before feed_env_write_path() was introduced,
+    # _mlat_apply called feed_env_path() and would have asked the apply
+    # library to rewrite /boot/airplanes-config.txt itself.
+    rm -rf "$ROOT_DIR/etc/airplanes"
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
+LATITUDE=52.5
+USER=alice
+MLAT_MARKER=yes
+EOF
+    local before
+    before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"
+
+    APPLY_ARGS=""
+    apl_feed_apply() {
+        APPLY_ARGS="$*"
+        APL_APPLY_STATUS=no_change
+        return 0
+    }
+
+    apl_feed_mlat_disable
+
+    [[ "$APPLY_ARGS" == *"--feed-env $ROOT_DIR/etc/airplanes/feed.env"* ]]
+    [[ "$APPLY_ARGS" != *"--feed-env $ROOT_DIR/boot/airplanes-config.txt"* ]]
+    # Source legacy file must not be touched by the resolver.
+    [ "$before" = "$(cat "$ROOT_DIR/boot/airplanes-config.txt")" ]
 }
 
 # --- setup helper (single 7-key transaction) ---

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -334,13 +334,15 @@ EOF
 @test "bridged-legacy: _uat_apply targets canonical feed.env, not boot config" {
     # Same shape as the mlat bridged-legacy regression — guards against
     # the writer side resolving via feed_env_path()'s reader fallback
-    # when feed.env doesn't exist yet on a bridged box.
+    # when feed.env doesn't exist yet on a bridged box. Uses a canonical
+    # key (UAT_INPUT) that apl_feed_import_legacy_config understands so
+    # this fixture is also a valid input to that command.
     rm -rf "$ROOT_DIR/etc/airplanes"
     mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
     : > "$ROOT_DIR/usr/bin/airplanes-feeder"
     chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
-DUMP978=yes
+UAT_INPUT=127.0.0.1:30978
 EOF
     local before
     before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -124,6 +124,7 @@ EOF
     write_feed_env
     ROOT="/"  # exercise systemctl path; PATH-stub captures it
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_uat_enable
     [ "$status" -eq 0 ]
@@ -135,6 +136,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     mark_unit_installed dump978-fa
     mark_unit_installed airplanes-978
 
@@ -148,6 +150,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     # INSTALLED_UNITS_FILE is empty — neither dump978-fa nor airplanes-978
     # is present. The restart for those must be skipped (not attempted).
 
@@ -167,6 +170,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_uat_enable --serial "00000978" --gain "40.0"
     [ "$status" -eq 0 ]
@@ -178,6 +182,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     # Seed both knobs so we can confirm disable doesn't wipe them.
     apl_feed_uat_enable --serial "00000978" --gain "40.0"
     : > "$SYSTEMCTL_LOG"
@@ -195,6 +200,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_uat_enable --serial "978" --gain "42.1"
 
@@ -208,6 +214,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     apl_feed_uat_enable
     apl_feed_uat_enable
@@ -222,6 +229,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_uat_enable --serial 'evil;rm -rf /'
     [ "$status" -ne 0 ]
@@ -235,6 +243,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_uat_enable --serial "$(printf 'a%.0s' {1..33})"
     [ "$status" -ne 0 ]
@@ -245,6 +254,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_uat_enable --gain "61"
     [ "$status" -ne 0 ]
@@ -259,6 +269,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
 
     run apl_feed_uat_enable --serial "00000978"
     [ "$status" -eq 0 ]
@@ -299,6 +310,7 @@ EOF
     write_feed_env
     ROOT="/"
     feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
     apl_feed_uat_enable --serial "00000978" --gain "40.0"
 
@@ -317,4 +329,32 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *'dump978-fa'*'not installed (image-only)'* ]]
     [[ "$output" == *'airplanes-978'*'not installed (image-only)'* ]]
+}
+
+@test "bridged-legacy: _uat_apply targets canonical feed.env, not boot config" {
+    # Same shape as the mlat bridged-legacy regression — guards against
+    # the writer side resolving via feed_env_path()'s reader fallback
+    # when feed.env doesn't exist yet on a bridged box.
+    rm -rf "$ROOT_DIR/etc/airplanes"
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
+DUMP978=yes
+EOF
+    local before
+    before="$(cat "$ROOT_DIR/boot/airplanes-config.txt")"
+
+    APPLY_ARGS=""
+    apl_feed_apply() {
+        APPLY_ARGS="$*"
+        APL_APPLY_STATUS=no_change
+        return 0
+    }
+
+    apl_feed_uat_disable
+
+    [[ "$APPLY_ARGS" == *"--feed-env $ROOT_DIR/etc/airplanes/feed.env"* ]]
+    [[ "$APPLY_ARGS" != *"--feed-env $ROOT_DIR/boot/airplanes-config.txt"* ]]
+    [ "$before" = "$(cat "$ROOT_DIR/boot/airplanes-config.txt")" ]
 }


### PR DESCRIPTION
Adds feed_env_write_path() in scripts/apl-feed/common.sh and switches the three writer callsites (import, mlat, uat) off feed_env_path(). The reader-side helper has a bridged-legacy fallback to /boot/airplanes-config.txt for status readers when the canonical file does not yet exist — correct there, wrong for writers, since translating the legacy source file into itself never produces the canonical feed.env the new daemons source. import.sh got this right after #68; this aligns mlat and uat with the same shape. Two regression tests pin the new behavior on a bridged-legacy fixture.

Addresses #3