### PR TITLE
Make apl-feed import permissive on bad values and recognise --privacy

### DIFF
--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -126,8 +126,14 @@ apl_feed_import_legacy_config() {
     )
     local k validator
     for k in LATITUDE LONGITUDE ALTITUDE GAIN UAT_INPUT DUMP978_SDR_SERIAL DUMP978_GAIN; do
+        # Gate on key PRESENCE, not value non-emptiness. valid_uat_input,
+        # valid_dump978_serial, and valid_mlat_user accept empty as a
+        # meaningful payload (clear the key). A legacy file containing
+        # `UAT_INPUT=` should propagate that as MLAT_INPUT="" so 978-
+        # disable saves on the legacy webconfig actually clear the daemon
+        # state — a value-non-empty gate would silently drop those.
+        grep -qE "^${k}=" "$path" || continue
         v="$(_apl_feed_import_extract "$path" "$k")"
-        [[ -n "$v" ]] || continue
         validator="${_import_validators[$k]}"
         if "$validator" "$v" >/dev/null 2>&1; then
             payload[$k]="$v"

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -79,22 +79,25 @@ apl_feed_import_legacy_config() {
                 fi
                 break
                 ;;
-            -*) die "unknown flag for import legacy-config: $1" ;;
-            *)
+            -*)
+                # parse_common_option owns --root, --server-url, etc.
+                # Check it BEFORE rejecting as unknown so chroot / build /
+                # test callers can pass `--root /mnt` to redirect paths.
                 local opt_rc
                 if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
                 case "$opt_rc" in
                     1) shift ;;
                     2) shift 2 ;;
-                    0)
-                        if [[ -z "$path" ]]; then
-                            path="$1"
-                            shift
-                        else
-                            die "import legacy-config takes exactly one path"
-                        fi
-                        ;;
+                    0) die "unknown flag for import legacy-config: $1" ;;
                 esac
+                ;;
+            *)
+                if [[ -z "$path" ]]; then
+                    path="$1"
+                    shift
+                else
+                    die "import legacy-config takes exactly one path"
+                fi
                 ;;
         esac
     done
@@ -105,12 +108,31 @@ apl_feed_import_legacy_config() {
     local -A payload=()
     local v
 
-    # Geo + gain + 978 keys: passthrough.
-    local k
+    # Geo + gain + 978 keys: passthrough through the matching validator
+    # so a legacy file with a stray bad value (e.g. GAIN=bad) doesn't
+    # fail the entire import. The library would have rejected the whole
+    # payload — costing the operator every other valid setting that was
+    # otherwise importable. configure-validators.sh is sourced upstream
+    # by apl-feed.sh; the fallback messaging there fires if the lib was
+    # not installed.
+    declare -A _import_validators=(
+        [LATITUDE]=valid_latitude
+        [LONGITUDE]=valid_longitude
+        [ALTITUDE]=valid_altitude
+        [GAIN]=valid_gain
+        [UAT_INPUT]=valid_uat_input
+        [DUMP978_SDR_SERIAL]=valid_dump978_serial
+        [DUMP978_GAIN]=valid_dump978_gain
+    )
+    local k validator
     for k in LATITUDE LONGITUDE ALTITUDE GAIN UAT_INPUT DUMP978_SDR_SERIAL DUMP978_GAIN; do
         v="$(_apl_feed_import_extract "$path" "$k")"
-        if [[ -n "$v" ]]; then
+        [[ -n "$v" ]] || continue
+        validator="${_import_validators[$k]}"
+        if "$validator" "$v" >/dev/null 2>&1; then
             payload[$k]="$v"
+        else
+            echo "import legacy-config: skipping $k=$v (invalid per $validator)" >&2
         fi
     done
 
@@ -162,12 +184,19 @@ apl_feed_import_legacy_config() {
         esac
     fi
     # PRIVACY → MLAT_PRIVATE. Wins over MLAT_MARKER when both are present.
+    # Legacy configs encode privacy in several shapes: yes/true/1 from
+    # generic forms, and `--privacy` cargo-culted from old documentation
+    # that suggested adding it as an mlat-client flag. All map to true.
+    # Unknown values are silently dropped rather than falling back to
+    # false — silently flipping a previously-private feeder to public
+    # on migration is the wrong failure mode.
     if grep -qE '^PRIVACY=' "$path"; then
         local privacy
         privacy="$(_apl_feed_import_extract "$path" PRIVACY)"
         case "$privacy" in
-            yes|true|1) payload[MLAT_PRIVATE]="true" ;;
-            *)          payload[MLAT_PRIVATE]="false" ;;
+            yes|true|1|--privacy) payload[MLAT_PRIVATE]="true" ;;
+            no|false|0|"")        payload[MLAT_PRIVATE]="false" ;;
+            *) echo "import legacy-config: unrecognised PRIVACY value '$privacy'; leaving MLAT_PRIVATE unchanged" >&2 ;;
         esac
     fi
     # MLAT_PRIVATE passthrough wins over both.

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -424,6 +424,31 @@ EOF
     grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
