### PR TITLE
feat(apply): emit journald audit on feed.env changes

### DIFF
--- a/scripts/apl-feed/apply.sh
+++ b/scripts/apl-feed/apply.sh
@@ -208,6 +208,13 @@ apl_feed_apply_cli() {
     if (( skip_restart == 1 )) || [[ "$ROOT" != "/" ]]; then
         apply_args+=(--no-restart)
     fi
+    # Implicit --no-audit when writing to a non-host rootfs: a scratch
+    # rootfs save is not an event worth logging to the host's journal.
+    # Audit gating is independent of restart gating — a deliberate
+    # --no-restart on the host (e.g., import.sh first-run) still audits.
+    if [[ "$ROOT" != "/" ]]; then
+        apply_args+=(--no-audit)
+    fi
     [[ -n "$lock_timeout" ]] && apply_args+=(--lock-timeout "$lock_timeout")
     apply_args+=(--feed-env "$feed_env" --lock-file "$lock_path")
     apply_args+=(--meta-file "$(root_path '/etc/airplanes/feed.meta.json')")

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -300,6 +300,12 @@ apl_feed_import_legacy_config() {
             echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
         fi
     fi
+    # Audit gating is orthogonal to restart gating — a host-rootfs
+    # --no-restart (airplanes-first-run) still audits; only scratch
+    # rootfs invocations skip audit.
+    if [[ "$ROOT" != "/" ]]; then
+        args+=(--no-audit)
+    fi
     for k in "${!payload[@]}"; do
         args+=("$k=${payload[$k]}")
     done

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -70,7 +70,7 @@ _mlat_apply() {
     args+=(--feed-env "$(feed_env_write_path)")
     args+=(--lock-file "$(feed_env_lock_path)")
     if [[ "$ROOT" != "/" ]]; then
-        args+=(--no-restart)
+        args+=(--no-restart --no-audit)
         echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
     fi
     MLAT_APPLY_RC=0

--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -112,7 +112,7 @@ _uat_apply() {
     args+=(--feed-env "$(feed_env_write_path)")
     args+=(--lock-file "$(feed_env_lock_path)")
     if [[ "$ROOT" != "/" ]]; then
-        args+=(--no-restart)
+        args+=(--no-restart --no-audit)
         echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
     fi
     UAT_APPLY_RC=0

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -589,6 +589,7 @@ apl_feed_apply() {
     local lock_timeout="$APL_FEED_APPLY_LOCK_TIMEOUT_DEFAULT"
     local meta_path=""
     local skip_restart=0
+    local skip_audit=0
     local create_if_missing=0
     local explicit_geo_in_payload=0
     local touched_lat=0 touched_lon=0
@@ -613,6 +614,10 @@ apl_feed_apply() {
         case "$1" in
             --no-restart)
                 skip_restart=1
+                shift
+                ;;
+            --no-audit)
+                skip_audit=1
                 shift
                 ;;
             --create-if-missing)
@@ -956,8 +961,28 @@ apl_feed_apply() {
     fi
 
     # Release lock before service restarts so a slow systemctl call cannot
-    # block subsequent writers.
+    # block subsequent writers. The audit log fires after release for the
+    # same reason — a stuck logger(1) must not hold up other writers.
     [[ -n "$lock_fd" ]] && eval "exec ${lock_fd}>&-"
+
+    # Best-effort journald audit. The feeder owner is the only journalctl
+    # reader on a normal Pi install; values are already in feed.env on disk.
+    # Skipped in build mode (image chroot has no journald), when logger(1)
+    # is missing, and when the caller passed --no-audit (e.g., scratch
+    # rootfs invocations from tests; apply.sh sets this when ROOT != "/").
+    # The redirect-or-true guard prevents a transient logger failure from
+    # aborting the apply — the write already succeeded.
+    if (( skip_audit == 0 )) \
+        && ! _apl_feed_apply_is_build_mode \
+        && command -v logger >/dev/null 2>&1 \
+        && (( ${#APL_APPLY_CHANGED[@]} > 0 )); then
+        local -a _audit_kvs=()
+        local _audit_k
+        for _audit_k in "${APL_APPLY_CHANGED[@]}"; do
+            _audit_kvs+=("${_audit_k}=\"${merged[$_audit_k]}\"")
+        done
+        logger -t apl-feed-apply -p user.info -- "applied: ${_audit_kvs[*]}" 2>/dev/null || true
+    fi
 
     if (( skip_restart == 1 )); then
         APL_APPLY_STATUS=applied

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -981,6 +981,11 @@ apl_feed_apply() {
         for _audit_k in "${APL_APPLY_CHANGED[@]}"; do
             _audit_kvs+=("${_audit_k}=\"${merged[$_audit_k]}\"")
         done
+        # Pin IFS for the array expansion: this lib is sourced and a
+        # caller-mutated IFS could otherwise produce multi-line or
+        # no-separator output. `local` scopes the override to the
+        # function; the caller's IFS is restored on return.
+        local IFS=' '
         logger -t apl-feed-apply -p user.info -- "applied: ${_audit_kvs[*]}" 2>/dev/null || true
     fi
 

--- a/test/test_apl_feed_apply_journal.bats
+++ b/test/test_apl_feed_apply_journal.bats
@@ -141,11 +141,22 @@ do_apply() {
 
 @test "missing logger(1) does not abort the apply" {
     seed_feed_env
+    # Removing the stub alone isn't enough — PATH still falls through
+    # to /usr/bin/logger on a real Debian/Ubuntu host. Shadow `command`
+    # so the lib's `command -v logger` returns false, while leaving
+    # every other `command -v` lookup unchanged.
     rm -f "$STUB_DIR/logger"
+    command() {
+        if [[ "$1" == "-v" && "$2" == "logger" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
     do_apply MLAT_USER=grace
+    unset -f command
     [ "$APL_APPLY_RC" -eq 0 ]
     [ "$APL_APPLY_STATUS" = "applied" ]
-    # No log file to check; the absence of an abort is the assertion.
+    [ ! -s "$LOGGER_LOG" ]
 }
 
 @test "logger exiting non-zero does not abort the apply" {

--- a/test/test_apl_feed_apply_journal.bats
+++ b/test/test_apl_feed_apply_journal.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+
+# Journald audit coverage for apl_feed_apply. Stubs logger(1) to record
+# its argv into LOGGER_LOG and asserts the audit line is emitted (or
+# suppressed) by each gate.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    LIB="$REPO_ROOT/scripts/lib"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    LOGGER_LOG="$ROOT_DIR/logger.log"
+    mkdir -p "$STUB_DIR" "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/run/airplanes"
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$LIB/configure-validators.sh"
+    # shellcheck source=../scripts/lib/feed-env-keys.sh
+    source "$LIB/feed-env-keys.sh"
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$LIB/feed-env-apply.sh"
+    eval "$bats_exit_trap"
+
+    FEED_ENV="$ROOT_DIR/etc/airplanes/feed.env"
+    LOCK_FILE="$ROOT_DIR/run/airplanes/feed-env.lock"
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+
+    # Recording logger stub. Captures argv per invocation so each test
+    # can assert exactly what (or what was NOT) audited.
+    cat > "$STUB_DIR/logger" <<STUB
+#!/usr/bin/env bash
+printf 'logger %s\n' "\$*" >> "$LOGGER_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+seed_feed_env() {
+    cat > "$FEED_ENV" <<EOF
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="120m"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+GAIN=auto
+UAT_INPUT=""
+DUMP978_SDR_SERIAL=""
+DUMP978_GAIN=44.5
+INPUT="127.0.0.1:30005"
+INPUT_TYPE=dump1090
+EOF
+}
+
+do_apply() {
+    APL_APPLY_RC=0
+    apl_feed_apply --feed-env "$FEED_ENV" --lock-file "$LOCK_FILE" "$@" || APL_APPLY_RC=$?
+}
+
+@test "single key change emits one audit line listing the key and new value" {
+    seed_feed_env
+    do_apply MLAT_USER=bob
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ -s "$LOGGER_LOG" ]
+    [ "$(wc -l < "$LOGGER_LOG")" -eq 1 ]
+    grep -F 'applied: MLAT_USER="bob"' "$LOGGER_LOG"
+    # Tag and priority flags should also be present. `--` stops grep
+    # from parsing the leading `-` as an option.
+    grep -F -- '-t apl-feed-apply' "$LOGGER_LOG"
+    grep -F -- '-p user.info' "$LOGGER_LOG"
+}
+
+@test "multi key change emits one audit line listing every changed key" {
+    seed_feed_env
+    do_apply MLAT_USER=carol MLAT_PRIVATE=true ALTITUDE=200
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "$(wc -l < "$LOGGER_LOG")" -eq 1 ]
+    grep -F 'MLAT_USER="carol"' "$LOGGER_LOG"
+    grep -F 'MLAT_PRIVATE="true"' "$LOGGER_LOG"
+    # ALTITUDE canonicalises to suffixed form (200 -> 200m).
+    grep -F 'ALTITUDE="200m"' "$LOGGER_LOG"
+}
+
+@test "no_change outcome emits no audit line" {
+    seed_feed_env
+    do_apply MLAT_USER=alice
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ ! -s "$LOGGER_LOG" ]
+}
+
+@test "rejected outcome emits no audit line" {
+    seed_feed_env
+    do_apply LATITUDE=200
+    [ "$APL_APPLY_RC" -eq 2 ]
+    [ "$APL_APPLY_STATUS" = "rejected" ]
+    [ ! -s "$LOGGER_LOG" ]
+}
+
+@test "--no-audit suppresses the audit line even on successful change" {
+    seed_feed_env
+    do_apply --no-audit MLAT_USER=dave
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ ! -s "$LOGGER_LOG" ]
+}
+
+@test "--no-audit is orthogonal to --no-restart" {
+    seed_feed_env
+    do_apply --no-restart MLAT_USER=erin
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    # --no-restart by itself MUST NOT suppress the audit.
+    [ -s "$LOGGER_LOG" ]
+    grep -F 'MLAT_USER="erin"' "$LOGGER_LOG"
+}
+
+@test "AIRPLANES_BUILD_MODE=1 suppresses the audit line" {
+    seed_feed_env
+    AIRPLANES_BUILD_MODE=1 do_apply MLAT_USER=frank
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ ! -s "$LOGGER_LOG" ]
+}
+
+@test "missing logger(1) does not abort the apply" {
+    seed_feed_env
+    rm -f "$STUB_DIR/logger"
+    do_apply MLAT_USER=grace
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    # No log file to check; the absence of an abort is the assertion.
+}
+
+@test "logger exiting non-zero does not abort the apply" {
+    seed_feed_env
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 7
+STUB
+    chmod +x "$STUB_DIR/logger"
+    do_apply MLAT_USER=heidi
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+}

--- a/test/test_apl_feed_bridged_legacy_bootstrap.bats
+++ b/test/test_apl_feed_bridged_legacy_bootstrap.bats
@@ -50,6 +50,13 @@ esac
 exit 0
 STUB
     chmod +x "$STUB_DIR/systemctl"
+    # No-op logger stub so the apply-time journald audit doesn't reach
+    # the host's real /dev/log.
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
     PATH="$STUB_DIR:$PATH"
     export PATH
 

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -36,6 +36,13 @@ printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
 exit 0
 STUB
     chmod +x "$STUB_DIR/systemctl"
+    # No-op logger stub so the apply-time journald audit doesn't reach
+    # the host's real /dev/log.
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
     PATH="$STUB_DIR:$PATH"
     export PATH
 }

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -43,6 +43,13 @@ esac
 exit 0
 STUB
     chmod +x "$STUB_DIR/systemctl"
+    # No-op logger stub so the apply-time journald audit doesn't reach
+    # the host's real /dev/log.
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
     PATH="$STUB_DIR:$PATH"
     export PATH
 }

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -67,6 +67,13 @@ esac
 exit 0
 STUB
     chmod +x "$STUB_DIR/systemctl"
+    # No-op logger stub so the apply-time journald audit doesn't reach
+    # the host's real /dev/log.
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
     PATH="$STUB_DIR:$PATH"
     export PATH
 

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -32,6 +32,13 @@ printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
 exit 0
 STUB
     chmod +x "$STUB_DIR/systemctl"
+    # No-op logger stub so the apply-time journald audit (added in the
+    # journal-audit feature) doesn't reach the host's real /dev/log.
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
     PATH="$STUB_DIR:$PATH"
     export PATH
 }


### PR DESCRIPTION
Every successful `apl_feed_apply` now emits one `logger -t apl-feed-apply` line listing the keys that changed and their new values. The feeder owner can read these via `journalctl -t apl-feed-apply` to see when each tracked config field was last written, regardless of which writer (webconfig, `apl-feed mlat`, future remote-sync CLI) made the change.

The audit fires after the apply lock is released so a slow logger can never block other writers, and is best-effort: a missing or failing `logger(1)` does not abort the apply. It is suppressed in build mode (image chroot, no journald), when `logger(1)` isn't installed, and via an orthogonal `--no-audit` flag that `apply.sh` sets automatically when targeting a non-host rootfs so test and CI invocations don't pollute the host journal.