### PR TITLE
Centralise legacy MLAT-key translation in a single helper lib

### DIFF
--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -69,29 +69,38 @@ if [[ -z "$MLAT_USER" ]]; then
     unset _mlat_user_short_id
 fi
 
-# Legacy PRIVACY read fallback. update.sh's migrate_privacy_to_mlat_private
-# converts PRIVACY=--privacy to MLAT_PRIVATE=true on every run; this in-
-# memory derivation handles a daemon restart that races ahead of the next
-# update.sh. Validation of MLAT_PRIVATE happens in the classifier below
-# so an invalid hand-edit fails loud.
-if [[ ! -v MLAT_PRIVATE && -v PRIVACY ]]; then
-    case "$PRIVACY" in
-        --privacy) MLAT_PRIVATE="true" ;;
-        *)         MLAT_PRIVATE="false" ;;
-    esac
+# Legacy PRIVACY / MLAT_MARKER read fallback. update.sh's
+# migrate_privacy_to_mlat_private converts these to canonical
+# MLAT_PRIVATE on every update; this in-memory derivation handles a
+# daemon restart that races ahead of the next update.sh. The single
+# source of truth for the parsing rules lives in
+# scripts/lib/legacy-mlat-translation.sh; the daemon sources it
+# defensively (a partial install where this script is in place but the
+# lib isn't yet must not take down the daemon — same pattern as the
+# state-writer source below). Unrecognised values leave MLAT_PRIVATE
+# unset so MLAT_MARKER can fall through, and ultimately the default
+# false applies.
+LEGACY_MLAT_TR="$(airplanes_path /usr/local/share/airplanes/lib/legacy-mlat-translation.sh)"
+if [[ -r "$LEGACY_MLAT_TR" ]]; then
+    # shellcheck source=lib/legacy-mlat-translation.sh
+    source "$LEGACY_MLAT_TR"
+else
+    derive_mlat_private_from_privacy() { return 1; }
+    derive_mlat_private_from_marker()  { return 1; }
 fi
+unset LEGACY_MLAT_TR
 
-# Legacy MLAT_MARKER read fallback. PHP webconfig still writes MLAT_MARKER
-# in /boot/airplanes-config.txt via its yes/no dropdown — inverted polarity
-# where "no" means privacy ON. Without this fallback a legacy-image feeder
-# would silently lose privacy on first daemon start under the new schema,
-# even though their stored preference says "private". The webconfig-side
-# migrator translation closes the window on the next save/update.
+if [[ ! -v MLAT_PRIVATE && -v PRIVACY ]]; then
+    if _v="$(derive_mlat_private_from_privacy "$PRIVACY")"; then
+        MLAT_PRIVATE="$_v"
+    fi
+    unset _v
+fi
 if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
-    case "$MLAT_MARKER" in
-        no) MLAT_PRIVATE="true" ;;
-        *)  MLAT_PRIVATE="false" ;;
-    esac
+    if _v="$(derive_mlat_private_from_marker "$MLAT_MARKER")"; then
+        MLAT_PRIVATE="$_v"
+    fi
+    unset _v
 fi
 MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
 

--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -75,6 +75,18 @@ else
     }
 fi
 
+# Legacy-key translation helpers (single source of truth for the
+# PRIVACY / MLAT_MARKER → MLAT_PRIVATE mapping used by import.sh, the
+# update-time migration, and the daemon runtime fallback). Defensive
+# source mirrors the pattern above.
+if [[ -r "$APL_FEED_DAEMON_LIB_DIR/legacy-mlat-translation.sh" ]]; then
+    # shellcheck source=scripts/lib/legacy-mlat-translation.sh
+    source "$APL_FEED_DAEMON_LIB_DIR/legacy-mlat-translation.sh"
+else
+    derive_mlat_private_from_privacy() { return 1; }
+    derive_mlat_private_from_marker()  { return 1; }
+fi
+
 # shellcheck source=scripts/apl-feed/common.sh
 source "$APL_FEED_LIB_DIR/common.sh"
 # shellcheck source=scripts/apl-feed/http.sh

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -181,29 +181,31 @@ apl_feed_import_legacy_config() {
     fi
 
     # MLAT_MARKER → MLAT_PRIVATE (inverted polarity: "no" = privacy ON).
+    # Translation lives in scripts/lib/legacy-mlat-translation.sh, shared
+    # with the update-time migration and the daemon runtime fallback.
+    # Unrecognised values are dropped (MLAT_PRIVATE not added to payload)
+    # rather than silently flipping to false — that would lose the
+    # operator's stored preference on migration.
     if grep -qE '^MLAT_MARKER=' "$path"; then
-        local marker
+        local marker derived
         marker="$(_apl_feed_import_extract "$path" MLAT_MARKER)"
-        case "$marker" in
-            no) payload[MLAT_PRIVATE]="true" ;;
-            *)  payload[MLAT_PRIVATE]="false" ;;
-        esac
+        if derived="$(derive_mlat_private_from_marker "$marker")"; then
+            payload[MLAT_PRIVATE]="$derived"
+        else
+            echo "import legacy-config: unrecognised MLAT_MARKER '$marker'; leaving MLAT_PRIVATE unchanged" >&2
+        fi
     fi
