### PR TITLE
Add --create-if-missing to apl_feed_apply for atomic bootstrap

### DIFF
--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -232,32 +232,22 @@ apl_feed_import_legacy_config() {
     lock_file="$(feed_env_lock_path)"
 
     # No recognised keys in the source: nothing to write. Return BEFORE
-    # creating any file on disk — leaving an empty canonical feed.env
-    # behind would defeat the bridged-legacy fallback in feed_env_path()
-    # (status readers would see empty canonical state instead of falling
-    # back to the still-populated /boot/airplanes-config.txt).
+    # invoking apply so we don't create a canonical feed.env via
+    # --create-if-missing for no useful reason. The legacy fallback in
+    # feed_env_path() stays available for status readers.
     if (( ${#payload[@]} == 0 )); then
         echo "import legacy-config: no recognised keys in $path"
         return 0
     fi
 
-    # apl_feed_apply rejects on missing feed.env. The legacy boot path
-    # may be invoked before any feed.env exists at all (e.g. on the
-    # first reboot after a bridge update) — pre-create an empty file so
-    # the library has somewhere to merge into. Track whether we created
-    # it so a rejected/filesystem_error apply can remove it instead of
-    # leaving an empty file behind that would suppress the legacy
-    # fallback for status readers.
-    local pre_created=0
-    if [[ ! -f "$feed_env_file" ]]; then
-        mkdir -p "$(dirname "$feed_env_file")"
-        : > "$feed_env_file"
-        pre_created=1
-    fi
-
+    # --create-if-missing makes the bootstrap atomic. The library creates
+    # the file inside its own lock before reading, so there is no
+    # check-then-create race with a concurrent writer. On rejection /
+    # filesystem_error the library never writes, so no empty canonical
+    # file is left behind — no import-side cleanup needed.
     local -a args=()
-    args+=(--feed-env "$feed_env_file" --lock-file "$lock_file")
-    # Skip restarts in three cases: explicit --no-restart from the caller
+    args+=(--feed-env "$feed_env_file" --lock-file "$lock_file" --create-if-missing)
+    # Skip restarts in two cases: explicit --no-restart from the caller
     # (airplanes-first-run passes this so the same script doesn't try to
     # restart units that have After=airplanes-first-run.service), or when
     # ROOT != "/" (build-mode / tests).
@@ -274,18 +264,6 @@ apl_feed_import_legacy_config() {
     IMPORT_APPLY_RC=0
     apl_feed_apply "${args[@]}" || IMPORT_APPLY_RC=$?
 
-    # Clean up a pre-created empty feed.env on any non-success path so the
-    # legacy fallback in feed_env_path() stays available. Only safe when
-    # we created it AND it is still empty — a concurrent writer that
-    # populated the file (under the apply lock) must not lose their
-    # write here.
-    local _import_cleanup_pre_created=0
-    if (( pre_created )) \
-        && [[ "$APL_APPLY_STATUS" != "applied" && "$APL_APPLY_STATUS" != "no_change" ]] \
-        && [[ -f "$feed_env_file" && ! -s "$feed_env_file" ]]; then
-        _import_cleanup_pre_created=1
-    fi
-
     case "$APL_APPLY_STATUS" in
         applied)
             echo "import legacy-config: applied ${#APL_APPLY_CHANGED[@]} key(s)"
@@ -300,12 +278,10 @@ apl_feed_import_legacy_config() {
             for rk in "${!APL_APPLY_ERRORS[@]}"; do
                 echo "import legacy-config: $rk: ${APL_APPLY_ERRORS[$rk]}" >&2
             done
-            (( _import_cleanup_pre_created )) && rm -f "$feed_env_file"
             return 1
             ;;
         *)
             echo "import legacy-config: apply ${APL_APPLY_STATUS:-failed}: ${APL_APPLY_ERROR_MESSAGE:-}" >&2
-            (( _import_cleanup_pre_created )) && rm -f "$feed_env_file"
             return 1
             ;;
     esac

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -413,9 +413,16 @@ _apl_feed_apply_reset_state() {
 # Public entry. See header comment for the contract.
 #
 # Usage:
-#   apl_feed_apply [--no-restart] [--lock-timeout SECS]
+#   apl_feed_apply [--no-restart] [--create-if-missing]
+#                  [--lock-timeout SECS]
 #                  [--feed-env PATH] [--lock-file PATH]
 #                  KEY=value [KEY=value ...]
+#
+# --create-if-missing: create feed.env inside the apply lock when it
+# doesn't yet exist. Without this flag, a missing file returns
+# filesystem_error. Used by apl_feed_import_legacy_config to make the
+# bootstrap atomic (no read-then-create race between two concurrent
+# writers).
 apl_feed_apply() {
     _apl_feed_apply_reset_state
 
@@ -423,6 +430,7 @@ apl_feed_apply() {
     local lock_path="$APL_FEED_APPLY_LOCK_DEFAULT"
     local lock_timeout="$APL_FEED_APPLY_LOCK_TIMEOUT_DEFAULT"
     local skip_restart=0
+    local create_if_missing=0
     local explicit_geo_in_payload=0
     local touched_lat=0 touched_lon=0
     local -A payload=()
@@ -433,6 +441,10 @@ apl_feed_apply() {
         case "$1" in
             --no-restart)
                 skip_restart=1
+                shift
+                ;;
+            --create-if-missing)
+                create_if_missing=1
                 shift
                 ;;
             --lock-timeout)
@@ -548,11 +560,27 @@ apl_feed_apply() {
     # config from a single-key POST — that would silently produce a
     # half-formed file. Matches Go apply-config's behavior of treating
     # a missing file as an internal error.
+    #
+    # The --create-if-missing flag opens a narrow exception for callers
+    # that legitimately produce a fresh feed.env in a single locked
+    # transaction (apl_feed_import_legacy_config). Creation happens HERE,
+    # under the lock, so a concurrent writer that checks file existence
+    # cannot see a half-formed canonical file as the bootstrap signal.
     if [[ ! -f "$feed_env" ]]; then
-        APL_APPLY_STATUS=filesystem_error
-        APL_APPLY_ERROR_MESSAGE="feed.env not found at $feed_env; run setup first"
-        [[ -n "$lock_fd" ]] && eval "exec ${lock_fd}>&-"
-        return 3
+        if (( create_if_missing )); then
+            mkdir -p "$(dirname "$feed_env")" 2>/dev/null || true
+            if ! : > "$feed_env" 2>/dev/null; then
+                APL_APPLY_STATUS=filesystem_error
+                APL_APPLY_ERROR_MESSAGE="cannot create feed.env at $feed_env"
+                [[ -n "$lock_fd" ]] && eval "exec ${lock_fd}>&-"
+                return 3
+            fi
+        else
+            APL_APPLY_STATUS=filesystem_error
+            APL_APPLY_ERROR_MESSAGE="feed.env not found at $feed_env; run setup first"
+            [[ -n "$lock_fd" ]] && eval "exec ${lock_fd}>&-"
+            return 3
+        fi
     fi
 
     # Read current feed.env into merged, then overlay payload.

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -410,3 +410,43 @@ EOF
     # The rewritten file must NOT contain the broken comment-tail.
     ! grep -q 'this is a comment' "$FEED_ENV"
 }
+
+@test "missing feed.env without --create-if-missing returns filesystem_error" {
+    [ ! -e "$FEED_ENV" ]
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 3 ]
+    [ "$APL_APPLY_STATUS" = "filesystem_error" ]
+    [ ! -e "$FEED_ENV" ]
+}
+
+@test "missing feed.env with --create-if-missing: file created inside lock, payload applied" {
+    [ ! -e "$FEED_ENV" ]
+    do_apply --no-restart --create-if-missing MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ -f "$FEED_ENV" ]
+    grep -qE '^MLAT_PRIVATE="?true"?$' "$FEED_ENV"
+}
+
+@test "--create-if-missing + rejected payload leaves no file behind" {
+    # The library creates the canonical file inside the lock only after
+    # the payload passes per-key validation. A rejected payload should
+    # not leak an empty file onto disk where a status reader would see
+    # it instead of the legacy fallback.
+    [ ! -e "$FEED_ENV" ]
+    do_apply --no-restart --create-if-missing LATITUDE=999
+    [ "$APL_APPLY_RC" -eq 2 ]
+    [ "$APL_APPLY_STATUS" = "rejected" ]
+    [ ! -e "$FEED_ENV" ]
+}
+
+@test "--create-if-missing is idempotent when feed.env already exists" {
+    seed_feed_env
+    cp "$FEED_ENV" "$FEED_ENV.before"
+    do_apply --no-restart --create-if-missing MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    grep -qE '^MLAT_PRIVATE="?true"?$' "$FEED_ENV"
+    # Original keys preserved.
+    grep -q '^MLAT_USER="alice"$' "$FEED_ENV"
+}


### PR DESCRIPTION
Import previously pre-created an empty feed.env outside any lock so the apply library would have a file to read into the merged map. A concurrent writer that sneaked in between the pre-create and apply's lock could see the empty canonical and skip its own bootstrap, then write a sparse update over what looked like a blank file. The library now accepts --create-if-missing and creates the file inside its own lock as part of the merge transaction. Per-key validation still runs before the lock, so a rejected payload returns rejected without ever creating a file. Import drops its pre-create + post-rejection cleanup in favour of the flag.

Addresses #3