### PR TITLE
Clean up apl-feed CLI and image-install marker on uninstall

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -18,11 +18,18 @@ Both `update.sh` (long block before `airplanes_enable_build_mode_from_args "$@"`
 
 ## `AIRPLANES_FEED_BRANCH` release-channel mechanism
 
-In `update.sh`'s fallback block, the variable defaults via `/etc/airplanes/release-channel`:
+`update.sh` and `install-update-common.sh` resolve `AIRPLANES_FEED_BRANCH` via `/etc/airplanes/release-channel`:
 
-- `update.sh` reads that file to pin the runtime-update branch on image-built feeders. Allowlist is `{main, dev}`. Invalid value aborts (intentional — silent fallback to `main` on a `dev` image is a sticky regression).
-- An **explicit `AIRPLANES_FEED_BRANCH` env var bypasses the allowlist** — the env var wins. There's a corresponding test in `test_install_update_common.bats` that pins this.
-- **`install.sh`'s standalone fallback hardcodes `AIRPLANES_FEED_BRANCH=main`** and does NOT read the release-channel file. Only `update.sh` does. (Fine in practice: `install.sh` runs once at install time on a fresh box that has no release-channel marker yet.)
+- Allowlist is `{stable, dev, main}`. `main` is a **legacy alias for `stable`** — pre-stable-release images may have written `main` to the file before tag resolution existed; treating it as `stable` keeps those images updatable without re-flashing. Invalid value aborts (intentional — silent fallback to `main` on a `dev` image is a sticky regression).
+- `stable` is a **sentinel**, not a branch name. After bootstrap deps install, `airplanes_resolve_feed_branch` calls `airplanes_resolve_latest_stable_tag` (which runs `git ls-remote --tags`) to resolve `stable` → the latest `v[MAJOR].[MINOR].[PATCH]` tag. Strict semver only; leading zeroes and prereleases are filtered out. Resolution happens **after** the `apt`/`dnf` step so curl-pipe-bash can reach deps install before any network resolution. Resolved value is exported so the resolved tag survives `update.sh`'s self-replace re-exec — without that, a transient `ls-remote` failure between invocations could thrash between tags.
+- An **explicit `AIRPLANES_FEED_BRANCH` env var bypasses this entire mechanism**. Operators can pin any ref for testing/recovery; the bridge can override; image build tooling can pin a specific branch. Pinned in `test_install_update_common.bats`.
+- **`install.sh`'s standalone fallback is rendered at release time.** `__FEED_REF__` (line 25) is a substitution marker; the release pipeline (`.github/workflows/release.yml`) replaces it with the tag string at build time, so the published `install.sh` pins to a specific tag. Unrendered (e.g. running raw from a clone) it falls back to `main`. The inline fallback does **not** read the release-channel file; only `update.sh` does. Fine in practice — `install.sh` runs once at install time on a fresh box.
+
+### Legacy bridge gap — DEV-375
+
+**The tag-resolution mechanism above is feed-side only.** The legacy bridge in `airplanes-update/update-airplanes.sh` still pins `AIRPLANES_FEED_BRANCH` to a concrete branch name (`main` or `dev`, auto-detected from its own checkout). That bypasses the release-channel allowlist entirely — legacy-image feeders updating via the bridge today track `main` HEAD, not the latest stable tag, even after a tagged release is cut.
+
+DEV-375 closes this in `airplanes-update/`: the bridge should write `release-channel=stable` (if absent) and unset its own `AIRPLANES_FEED_BRANCH`, deferring to the feed-side resolution. Until that ships, anyone debugging "why didn't this tagged release land on legacy feeders?" can stop looking in `feed/` — the resolution code is in place, but the bridge isn't routing through it yet.
 
 ## `scripts/lib/` extraction discipline
 

--- a/test/test_install_uninstall_symmetry.bats
+++ b/test/test_install_uninstall_symmetry.bats
@@ -220,16 +220,7 @@ run_uninstall() {
     [ "$before_listing" = "$after_listing" ]
 }
 
-# --- Known install↔uninstall drift -------------------------------------------
-#
-# The tests below assert the install→uninstall round-trip contract for paths
-# the current uninstall.sh DOES NOT clean up. Each is skipped today; remove
-# the skip line when the corresponding uninstall.sh patch lands. Skip rather
-# than delete so the failures surface as a concrete TODO list rather than
-# slipping out of memory.
-
-@test "(known leak) after install footprint, uninstall removes /usr/local/bin/apl-feed CLI wrapper" {
-    skip "Known drift: update.sh:545 installs the apl-feed CLI to /usr/local/bin/apl-feed; uninstall.sh does not rm it. Manual-install scope; surfaces as a finding."
+@test "after install footprint, uninstall removes /usr/local/bin/apl-feed CLI wrapper" {
     stage_install_footprint
     run_uninstall
 
@@ -237,8 +228,7 @@ run_uninstall() {
     [ ! -e "$ROOT_DIR/usr/local/bin/apl-feed" ]
 }
 
-@test "(known leak) after build-mode install footprint, uninstall removes /etc/airplanes/image-install marker" {
-    skip "Known drift: update.sh:769 writes /etc/airplanes/image-install in build mode; uninstall.sh does not rm it. Build-mode scope; surfaces as a finding."
+@test "after build-mode footprint, uninstall removes /etc/airplanes/image-install marker" {
     stage_install_footprint
     : > "$ROOT_DIR/etc/airplanes/image-install"
     run_uninstall

--- a/test/test_install_uninstall_symmetry.bats
+++ b/test/test_install_uninstall_symmetry.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+
+# Install/uninstall symmetry: stage the canonical install footprint, run
+# uninstall.sh, assert what's removed vs preserved. Catches drift between
+# what install/update/configure put down and what uninstall removes.
+#
+# The footprint enumerated in stage_install_footprint() is the documented
+# contract — adding a new install-time write outside $IPATH must come with
+# a matching entry here AND a matching `rm` in uninstall.sh.
+#
+# Companion to test_uninstall_script.bats: that file pins uninstall's
+# behavior given specific seeded states; this file pins the install↔uninstall
+# round-trip against the full installer footprint.
+
+setup() {
+    UNINSTALL="$BATS_TEST_DIRNAME/../uninstall.sh"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    TAR1090_LOG="$ROOT_DIR/tar1090.log"
+    USERDEL_LOG="$ROOT_DIR/userdel.log"
+    GROUPDEL_LOG="$ROOT_DIR/groupdel.log"
+    mkdir -p "$STUB_DIR"
+
+    # Silent systemctl stub — `systemctl disable --now airplanes-mlat2 &>/dev/null`
+    # would otherwise drop stdio captures.
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+
+    # userdel / groupdel stubs. Uninstall must NOT invoke these for the
+    # airplanes-feed account (CLAUDE.md architecture.md: "The original
+    # `airplanes` user is intentionally not removed on upgrade — it may be
+    # referenced by user-supplied drop-ins or orphan units." Same principle
+    # applies to the airplanes-feed account on uninstall.) The log files are
+    # only created when the stub is invoked, so absence of the log file is
+    # the assertion.
+    cat > "$STUB_DIR/userdel" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$USERDEL_LOG"
+exit 0
+SH
+    chmod +x "$STUB_DIR/userdel"
+
+    cat > "$STUB_DIR/groupdel" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GROUPDEL_LOG"
+exit 0
+SH
+    chmod +x "$STUB_DIR/groupdel"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Stage a maximally-realistic post-install state at AIRPLANES_ROOT.
+#
+# Path enumeration sourced from update.sh's install steps:
+#   - $IPATH contents: update.sh:474-497, 545, 569-589, 644-651, 716
+#   - systemd units in /lib/systemd/system: update.sh:594-596 (manual install)
+#   - /usr/local/bin/apl-feed: update.sh:545
+#   - /etc/airplanes/ artifacts: update.sh:428,472,569,704; create-uuid.sh;
+#     claim-registration.sh:register_claim_secret
+#   - /etc/default/airplanes symlink: update-migrations.sh:finalize_legacy_feed_env_migration
+#
+# Inside $IPATH only a representative sample is staged; `rm -rf $IPATH` wipes
+# the entire directory wholesale, so per-file enumeration there has no
+# additional signal.
+stage_install_footprint() {
+    # $IPATH (= /usr/local/share/airplanes) — wiped wholesale by uninstall.
+    local ipath="$ROOT_DIR/usr/local/share/airplanes"
+    mkdir -p "$ipath/git"
+    mkdir -p "$ipath/apl-feed"
+    mkdir -p "$ipath/lib"
+    mkdir -p "$ipath/venv/bin"
+    mkdir -p "$ipath/mlat-client-git"
+    mkdir -p "$ipath/readsb-git"
+    : > "$ipath/update.sh"
+    : > "$ipath/uninstall.sh"
+    : > "$ipath/airplanes-feed.sh"
+    : > "$ipath/airplanes-mlat.sh"
+    : > "$ipath/apl-feed.sh"
+    : > "$ipath/apl-feed/status.sh"
+    : > "$ipath/lib/state-writer.sh"
+    : > "$ipath/lib/state-reader.sh"
+    : > "$ipath/feed-airplanes"
+    : > "$ipath/lastlog"
+
+    # Manual-install systemd unit layout — /lib/systemd/system. The image-
+    # install layout (/etc/systemd/system) is intentionally out of scope here;
+    # uninstall.sh is the manual-install uninstaller. See known-leaks tests
+    # below for the image-install gap.
+    mkdir -p "$ROOT_DIR/lib/systemd/system"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-feed.service"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-mlat.service"
+
+    # CLI wrapper at /usr/local/bin — installed by update.sh:545.
+    mkdir -p "$ROOT_DIR/usr/local/bin"
+    : > "$ROOT_DIR/usr/local/bin/apl-feed"
+
+    # /etc/airplanes/ — canonical config + identity. feed.env and the claim
+    # secret are intentionally preserved across uninstall (user-config and
+    # re-claim continuity); feeder-id is explicitly preserved by uninstall.sh.
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    printf 'canonical-uuid-content\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
+    printf 'LATITUDE=0\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    printf 'secret-token\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    # Legacy symlink at /etc/default/airplanes → /etc/airplanes/feed.env,
+    # materialized by finalize_legacy_feed_env_migration on manual installs.
+    mkdir -p "$ROOT_DIR/etc/default"
+    ln -sfn '/etc/airplanes/feed.env' "$ROOT_DIR/etc/default/airplanes"
+}
+
+run_uninstall() {
+    run env -i \
+        PATH="$STUB_DIR:/usr/bin:/bin" \
+        AIRPLANES_ROOT="$ROOT_DIR" \
+        SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+        TAR1090_LOG="$TAR1090_LOG" \
+        USERDEL_LOG="$USERDEL_LOG" \
+        GROUPDEL_LOG="$GROUPDEL_LOG" \
+        bash "$UNINSTALL"
+}
+
+@test "after install footprint, uninstall removes manual-install systemd units" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-feed.service" ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-mlat.service" ]
+}
+
+@test "after install footprint, uninstall wipes IPATH and leaves only the legacy UUID symlink" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -d "$ROOT_DIR/usr/local/share/airplanes" ]
+    # IPATH is recreated empty (uninstall.sh:59-60) then the legacy
+    # airplanes-uuid symlink is re-materialized when canonical feeder-id
+    # exists (uninstall.sh:70-72). Nothing else should remain.
+    local remaining
+    remaining="$(ls -A "$ROOT_DIR/usr/local/share/airplanes")"
+    [ "$remaining" = "airplanes-uuid" ]
+    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+}
+
+@test "after install footprint, uninstall preserves /etc/airplanes/feeder-id" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/etc/airplanes/feeder-id" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "canonical-uuid-content" ]
+}
+
+@test "after install footprint, uninstall preserves /etc/airplanes/feed.env (user config)" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/etc/airplanes/feed.env" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feed.env")" = "LATITUDE=0" ]
+}
+
+@test "after install footprint, uninstall preserves /etc/airplanes/feeder-claim-secret (re-claim continuity)" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "secret-token" ]
+}
+
+@test "after install footprint, uninstall preserves the /etc/default/airplanes legacy symlink" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ -L "$ROOT_DIR/etc/default/airplanes" ]
+}
+
+@test "uninstall does not invoke userdel for the airplanes-feed account (intentional preserve)" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$USERDEL_LOG" ]
+}
+
+@test "uninstall does not invoke groupdel for the airplanes-feed group (intentional preserve)" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -f "$GROUPDEL_LOG" ]
+}
+
+@test "after install footprint, second uninstall is byte-identical to the first (idempotent)" {
+    stage_install_footprint
+    run_uninstall
+    [ "$status" -eq 0 ]
+
+    local before_listing
+    before_listing="$(find "$ROOT_DIR" -mindepth 1 -not -path "$STUB_DIR*" -not -name 'systemctl.log' -not -name 'tar1090.log' -not -name 'userdel.log' -not -name 'groupdel.log' | sort)"
+
+    : > "$SYSTEMCTL_LOG"
+    run_uninstall
+    [ "$status" -eq 0 ]
+
+    local after_listing
+    after_listing="$(find "$ROOT_DIR" -mindepth 1 -not -path "$STUB_DIR*" -not -name 'systemctl.log' -not -name 'tar1090.log' -not -name 'userdel.log' -not -name 'groupdel.log' | sort)"
+
+    [ "$before_listing" = "$after_listing" ]
+}
+
+# --- Known install↔uninstall drift -------------------------------------------
+#
+# The tests below assert the install→uninstall round-trip contract for paths
+# the current uninstall.sh DOES NOT clean up. Each is skipped today; remove
+# the skip line when the corresponding uninstall.sh patch lands. Skip rather
+# than delete so the failures surface as a concrete TODO list rather than
+# slipping out of memory.
+
+@test "(known leak) after install footprint, uninstall removes /usr/local/bin/apl-feed CLI wrapper" {
+    skip "Known drift: update.sh:545 installs the apl-feed CLI to /usr/local/bin/apl-feed; uninstall.sh does not rm it. Manual-install scope; surfaces as a finding."
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/usr/local/bin/apl-feed" ]
+}
+
+@test "(known leak) after build-mode install footprint, uninstall removes /etc/airplanes/image-install marker" {
+    skip "Known drift: update.sh:769 writes /etc/airplanes/image-install in build mode; uninstall.sh does not rm it. Build-mode scope; surfaces as a finding."
+    stage_install_footprint
+    : > "$ROOT_DIR/etc/airplanes/image-install"
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/etc/airplanes/image-install" ]
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,6 +17,8 @@ FEEDER_ID="$(airplanes_path /etc/airplanes/feeder-id)"
 LEGACY_UUID="$IPATH/airplanes-uuid"
 SYSTEMD_DIR="$(airplanes_path /lib/systemd/system)"
 TAR1090_DIR="$(airplanes_path /usr/local/share/tar1090)"
+LOCAL_BIN_APL_FEED="$(airplanes_path /usr/local/bin/apl-feed)"
+IMAGE_INSTALL_MARKER="$(airplanes_path /etc/airplanes/image-install)"
 
 systemctl disable --now airplanes-mlat
 systemctl disable --now airplanes-mlat2 &>/dev/null
@@ -33,6 +35,11 @@ rm -f "$SYSTEMD_DIR/airplanes-mlat.service"
 rm -f "$SYSTEMD_DIR/airplanes-mlat2.service"
 rm -f "$SYSTEMD_DIR/airplanes-feed.service"
 systemctl daemon-reload || true
+
+# Named-path artifacts written by update.sh outside $IPATH. The IPATH wipe
+# below handles everything inside it.
+rm -f "$LOCAL_BIN_APL_FEED"
+rm -f "$IMAGE_INSTALL_MARKER"
 
 # Preserve the legacy fallback in memory before wiping IPATH so the canonical
 # feeder-id can be materialized from it if no canonical copy exists. The


### PR DESCRIPTION
Uninstall previously left `/usr/local/bin/apl-feed` and the build-mode marker at `/etc/airplanes/image-install` behind, even though `update.sh` writes them. Both are now removed on uninstall.

Adds a BATS regression test that pins the install→uninstall footprint as a contract: stage the canonical post-install state, run uninstall, assert removed-vs-preserved sets. The two paths above were originally encoded as skipped tests in the same file; this change flips them to live assertions.

Also refreshes `.claude/rules/architecture.md` so the `AIRPLANES_FEED_BRANCH` release-channel section matches the current `{stable, dev, main}` allowlist and the `__FEED_REF__` substitution in `install.sh`.