+@test "empty UAT_INPUT propagates as cleared key (legacy 978-disable save)" {
+    # Regression: previously the import gated on value non-emptiness, so
+    # a legacy save that wrote `UAT_INPUT=` (clear 978) was dropped on
+    # the floor and the daemon kept running with the stale endpoint.
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE="52.5"
+LONGITUDE="13.4"
+ALTITUDE="120m"
+MLAT_USER="alice"
+MLAT_ENABLED=true
+GEO_CONFIGURED=true
+UAT_INPUT="127.0.0.1:30978"
+EOF
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+UAT_INPUT=
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^UAT_INPUT=""?$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
 @test "invalid passthrough value (GAIN=bad) is skipped, valid keys still import" {
     # Before this validation, GAIN=bad would make apl_feed_apply reject
     # the entire payload — the user would lose every other valid

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -362,3 +362,84 @@ echo "rc=${rc:-0}"
     # The critical check: no "unbound variable" error.
     ! [[ "$output" == *'unbound variable'* ]]
 }
+
+@test "--root <path> from parse_common_option is accepted, not rejected" {
+    # Regression for an earlier ordering bug: the -* arm fired before
+    # parse_common_option, so chroot / build callers could not pass
+    # --root /mnt and the restart-skip implicit path was unreachable.
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+EOF
+    APPLY_ARGS_LOG="$ROOT_DIR/apply.argv"
+    : > "$APPLY_ARGS_LOG"
+    apl_feed_apply() {
+        printf '%s\n' "$*" >> "$APPLY_ARGS_LOG"
+        APL_APPLY_STATUS=no_change
+        return 0
+    }
+
+    import --root "$ROOT_DIR" "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    # parse_common_option set ROOT=$ROOT_DIR; non-host implicit path
+    # then adds --no-restart.
+    [ "$ROOT" = "$ROOT_DIR" ]
+    grep -q -- '--no-restart' "$APPLY_ARGS_LOG"
+}
+
+@test "PRIVACY=--privacy maps to MLAT_PRIVATE=true" {
+    # Regression: legacy configs that encoded privacy as `--privacy`
+    # (cargo-culted from old mlat-client flag documentation) used to
+    # fall through to the catch-all and turn previously-private feeders
+    # public on migration.
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+PRIVACY=--privacy
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "PRIVACY=unrecognised does NOT silently flip privacy off" {
+    # Sets MLAT_MARKER=no (privacy ON) first, then PRIVACY=garble. The
+    # old catch-all behavior would have turned this into MLAT_PRIVATE=
+    # false on migration. The new behavior keeps MLAT_PRIVATE=true via
+    # the MLAT_MARKER mapping and ignores the unrecognised PRIVACY.
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+MLAT_MARKER=no
+PRIVACY=garble
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -qE '^MLAT_PRIVATE=(true|"true")$' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "invalid passthrough value (GAIN=bad) is skipped, valid keys still import" {
+    # Before this validation, GAIN=bad would make apl_feed_apply reject
+    # the entire payload — the user would lose every other valid
+    # setting along with the bad one. The import is permissive by
+    # design: skip invalid values, log to stderr, apply the rest.
+    cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
+LATITUDE=52.5
+LONGITUDE=13.4
+ALTITUDE=120m
+USER=alice
+GAIN=bad
+EOF
+    import "$ROOT_DIR/airplanes-config.txt"
+    [ "$IMPORT_RC" -eq 0 ]
+    grep -q '^MLAT_USER="alice"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^LATITUDE="52.5"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    # GAIN was skipped, never written.
+    ! grep -q '^GAIN=' "$ROOT_DIR/etc/airplanes/feed.env"
+}


### PR DESCRIPTION
Three independent fixes to apl-feed import legacy-config surfaced by external review. parse_common_option moved above the unknown-flag rejection so --root /mnt is no longer rejected before being parsed; chroot, build-mode, and test callers can now redirect paths. Legacy configs sometimes encode privacy as PRIVACY=--privacy (cargo-culted from old mlat-client documentation) — that now maps to MLAT_PRIVATE=true so previously-private feeders don't silently flip public on migration, and unknown PRIVACY values are dropped rather than coerced to false. Passthrough keys (LATITUDE, LONGITUDE, ALTITUDE, GAIN, UAT_INPUT, DUMP978_SDR_SERIAL, DUMP978_GAIN) are validated per-key against configure-validators.sh and skipped on failure with a stderr note, so one bad legacy value no longer fails the whole import.

Addresses #3