### PR TITLE
Add airplanes-feed to video group so vcgencmd reads /dev/vchiq

### DIFF
--- a/scripts/lib/service-account.sh
+++ b/scripts/lib/service-account.sh
@@ -65,6 +65,22 @@ ensure_airplanes_feed_account() {
         fi
     fi
 
+    # Pi hardware needs the daemon user in the `video` group so /dev/vchiq
+    # is readable for `vcgencmd get_throttled` (airplanes-diagnostics push).
+    # Gate on vcgencmd-presence AND the `video` group existing so the
+    # membership lands only where it will be used. The `video` group exists
+    # on most Debian/Ubuntu hosts regardless of Pi userland; the vcgencmd
+    # guard keeps non-Pi systems out of the group.
+    if command -v vcgencmd >/dev/null 2>&1 && getent group video >/dev/null 2>&1
+    then
+        if ! id -nG "$uname" 2>/dev/null | tr ' ' '\n' | grep -qx video
+        then
+            usermod -aG video "$uname" 2>/dev/null \
+                || gpasswd -a "$uname" video 2>/dev/null \
+                || echo "WARNING: could not add $uname to video group; airplanes-diagnostics throttle fields will stay null until manually fixed" >&2
+        fi
+    fi
+
     # heal_claim_state_ownership runs after account setup so its chown
     # target group exists. Defaults to airplanes-feed:airplanes-feed; the
     # uname/gname args here are not threaded through because the heal

--- a/test/test_service_account.bats
+++ b/test/test_service_account.bats
@@ -39,6 +39,20 @@ setup() {
     PATH="$STUB_DIR:$PATH"
     export PATH COMMAND_LOG
 
+    # Default: simulate a non-Pi host. `ensure_airplanes_feed_account`'s
+    # video-group block gates on `command -v vcgencmd`. PATH-stubbing
+    # alone is insufficient — on a Pi dev box `/usr/bin/vcgencmd` is
+    # still reachable through the rest of PATH. Override `command` as
+    # a shell function so vcgencmd resolution fails regardless of host.
+    # Video-specific tests opt out via `unset -f command` + an explicit
+    # vcgencmd stub.
+    command() {
+        if [ "$1" = "-v" ] && [ "$2" = "vcgencmd" ]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+
     # shellcheck source=/dev/null
     source "$CLAIM_LIB"
     # shellcheck source=/dev/null
@@ -263,4 +277,151 @@ esac'
     [ -n "$adduser_line" ]
     [ "$heal_line" -gt "$adduser_line" ]
     grep -q "^heal $ETC_AIRPLANES$" "$COMMAND_LOG"
+}
+
+# Video-group block: airplanes-feed needs membership so the diagnostics
+# daemon can read /dev/vchiq for vcgencmd get_throttled. Gated on
+# vcgencmd presence + `video` group existence.
+
+@test "vcgencmd + video present, user not in video: usermod adds airplanes-feed to video" {
+    # Daemon group already supplementary so the daemon cascade is skipped
+    # and only the video block fires — isolates the assertion to the new
+    # behavior.
+    unset -f command
+    _stub vcgencmd 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup airplanes-feed"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    grep -q "^usermod -aG video airplanes-feed$" "$COMMAND_LOG"
+    # Daemon cascade correctly skipped — airplanes-feed already supplementary.
+    ! grep -q "^usermod -aG airplanes-feed airplanes-feed$" "$COMMAND_LOG"
+    ! grep -q "^gpasswd " "$COMMAND_LOG"
+}
+
+@test "vcgencmd absent: video block skipped even when video group exists" {
+    # Setup's `command` override makes `command -v vcgencmd` fail
+    # regardless of host PATH — this test inherits that without
+    # `unset -f command` or adding a vcgencmd stub.
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup airplanes-feed"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    # Anchored: bare ' video ' substring would miss the end-of-line case.
+    ! grep -q "^usermod -aG video airplanes-feed$" "$COMMAND_LOG"
+    ! grep -q "^gpasswd -a airplanes-feed video$" "$COMMAND_LOG"
+}
+
+@test "vcgencmd present, video group absent: video block skipped" {
+    unset -f command
+    _stub vcgencmd 'exit 0'
+    _stub getent '
+case "$*" in
+    "group video") exit 2;;
+    *) exit 0;;
+esac'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup airplanes-feed"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    ! grep -q "^usermod -aG video airplanes-feed$" "$COMMAND_LOG"
+    ! grep -q "^gpasswd -a airplanes-feed video$" "$COMMAND_LOG"
+}
+
+@test "video block: usermod fails, gpasswd succeeds — fallback, no warning" {
+    # Daemon group already supplementary; only the video cascade exercises
+    # the failing usermod stub, so the assertion is unambiguous.
+    unset -f command
+    _stub vcgencmd 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup airplanes-feed"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+    _stub usermod 'printf "usermod %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub gpasswd 'printf "gpasswd %s\n" "$*" >> "$COMMAND_LOG"; exit 0'
+
+    set -e
+    run ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    [ "$status" -eq 0 ]
+    grep -q "^usermod -aG video airplanes-feed$" "$COMMAND_LOG"
+    grep -q "^gpasswd -a airplanes-feed video$" "$COMMAND_LOG"
+    [[ "$output" != *"WARNING: could not add airplanes-feed to video"* ]]
+}
+
+@test "video block: usermod AND gpasswd fail — warning printed, function returns 0" {
+    unset -f command
+    _stub vcgencmd 'exit 0'
+    _stub id '
+case "$1" in
+    -u) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+    -nG) printf "id %s\n" "$*" >> "$COMMAND_LOG"; echo "nogroup airplanes-feed"; exit 0;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+    _stub usermod 'printf "usermod %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+    _stub gpasswd 'printf "gpasswd %s\n" "$*" >> "$COMMAND_LOG"; exit 1'
+
+    set -e
+    run ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING: could not add airplanes-feed to video group"* ]]
+}
+
+@test "fresh user path: adduser runs, then video usermod fires after user creation" {
+    # id -u fails until adduser drops a marker file, then succeeds — so
+    # the fresh-create branch is taken and the post-creation `id -nG`
+    # call inside the video block sees the user's primary group, matching
+    # the production state.
+    unset -f command
+    _stub vcgencmd 'exit 0'
+    _stub getent 'case "$*" in
+    "group airplanes-feed") echo "airplanes-feed:x:999:" ;;
+    *) exit 0 ;;
+esac'
+    _stub adduser 'printf "adduser %s\n" "$*" >> "$COMMAND_LOG"; touch "'"$TMP"'/user_created"; exit 0'
+    _stub id '
+case "$1" in
+    -u)
+        printf "id %s\n" "$*" >> "$COMMAND_LOG"
+        if [ -e "'"$TMP"'/user_created" ]; then exit 0; else exit 1; fi
+        ;;
+    -nG)
+        printf "id %s\n" "$*" >> "$COMMAND_LOG"
+        if [ -e "'"$TMP"'/user_created" ]; then echo "airplanes-feed"; exit 0; fi
+        exit 1
+        ;;
+    *) printf "id %s\n" "$*" >> "$COMMAND_LOG"; exit 0;;
+esac'
+
+    set -e
+    ensure_airplanes_feed_account airplanes-feed airplanes-feed "$HOME_DIR" "$ETC_AIRPLANES"
+
+    grep -q "^adduser " "$COMMAND_LOG"
+    grep -q "^usermod -aG video airplanes-feed$" "$COMMAND_LOG"
+    # Ordering: video usermod fires after the adduser call.
+    local adduser_line video_line
+    adduser_line="$(grep -n '^adduser ' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    video_line="$(grep -n '^usermod -aG video airplanes-feed$' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    [ "$video_line" -gt "$adduser_line" ]
 }


### PR DESCRIPTION
The `airplanes-feed` user runs `airplanes-diagnostics.service`, which calls `vcgencmd get_throttled` to populate the `pi_health.throttle` block in the diagnostics push. `/dev/vchiq` is owned `root:video`, so without supplementary group membership the call silently fails and the eight throttle keys come through `null`.

`ensure_airplanes_feed_account` now adds the user to the `video` group during account setup, gated on both `vcgencmd` being installed and the `video` group existing. The cascade and idempotence guards mirror the existing daemon-group repair path. No-op on hosts without raspi-utils.