-    # PRIVACY → MLAT_PRIVATE. Wins over MLAT_MARKER when both are present.
-    # Legacy configs encode privacy in several shapes: yes/true/1 from
-    # generic forms, and `--privacy` cargo-culted from old documentation
-    # that suggested adding it as an mlat-client flag. All map to true.
-    # Unknown values are silently dropped rather than falling back to
-    # false — silently flipping a previously-private feeder to public
-    # on migration is the wrong failure mode.
+    # PRIVACY → MLAT_PRIVATE. Wins over MLAT_MARKER when both are present
+    # (PHP webconfig is still the active writer of marker, but PRIVACY is
+    # the more deliberate hand-edit signal).
     if grep -qE '^PRIVACY=' "$path"; then
-        local privacy
+        local privacy derived
         privacy="$(_apl_feed_import_extract "$path" PRIVACY)"
-        case "$privacy" in
-            yes|true|1|--privacy) payload[MLAT_PRIVATE]="true" ;;
-            no|false|0|"")        payload[MLAT_PRIVATE]="false" ;;
-            *) echo "import legacy-config: unrecognised PRIVACY value '$privacy'; leaving MLAT_PRIVATE unchanged" >&2 ;;
-        esac
+        if derived="$(derive_mlat_private_from_privacy "$privacy")"; then
+            payload[MLAT_PRIVATE]="$derived"
+        else
+            echo "import legacy-config: unrecognised PRIVACY value '$privacy'; leaving MLAT_PRIVATE unchanged" >&2
+        fi
     fi
     # MLAT_PRIVATE passthrough wins over both.
     if grep -qE '^MLAT_PRIVATE=' "$path"; then

--- a/scripts/lib/legacy-mlat-translation.sh
+++ b/scripts/lib/legacy-mlat-translation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Pure-function translators for legacy MLAT keys → canonical MLAT_PRIVATE.
+# Single source of truth; sourced from:
+#   - scripts/apl-feed/import.sh         (apl-feed import legacy-config)
+#   - scripts/lib/update-migrations.sh   (migrate_privacy_to_mlat_private)
+#   - scripts/airplanes-mlat.sh          (daemon runtime read fallback)
+#
+# Same input → same output, every site. Pinned by test/test_legacy_mlat_translation.bats.
+#
+# No globals read or written, no side effects. Safe to source anywhere.
+
+# PRIVACY → MLAT_PRIVATE.
+#
+# Canonical legacy form is `--privacy` (cargo-culted from old mlat-client
+# docs). Empty / no / false / 0 map to "false" explicitly. Anything else
+# is unrecognised — return non-zero so the caller can decide whether to
+# leave MLAT_PRIVATE at its existing on-disk value (preferred) or default
+# to a safe value (only when no existing value is available).
+#
+# Whitespace around the value is trimmed first; hand-edits like
+# `PRIVACY=" --privacy "` are tolerated.
+#
+# Stdout: "true" or "false" on recognised input. No output on unrecognised.
+# Returns: 0 recognised, 1 unrecognised.
+derive_mlat_private_from_privacy() {
+    local v="$1"
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    case "$v" in
+        --privacy)        printf 'true' ;;
+        ''|no|false|0)    printf 'false' ;;
+        *) return 1 ;;
+    esac
+}
+
+# MLAT_MARKER → MLAT_PRIVATE.
+#
+# Inverted polarity: PHP webconfig's "no" means privacy ON. Yes / true /
+# 1 mean privacy OFF (marker shown). Anything else is unrecognised.
+#
+# Stdout: "true" or "false" on recognised input. No output on unrecognised.
+# Returns: 0 recognised, 1 unrecognised.
+derive_mlat_private_from_marker() {
+    local v="$1"
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    case "$v" in
+        no)               printf 'true' ;;
+        yes|true|1)       printf 'false' ;;
+        *) return 1 ;;
+    esac
+}

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -271,31 +271,28 @@ migrate_privacy_to_mlat_private() {
         return 0
     fi
 
-    local mlat_private
+    # Translation rules are in scripts/lib/legacy-mlat-translation.sh
+    # (single source of truth across import.sh, this migration, and
+    # airplanes-mlat.sh's daemon-read fallback). update.sh sources that
+    # lib before calling this function. On an unrecognised legacy value
+    # the helper returns non-zero — leave mlat_private at false so the
+    # post-migration disk default mirrors the daemon's
+    # ${MLAT_PRIVATE:-false} runtime fallback.
+    local mlat_private="false"
     if [[ "$has_mlat_private" == "1" ]]; then
         mlat_private="$(_extract_env_value "$feed_env" MLAT_PRIVATE)"
     elif [[ "$has_privacy" == "1" ]]; then
-        local privacy_value
+        local privacy_value derived
         privacy_value="$(_extract_env_value "$feed_env" PRIVACY)"
-        # Trim leading/trailing whitespace; tolerate hand-edits like
-        # `PRIVACY=" --privacy "` and `PRIVACY=--privacy`.
-        privacy_value="${privacy_value#"${privacy_value%%[![:space:]]*}"}"
-        privacy_value="${privacy_value%"${privacy_value##*[![:space:]]}"}"
-        case "$privacy_value" in
-            --privacy) mlat_private="true" ;;
-            *)         mlat_private="false" ;;
-        esac
+        if derived="$(derive_mlat_private_from_privacy "$privacy_value")"; then
+            mlat_private="$derived"
+        fi
     elif [[ "$has_marker" == "1" ]]; then
