### PR TITLE
Authenticate /api/feeders/status with Bearer alv1 token

### DIFF
--- a/scripts/apl-feed/http.sh
+++ b/scripts/apl-feed/http.sh
@@ -30,9 +30,18 @@ post_json_bearer() {
     local body="$3"
     local response_file="$4"
 
-    local cfg
+    local cfg rc
     cfg="$(mktemp -t apl-feed-curlcfg.XXXXXX)" || return 1
     chmod 0600 "$cfg" || { rm -f "$cfg"; return 1; }
+    # Primary cleanup is the explicit `rm -f "$cfg"` at function return.
+    # TMP_FILES is only a safety net for DIRECT callers — i.e., not the
+    # `status=$(post_json_bearer ...)` pattern every current caller uses,
+    # because bash resets EXIT traps in command-substitution subshells
+    # AND TMP_FILES mutations don't propagate out. Direct callers get
+    # the EXIT-trap reap for signal-kills between mktemp and the rm
+    # below; $() callers only get the explicit rm. Residual leak window
+    # for $() callers is the few microseconds between mktemp and the rm
+    # — accepted.
     TMP_FILES+=("$cfg")
     # `curl --config` reads `key = "value"` lines; backslash-escape any
     # embedded backslashes or double quotes in the token before substitution.
@@ -43,6 +52,7 @@ post_json_bearer() {
     # header, which the backend would reject as `malformed_authorization`
     # rather than the actual local I/O error.
     if ! printf 'header = "Authorization: Bearer %s"\n' "$escaped" > "$cfg"; then
+        rm -f "$cfg"
         return 1
     fi
 
@@ -55,6 +65,9 @@ post_json_bearer() {
         --output "$response_file" \
         --write-out '%{http_code}' \
         "$SERVER_URL$path"
+    rc=$?
+    rm -f "$cfg"
+    return "$rc"
 }
 
 body_preview() {
@@ -65,11 +78,13 @@ body_preview() {
 status_probe_version() {
     local uuid="$1"
     local secret="$2"
-    local response_file status curl_rc version body
+    local response_file status curl_rc version body token
     response_file="$(mktemp)"
-    body="$(printf '{"uuid":"%s","current_secret":"%s"}' "$uuid" "$secret")"
+    # Body carries only the UUID; auth is in the Bearer header.
+    body="$(printf '{"uuid":"%s"}' "$uuid")"
+    token="alv1.${uuid}.${secret}"
     set +e
-    status="$(post_json '/api/feeders/status' "$body" "$response_file")"
+    status="$(post_json_bearer "$token" '/api/feeders/status' "$body" "$response_file")"
     curl_rc=$?
     set -e
     if [[ "$curl_rc" -ne 0 || "$status" != "200" ]]; then

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -372,7 +372,7 @@ website_feed_status_line() {
 claim_registration_status_line() {
     require_jq
 
-    local uuid final pending secret response_file body status curl_rc
+    local uuid final pending secret response_file body status curl_rc token
     local registered version owner_present reset_until error preview
     local last_seen_present last_seen_at last_seen_age
 
@@ -401,9 +401,11 @@ claim_registration_status_line() {
     fi
 
     response_file="$(new_tmp_file)"
-    body="$(printf '{"uuid":"%s","current_secret":"%s"}' "$uuid" "$secret")"
+    # Body carries only the UUID; auth is in the Bearer header.
+    body="$(printf '{"uuid":"%s"}' "$uuid")"
+    token="alv1.${uuid}.${secret}"
     set +e
-    status="$(post_json '/api/feeders/status' "$body" "$response_file")"
+    status="$(post_json_bearer "$token" '/api/feeders/status' "$body" "$response_file")"
     curl_rc=$?
     set -e
     if [[ "$curl_rc" -ne 0 ]]; then

--- a/test/contracts/feeder-api-v1.json
+++ b/test/contracts/feeder-api-v1.json
@@ -127,9 +127,9 @@
     },
     "authenticated_recent": {
       "request": {
-        "uuid": "11111111-2222-3333-4444-555555555555",
-        "current_secret": "ABCDEFGHIJKLMNOP"
+        "uuid": "11111111-2222-3333-4444-555555555555"
       },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
       "response": {
         "status": 200,
         "body": {
@@ -145,9 +145,9 @@
     },
     "authenticated_stale": {
       "request": {
-        "uuid": "33333333-4444-5555-6666-777777777777",
-        "current_secret": "ABCDEFGHIJKLMNOP"
+        "uuid": "33333333-4444-5555-6666-777777777777"
       },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
       "response": {
         "status": 200,
         "body": {
@@ -163,9 +163,9 @@
     },
     "authenticated_never_seen": {
       "request": {
-        "uuid": "44444444-5555-6666-7777-888888888888",
-        "current_secret": "ABCDEFGHIJKLMNOP"
+        "uuid": "44444444-5555-6666-7777-888888888888"
       },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
       "response": {
         "status": 200,
         "body": {

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -130,7 +130,21 @@ class H(http.server.BaseHTTPRequestHandler):
             self.wfile.write(secret_body.encode())
             return
         if self.path == "/api/feeders/status":
-            current = body.get("current_secret")
+            # /status moved to Authorization: Bearer alv1.<uuid>.<secret>;
+            # the body now only carries the UUID. Parse the bearer
+            # against the body uuid the way the production server does:
+            # malformed token → no auth (soft-fail to minimal),
+            # token_uuid != body uuid → no auth (real server returns
+            # 400 uuid_mismatch, but the feed-side test cases never
+            # exercise that branch so soft-failing here is fine).
+            current = ""
+            body_uuid = body.get("uuid")
+            auth = self.headers.get("Authorization", "")
+            if auth.startswith("Bearer alv1.") and body_uuid:
+                rest = auth[len("Bearer alv1."):]
+                parts = rest.split(".", 1)
+                if len(parts) == 2 and parts[0] == body_uuid:
+                    current = parts[1]
             if current == active_secret:
                 out = {
                     "registered": True,

--- a/test/test_apl_feed_http.bats
+++ b/test/test_apl_feed_http.bats
@@ -161,12 +161,28 @@ mock_url() {
 }
 
 @test "status_probe_version: cleans up its tempfile" {
+    # status_probe_version's response_file is rm'd inside the function.
+    # post_json_bearer's curl-config tempfile is also rm'd inside the
+    # helper on return (the TMP_FILES safety-net would have been
+    # invisible from this scope anyway — see post_json_bearer for why).
     start_mock_server 200 '{"version":7}'
     SERVER_URL="$(mock_url)"
     before="$(find "$TMPDIR" -type f 2>/dev/null | wc -l | tr -d ' ')"
     status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP' >/dev/null || true
     after="$(find "$TMPDIR" -type f 2>/dev/null | wc -l | tr -d ' ')"
     [ "$before" = "$after" ]
+}
+
+@test "status_probe_version: sends Authorization: Bearer alv1.<uuid>.<secret>" {
+    # DEV-427: /status moved to Bearer auth. The body now carries only
+    # the uuid; the secret rides in the Authorization header so it can't
+    # leak via request-body access logs.
+    start_mock_server_with_headers 200 '{"version":7}'
+    SERVER_URL="$(mock_url)"
+    run status_probe_version '11111111-2222-3333-4444-555555555555' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 0 ]
+    grep -qi '^Authorization: Bearer alv1\.11111111-2222-3333-4444-555555555555\.ABCDEFGHIJKLMNOP$' "$ROOT_DIR/headers.log"
+    [ "$(cat "$MOCK_REQUEST_BODY")" = '{"uuid":"11111111-2222-3333-4444-555555555555"}' ]
 }
 
 # --- post_json_bearer ---
@@ -259,18 +275,41 @@ SH
     grep -qi '^Content-Type: application/json' "$ROOT_DIR/headers.log"
 }
 
-@test "post_json_bearer: tempfile is registered in TMP_FILES for cleanup" {
+@test "post_json_bearer: tempfile is registered in TMP_FILES safety-net and 0600" {
+    # Stub rm so the curl-config tempfile survives the in-function
+    # cleanup; that lets us assert both the TMP_FILES registration (for
+    # the EXIT trap safety-net) and the 0600 mode on the created file.
+    # The next test asserts the primary in-function cleanup actually
+    # runs.
+    rm_real="$(command -v rm)"
+    rm() { :; }  # no-op
     start_mock_server_with_headers 200 '{}'
     SERVER_URL="$(mock_url)"
     response_file="$TMPDIR/resp"
     before_count="${#TMP_FILES[@]}"
     post_json_bearer 'alv1.x.y' '/api/feeders/diagnostics' '{}' "$response_file" >/dev/null
+    unset -f rm
     [ "${#TMP_FILES[@]}" -gt "$before_count" ]
     last_entry="${TMP_FILES[-1]}"
     [ -f "$last_entry" ]
     # 0600 mode — owner-read/write only
     mode="$(stat -c '%a' "$last_entry" 2>/dev/null || stat -f '%A' "$last_entry")"
     [ "$mode" = '600' ]
+}
+
+@test "post_json_bearer: tempfile is rm'd on return (primary cleanup)" {
+    # Primary cleanup: the helper rm's the curl-config inside the
+    # function so callers using $() command substitution (where
+    # TMP_FILES mutations are lost) still don't leak. TMP_FILES is the
+    # safety-net for signal-kill / set-e-bail paths.
+    start_mock_server_with_headers 200 '{}'
+    SERVER_URL="$(mock_url)"
+    response_file="$TMPDIR/resp"
+    before="$(find "$TMPDIR" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    post_json_bearer 'alv1.x.y' '/api/feeders/diagnostics' '{}' "$response_file" >/dev/null
+    rm -f "$response_file"
+    after="$(find "$TMPDIR" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$before" = "$after" ]
 }
 
 @test "post_json: still works after http.sh has loaded post_json_bearer (regression)" {

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -65,17 +65,19 @@ teardown() {
     rm -rf "$ROOT_DIR"
 }
 
-# Stub `post_json` to write a prepared response and return a chosen
-# code. Defines the function in the current shell so the next call to
-# claim_registration_status_line / status_probe_version uses it.
+# Stub `post_json_bearer` to write a prepared response and return a
+# chosen code. Defines the function in the current shell so the next
+# call to claim_registration_status_line / status_probe_version uses it.
+# DEV-427: /status migrated from post_json to post_json_bearer; the stub
+# matches the new helper's 4-arg signature (response_file is $4).
 stub_post_json() {
     # stub_post_json <http-status-code> <response-body-json>
     # On rc=99 sentinel, simulates network failure (curl rc != 0).
     local code="$1"
     local body="$2"
     eval "
-post_json() {
-    local response_file=\"\$3\"
+post_json_bearer() {
+    local response_file=\"\$4\"
     if [[ '$code' == '99' ]]; then
         return 7
     fi


### PR DESCRIPTION
`claim_registration_status_line` and `status_probe_version` now send the claim secret in an `Authorization: Bearer alv1.<uuid>.<secret>` header instead of a body `current_secret` field. The body shrinks to just `{"uuid":"..."}` for both endpoints. `claim_rotate`'s lost-response recovery and `claim rotate --abort` reach the server through the same new Bearer path.

`claim.sh`'s `/api/feeders/secret` POSTs are unchanged — first-claim has no current secret to put in a header, and the rotation replay path needs the secret in the body to satisfy the server's NOOP_REPLAY check.

`post_json_bearer` now rm's its curl-config tempfile before return. The previous `TMP_FILES` registration stays as a safety-net for direct callers, but bash resets EXIT traps inside command-substitution subshells, so callers that capture via `$()` couldn't have relied on it alone.

Refs [DEV-427](https://airplanes-live.atlassian.net/browse/DEV-427).

[DEV-427]: https://airplanes-live.atlassian.net/browse/DEV-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