-        local marker_value
+        local marker_value derived
         marker_value="$(_extract_env_value "$feed_env" MLAT_MARKER)"
-        marker_value="${marker_value#"${marker_value%%[![:space:]]*}"}"
-        marker_value="${marker_value%"${marker_value##*[![:space:]]}"}"
-        case "$marker_value" in
-            no) mlat_private="true" ;;
-            *)  mlat_private="false" ;;
-        esac
-    else
-        mlat_private="false"
+        if derived="$(derive_mlat_private_from_marker "$marker_value")"; then
+            mlat_private="$derived"
+        fi
     fi
 
     if [[ "$has_privacy" == "1" || "$has_marker" == "1" || "$has_mlat_private" == "0" ]]; then

--- a/test/test_apl_feed_bridged_legacy_bootstrap.bats
+++ b/test/test_apl_feed_bridged_legacy_bootstrap.bats
@@ -25,6 +25,8 @@ setup() {
     source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-keys.sh"
     # shellcheck source=../scripts/lib/feed-env-apply.sh
     source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
+    # shellcheck source=../scripts/lib/legacy-mlat-translation.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/legacy-mlat-translation.sh"
     # shellcheck source=../scripts/apl-feed/common.sh
     source "$LIB_DIR/common.sh"
     # shellcheck source=../scripts/apl-feed/import.sh

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -18,6 +18,8 @@ setup() {
     source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-keys.sh"
     # shellcheck source=../scripts/lib/feed-env-apply.sh
     source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
+    # shellcheck source=../scripts/lib/legacy-mlat-translation.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/legacy-mlat-translation.sh"
     # shellcheck source=../scripts/apl-feed/common.sh
     source "$LIB_DIR/common.sh"
     # shellcheck source=../scripts/apl-feed/import.sh
@@ -112,14 +114,18 @@ EOF
     grep -qE '^MLAT_PRIVATE=(false|"false")$' "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
-@test "PRIVACY=yes wins over MLAT_MARKER=yes" {
+@test "PRIVACY=--privacy wins over MLAT_MARKER=yes" {
+    # MLAT_MARKER=yes (privacy OFF) and PRIVACY=--privacy (privacy ON)
+    # conflict. PRIVACY wins because it's the more deliberate hand-edit
+    # signal (PHP webconfig writes MLAT_MARKER; PRIVACY appears only in
+    # hand-edited configs and historical airplanes-mlat docs).
     cat > "$ROOT_DIR/airplanes-config.txt" <<EOF
 LATITUDE=52.5
 LONGITUDE=13.4
 ALTITUDE=120m
 USER=alice
 MLAT_MARKER=yes
-PRIVACY=yes
+PRIVACY=--privacy
 EOF
     import "$ROOT_DIR/airplanes-config.txt"
     [ "$IMPORT_RC" -eq 0 ]

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -202,6 +202,7 @@ SH
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
     mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    install_legacy_mlat_translation_lib "$root"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -326,6 +327,7 @@ SH
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
     mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    install_legacy_mlat_translation_lib "$root"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -406,6 +408,7 @@ SH
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
     mkdir -p "$root/boot" "$root/usr/bin" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    install_legacy_mlat_translation_lib "$root"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
     chmod +x "$root/usr/bin/airplanes-feeder"
     cat > "$root/boot/airplanes-config.txt" <<'EOF'
@@ -564,6 +567,16 @@ install_state_writer_lib() {
     install -d -m 0755 "$root/usr/local/share/airplanes/lib"
     install -m 0644 "$BATS_TEST_DIRNAME/../scripts/lib/state-writer.sh" \
         "$root/usr/local/share/airplanes/lib/state-writer.sh"
+}
+
+# Same as install_state_writer_lib but for the legacy-key translation
+# helpers airplanes-mlat.sh sources defensively when deriving MLAT_PRIVATE
+# from PRIVACY / MLAT_MARKER.
+install_legacy_mlat_translation_lib() {
+    local root="$1"
+    install -d -m 0755 "$root/usr/local/share/airplanes/lib"
+    install -m 0644 "$BATS_TEST_DIRNAME/../scripts/lib/legacy-mlat-translation.sh" \
+        "$root/usr/local/share/airplanes/lib/legacy-mlat-translation.sh"
 }
 
 # Set up an mlat run with stubbed nc/sleep/mlat-client so the daemon

--- a/test/test_legacy_mlat_translation.bats
+++ b/test/test_legacy_mlat_translation.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# Pure-function tests for scripts/lib/legacy-mlat-translation.sh. Three
+# downstream sites (apl-feed/import.sh, update-migrations.sh, airplanes-
+# mlat.sh) historically had divergent inline parsers; this lib is now
+# the single source of truth. The matrix below is the contract those
+# sites import from.
+
+setup() {
+    LIB="$BATS_TEST_DIRNAME/../scripts/lib/legacy-mlat-translation.sh"
+    # shellcheck source=../scripts/lib/legacy-mlat-translation.sh
+    source "$LIB"
+}
+
+assert_recognised() {
+    local fn="$1" input="$2" expected="$3"
+    local out rc=0
+    out="$("$fn" "$input")" || rc=$?
+    if (( rc != 0 )); then
+        echo "FAIL: $fn '$input' returned rc=$rc, expected rc=0 + '$expected'" >&2
+        return 1
+    fi
+    if [[ "$out" != "$expected" ]]; then
+        echo "FAIL: $fn '$input' = '$out', expected '$expected'" >&2
+        return 1
+    fi
+}
+
+assert_unrecognised() {
+    local fn="$1" input="$2"
+    local out rc=0
+    out="$("$fn" "$input")" || rc=$?
+    if (( rc == 0 )); then
+        echo "FAIL: $fn '$input' returned rc=0 (recognised as '$out'), expected rc!=0 (unrecognised)" >&2
+        return 1
+    fi
+    if [[ -n "$out" ]]; then
+        echo "FAIL: $fn '$input' emitted '$out' on unrecognised; should be empty" >&2
+        return 1
+    fi
+}
+
+@test "derive_mlat_private_from_privacy: --privacy → true" {
+    assert_recognised derive_mlat_private_from_privacy '--privacy' 'true'
+}
+
+@test "derive_mlat_private_from_privacy: whitespace around --privacy tolerated" {
+    assert_recognised derive_mlat_private_from_privacy '  --privacy  ' 'true'
+    assert_recognised derive_mlat_private_from_privacy $'\t--privacy\n' 'true'
+}
+
+@test "derive_mlat_private_from_privacy: empty → false" {
+    assert_recognised derive_mlat_private_from_privacy '' 'false'
+}
+
+@test "derive_mlat_private_from_privacy: explicit no/false/0 → false" {
+    assert_recognised derive_mlat_private_from_privacy 'no' 'false'
+    assert_recognised derive_mlat_private_from_privacy 'false' 'false'
+    assert_recognised derive_mlat_private_from_privacy '0' 'false'
+}
+
+@test "derive_mlat_private_from_privacy: unrecognised values return non-zero" {
+    # No silent flip to false on values we don't understand. Callers
+    # must decide whether to preserve current state or default; the
+    # helper refuses to coerce.
+    assert_unrecognised derive_mlat_private_from_privacy 'yes'
+    assert_unrecognised derive_mlat_private_from_privacy 'true'
+    assert_unrecognised derive_mlat_private_from_privacy '1'
+    assert_unrecognised derive_mlat_private_from_privacy 'garble'
+    assert_unrecognised derive_mlat_private_from_privacy '--public'
+}
+
+@test "derive_mlat_private_from_marker: no → true (inverted polarity)" {
+    assert_recognised derive_mlat_private_from_marker 'no' 'true'
+}
+
+@test "derive_mlat_private_from_marker: yes/true/1 → false" {
+    assert_recognised derive_mlat_private_from_marker 'yes' 'false'
+    assert_recognised derive_mlat_private_from_marker 'true' 'false'
+    assert_recognised derive_mlat_private_from_marker '1' 'false'
+}
+
+@test "derive_mlat_private_from_marker: whitespace tolerated" {
+    assert_recognised derive_mlat_private_from_marker '  no  ' 'true'
+    assert_recognised derive_mlat_private_from_marker $'\tyes\n' 'false'
+}
+
+@test "derive_mlat_private_from_marker: unrecognised returns non-zero" {
+    assert_unrecognised derive_mlat_private_from_marker ''
+    assert_unrecognised derive_mlat_private_from_marker 'garble'
+    assert_unrecognised derive_mlat_private_from_marker 'private'
+}
+
+@test "no side effects: helpers don't leak named variables" {
+    # Run a representative call set and assert the helpers' internal
+    # locals (v) are not visible to the caller. (Full `declare -p` diff
+    # would also catch implicit bash state like BASH_REMATCH; this test
+    # focuses on the explicit invariant.)
+    unset v _import_v _migration_v 2>/dev/null || true
+    derive_mlat_private_from_privacy '--privacy' >/dev/null
+    derive_mlat_private_from_marker 'no' >/dev/null
+    [ -z "${v:-}" ]
+}

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -16,6 +16,8 @@ setup() {
     source "$COMMON_LIB"
     # shellcheck source=/dev/null
     source "$LIB"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/scripts/lib/legacy-mlat-translation.sh"
 }
 
 teardown() {

--- a/update.sh
+++ b/update.sh
@@ -341,6 +341,8 @@ fi
 # function definitions and the migration ordering contract.
 # shellcheck source=scripts/lib/update-migrations.sh
 source "$GIT/scripts/lib/update-migrations.sh"
+# shellcheck source=scripts/lib/legacy-mlat-translation.sh
+source "$GIT/scripts/lib/legacy-mlat-translation.sh"
 
 # Pre-config retirements run before the config-incomplete setup.sh dispatch
 # below: an operator with a stale legacy unit but missing config still gets
@@ -406,10 +408,10 @@ if [[ "$IMAGE_INSTALL" == "1" ]]; then
     # this fallback, a legacy-image feeder updating to the new schema
     # would silently lose its stored privacy preference.
     if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
-        case "$MLAT_MARKER" in
-            no) MLAT_PRIVATE="true" ;;
-            *)  MLAT_PRIVATE="false" ;;
-        esac
+        if _v="$(derive_mlat_private_from_marker "$MLAT_MARKER")"; then
+            MLAT_PRIVATE="$_v"
+        fi
+        unset _v
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
     # Legacy GEO_CONFIGURED fallback. Both coords numerically zero (or
@@ -437,10 +439,10 @@ else
     MLAT_USER="${MLAT_USER-}"
     MLAT_ENABLED="${MLAT_ENABLED:-true}"
     if [[ ! -v MLAT_PRIVATE && -v MLAT_MARKER ]]; then
-        case "$MLAT_MARKER" in
-            no) MLAT_PRIVATE="true" ;;
-            *)  MLAT_PRIVATE="false" ;;
-        esac
+        if _v="$(derive_mlat_private_from_marker "$MLAT_MARKER")"; then
+            MLAT_PRIVATE="$_v"
+        fi
+        unset _v
     fi
     MLAT_PRIVATE="${MLAT_PRIVATE:-false}"
     if [[ ! -v GEO_CONFIGURED ]]; then
@@ -530,6 +532,7 @@ historical_daemon_libs=(
     configure-validators.sh
     feed-env-apply.sh
     feed-env-keys.sh
+    legacy-mlat-translation.sh
     state-reader.sh
     state-writer.sh
 )


### PR DESCRIPTION
Three sites used to parse PRIVACY / MLAT_MARKER differently: the apl-feed import path, the update-time feed.env migration, and the daemon's runtime read fallback. The same legacy config could end up with different MLAT_PRIVATE values depending on which path touched it. Centralised into scripts/lib/legacy-mlat-translation.sh — derive_mlat_private_from_privacy and derive_mlat_private_from_marker — sourced by all three call sites. Unrecognised values now return non-zero and the caller preserves the existing state rather than coercing to false, so a hand-edit like PRIVACY=garble can no longer silently flip a previously-private feeder to public. The daemon and CLI source defensively (stub functions when the lib is missing) so a partial install falls through to the safe false default instead of crashing.

Addresses #3