### PR TITLE
Add apl-feed config sync subcommand and metadata-LWW apply gate

### DIFF
--- a/scripts/airplanes-config-sync.service
+++ b/scripts/airplanes-config-sync.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=airplanes.live feeder remote-config sync
+Wants=network-online.target
+After=network-online.target airplanes-feed.service
+ConditionPathExists=/etc/airplanes/feeder-claim-secret
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/apl-feed config sync
+TimeoutStartSec=60s
+SyslogIdentifier=airplanes-config-sync
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths=/var/lib/airplanes /etc/airplanes /run

--- a/scripts/airplanes-config-sync.timer
+++ b/scripts/airplanes-config-sync.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sync feeder remote configuration with airplanes.live every 60 seconds
+
+[Timer]
+OnBootSec=45s
+OnUnitActiveSec=60s
+RandomizedDelaySec=30s
+Unit=airplanes-config-sync.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -111,6 +111,8 @@ source "$APL_FEED_LIB_DIR/apply.sh"
 source "$APL_FEED_LIB_DIR/schema.sh"
 # shellcheck source=scripts/apl-feed/import.sh
 source "$APL_FEED_LIB_DIR/import.sh"
+# shellcheck source=scripts/apl-feed/config.sh
+source "$APL_FEED_LIB_DIR/config.sh"
 
 main() {
     local cmd="${1:-}"
@@ -158,6 +160,10 @@ main() {
         import)
             shift
             dispatch_import "$@"
+            ;;
+        config)
+            shift
+            dispatch_config "$@"
             ;;
         -h|--help|'')
             usage

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -51,6 +51,7 @@ Usage:
   apl-feed diagnostics disable
   apl-feed apply [--no-restart] [--lock-timeout SECS]
   apl-feed schema
+  apl-feed config sync [--dry-run] [--no-restart]
   apl-feed import legacy-config [--no-restart] <path>
   apl-feed backup <file>
   apl-feed restore <file>

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -74,6 +74,15 @@ _config_sync_read_bool() {
 # associative arrays via nameref. Missing / corrupt / non-v1 schema all
 # leave the maps empty without erroring — callers fall back to the
 # legacy tuple per-key.
+#
+# Per-entry shape is filtered to enforce:
+#   - edited_at matches the RFC 3339 UTC regex (mirrors the apply lib's
+#     APL_FEED_APPLY_EDITED_AT_RE)
+#   - edited_by ∈ {feeder, website, legacy}
+# Invalid entries are dropped silently. The next call to apl_feed_apply
+# overwrites the sidecar from clean state, so a one-off corrupt entry
+# heals itself; meanwhile we never propagate the bad metadata to the
+# server and stay out of a 400 validation_failed loop.
 _config_sync_load_meta() {
     local meta_path="$1"
     local -n at_out="$2"
@@ -88,6 +97,8 @@ _config_sync_load_meta() {
             select(.value | type == "object") |
             select(.value.edited_at | type == "string") |
             select(.value.edited_by | type == "string") |
+            select(.value.edited_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?Z$")) |
+            select(.value.edited_by | IN("feeder", "website", "legacy")) |
             "\(.key)\t\(.value.edited_at)\t\(.value.edited_by)"
         else empty end
     ' "$meta_path" 2>/dev/null)"; then
@@ -152,7 +163,14 @@ _config_sync_build_payload() {
     local lat_at="${meta_at[LATITUDE]:-}"
     local lon_at="${meta_at[LONGITUDE]:-}"
     if [[ -n "$lat_at" && -n "$lon_at" ]]; then
-        if [[ "$lat_at" < "$lon_at" ]]; then
+        # Atomic-group edited_at = MAX of the two axes' stamps. apl_feed_apply
+        # writes both axes in a single locked transaction with the same
+        # stamp, so MIN and MAX are equal in the normal case. In the
+        # divergent-stamps edge case (legacy seed + a partial hand-edit
+        # that touched only one axis), MAX reflects when the position
+        # *state* was last changed, not the older lagging stamp. The
+        # symmetric LWW gate in _config_sync_apply_response uses MAX too.
+        if [[ "$lat_at" > "$lon_at" ]]; then
             position_at="$lat_at"
         else
             position_at="$lon_at"
@@ -371,6 +389,7 @@ _config_sync_apply_response() {
         _config_sync_log error "reason=apply_translate body=$(body_preview "$response_file")"
         APL_APPLY_INCOMING_META_EDITED_AT=()
         APL_APPLY_INCOMING_META_EDITED_BY=()
+        APL_APPLY_INCOMING_SERVER_TIME=""
         return 1
     fi
     if (( ${#apply_args[@]} == 0 )); then
@@ -379,7 +398,95 @@ _config_sync_apply_response() {
         _config_sync_log info "reason=empty_fields_payload"
         APL_APPLY_INCOMING_META_EDITED_AT=()
         APL_APPLY_INCOMING_META_EDITED_BY=()
+        APL_APPLY_INCOMING_SERVER_TIME=""
         return 0
+    fi
+
+    # Pass the server's authoritative `server_time` to the apply lib so
+    # its bogus-future-heal threshold is computed against trusted time
+    # rather than a possibly-fast local clock.
+    APL_APPLY_INCOMING_SERVER_TIME="$(parse_field_from "$response_file" '.server_time')"
+
+    # Atomic position-group LWW decision. The server treats position as
+    # a single field, but the apply lib gates per feed.env key. Without
+    # this pre-check, a feeder whose on-disk LATITUDE/LONGITUDE stamps
+    # have somehow diverged could apply one axis from the server tuple
+    # and skip the other — producing a hybrid position. Compute the
+    # group decision against the OLDER of the two on-disk stamps so a
+    # stale half can't masquerade as the whole.
+    local _have_lat_arg=0 _have_lon_arg=0
+    local _arg
+    for _arg in "${apply_args[@]}"; do
+        case "$_arg" in
+            LATITUDE=*) _have_lat_arg=1 ;;
+            LONGITUDE=*) _have_lon_arg=1 ;;
+        esac
+    done
+    if (( _have_lat_arg == 1 && _have_lon_arg == 1 )); then
+        local _meta_path
+        _meta_path="$(feed_env_write_path)"
+        _meta_path="${_meta_path%/feed.env}/feed.meta.json"
+        local -A _on_at=() _on_by=()
+        _config_sync_load_meta "$_meta_path" _on_at _on_by
+        local _lat_at="${_on_at[LATITUDE]:-}"
+        local _lon_at="${_on_at[LONGITUDE]:-}"
+        local _pos_group_at=""
+        if [[ -n "$_lat_at" && -n "$_lon_at" ]]; then
+            # MAX-of-pair: see comment in _config_sync_build_payload.
+            # If LAT was edited fresh but LON's stamp is stale, the
+            # position state was effectively newly edited at the LAT
+            # time — incoming must beat MAX to apply atomically.
+            if [[ "$_lat_at" > "$_lon_at" ]]; then
+                _pos_group_at="$_lat_at"
+            else
+                _pos_group_at="$_lon_at"
+            fi
+        elif [[ -n "$_lat_at" ]]; then
+            _pos_group_at="$_lat_at"
+        elif [[ -n "$_lon_at" ]]; then
+            _pos_group_at="$_lon_at"
+        fi
+        local _incoming_pos_at="${APL_APPLY_INCOMING_META_EDITED_AT[LATITUDE]:-}"
+        if [[ -n "$_pos_group_at" && -n "$_incoming_pos_at" ]]; then
+            # Use the same bogus-future-heal carve-out the lib applies.
+            # If on-disk is wildly in server-future, the heal path must
+            # run — keep both axes in the payload.
+            local _heal_threshold
+            if [[ -n "$APL_APPLY_INCOMING_SERVER_TIME" \
+                && "$APL_APPLY_INCOMING_SERVER_TIME" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([.][0-9]+)?Z$ ]]; then
+                _heal_threshold="$(date -u -d "$APL_APPLY_INCOMING_SERVER_TIME +300 seconds" \
+                    +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+            fi
+            local _is_bogus_future=0
+            if [[ -n "$_heal_threshold" && "$_pos_group_at" > "$_heal_threshold" ]]; then
+                _is_bogus_future=1
+            fi
+            if (( _is_bogus_future == 0 )) && [[ ! "$_incoming_pos_at" > "$_pos_group_at" ]]; then
+                # Drop both LATITUDE and LONGITUDE from apply_args and
+                # the incoming-meta arrays so the lib's gate has nothing
+                # to decide for position. Other fields apply as usual.
+                local -a _filtered=()
+                for _arg in "${apply_args[@]}"; do
+                    case "$_arg" in
+                        LATITUDE=*|LONGITUDE=*) ;;
+                        *) _filtered+=("$_arg") ;;
+                    esac
+                done
+                apply_args=("${_filtered[@]}")
+                unset 'APL_APPLY_INCOMING_META_EDITED_AT[LATITUDE]'
+                unset 'APL_APPLY_INCOMING_META_EDITED_AT[LONGITUDE]'
+                unset 'APL_APPLY_INCOMING_META_EDITED_BY[LATITUDE]'
+                unset 'APL_APPLY_INCOMING_META_EDITED_BY[LONGITUDE]'
+                _config_sync_log info "reason=position_group_skipped_by_lww"
+            fi
+        fi
+        if (( ${#apply_args[@]} == 0 )); then
+            _config_sync_log info "reason=all_keys_skipped_after_pos_group"
+            APL_APPLY_INCOMING_META_EDITED_AT=()
+            APL_APPLY_INCOMING_META_EDITED_BY=()
+            APL_APPLY_INCOMING_SERVER_TIME=""
+            return 0
+        fi
     fi
 
     feed_env_ensure_canonical_for_write
@@ -398,6 +505,7 @@ _config_sync_apply_response() {
     # the timer's next tick) starts from a clean slate.
     APL_APPLY_INCOMING_META_EDITED_AT=()
     APL_APPLY_INCOMING_META_EDITED_BY=()
+    APL_APPLY_INCOMING_SERVER_TIME=""
 
     case "$APL_APPLY_STATUS" in
         applied|no_change)
@@ -501,7 +609,16 @@ apl_feed_config_sync() {
         _config_sync_log error "reason=unreadable_claim_secret path=$secret_path"
         return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
     fi
-    secret="$(read_secret_file "$secret_path")"
+    # read_secret_file calls `die` (exit 1) on a malformed secret.
+    # Without the `||` capture, set -e would propagate that exit 1 out
+    # of this function — masking it as a generic transient failure
+    # instead of the hard-config error it actually is.
+    local _secret_rc=0
+    secret="$(read_secret_file "$secret_path" 2>/dev/null)" || _secret_rc=$?
+    if (( _secret_rc != 0 )) || [[ -z "$secret" ]]; then
+        _config_sync_log error "reason=invalid_claim_secret path=$secret_path"
+        return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
+    fi
 
     local feed_env meta_path feeder_time payload response_file
     feed_env="$(root_path '/etc/airplanes/feed.env')"

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -1,0 +1,600 @@
+#!/usr/bin/env bash
+
+# `apl-feed config sync` — push the local feed.env snapshot to
+# airplanes.live and apply the server's merged response. Invoked every
+# ~60s by airplanes-config-sync.timer (with 30s jitter). Operators can
+# trigger a one-shot run manually.
+#
+# Wire shape, gates, and merge semantics in
+# infrastructure/docs/feeder.md#remote-configuration. Authentication is
+# the standard Authorization: Bearer alv1.<uuid>.<secret> token. The
+# library's metadata-LWW gate (APL_APPLY_INCOMING_META_*) protects this
+# call site against a concurrent operator/webconfig write that lands
+# between the snapshot read and the apply step.
+#
+# Exit codes (intentional minimal surface — mirrors
+# airplanes-diagnostics.sh):
+#   0   applied / no_change / unowned heartbeat / any transient or
+#       recoverable failure (401, 423, 426, 429, 4xx body, 5xx,
+#       network error). The structured log line carries the reason;
+#       the operator reads journalctl -u airplanes-config-sync.
+#   64  hard local config error — missing Feeder ID or claim secret,
+#       broken installation. systemctl marks the unit failed so the
+#       failure surfaces in `apl-feed status` and `systemctl status`.
+
+# Legacy fallback tuple matches the migration in
+# scripts/lib/update-migrations.sh:migrate_seed_feed_meta_json so a
+# feeder whose sidecar is missing or corrupt converges to the server's
+# state rather than forging fresh feeder-stamped tuples.
+CONFIG_SYNC_LEGACY_EDITED_AT="2020-01-01T00:00:00Z"
+CONFIG_SYNC_LEGACY_EDITED_BY="legacy"
+
+CONFIG_SYNC_EXIT_OK=0
+CONFIG_SYNC_EXIT_BAD_CONFIG=64
+
+# Sentinel mtime path. Overridable for tests + chroot smokes.
+CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-/var/lib/airplanes/config-sync-last-success}"
+
+# Structured logger. Mirrors airplanes-diagnostics.sh's `log` so the two
+# timers produce a uniform journal stream.
+_config_sync_log() {
+    local level="$1"
+    shift
+    printf 'apl-feed-config-sync level=%s %s\n' "$level" "$*" >&2
+}
+
+# True if feed.env has a (non-comment) line matching `^[[:space:]]*KEY=`.
+# Distinguishes "absent" (omit field from payload) from "present-empty"
+# (emit tombstone where the schema accepts null).
+_config_sync_has_key() {
+    local feed_env="$1" key="$2"
+    [[ -f "$feed_env" ]] || return 1
+    grep -qE "^[[:space:]]*${key}=" "$feed_env" 2>/dev/null
+}
+
+# Normalize a feed.env bool ("true"/"yes"/"1"/"on" or "false"/"no"/"0"/
+# "off") to the canonical "true"/"false" the API expects as a JSON bool.
+# Returns 1 (and emits nothing) on unparseable / empty.
+_config_sync_read_bool() {
+    local raw="${1:-}"
+    case "${raw,,}" in
+        true|yes|1|on)
+            printf 'true'
+            return 0
+            ;;
+        false|no|0|off)
+            printf 'false'
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# Load /etc/airplanes/feed.meta.json into per-key (edited_at, edited_by)
+# associative arrays via nameref. Missing / corrupt / non-v1 schema all
+# leave the maps empty without erroring — callers fall back to the
+# legacy tuple per-key.
+_config_sync_load_meta() {
+    local meta_path="$1"
+    local -n at_out="$2"
+    local -n by_out="$3"
+    at_out=()
+    by_out=()
+    [[ -f "$meta_path" ]] || return 0
+    local entries
+    if ! entries="$(jq -r '
+        if (type == "object") and (.schema_version == 1) and (.fields | type == "object") then
+            .fields | to_entries[] |
+            select(.value | type == "object") |
+            select(.value.edited_at | type == "string") |
+            select(.value.edited_by | type == "string") |
+            "\(.key)\t\(.value.edited_at)\t\(.value.edited_by)"
+        else empty end
+    ' "$meta_path" 2>/dev/null)"; then
+        return 0
+    fi
+    local key at by
+    while IFS=$'\t' read -r key at by; do
+        [[ -z "$key" ]] && continue
+        at_out[$key]="$at"
+        by_out[$key]="$by"
+    done <<< "$entries"
+}
+
+# Resolve per-field outgoing (edited_at, edited_by). Sets the
+# top-level _PAY_AT_<key> / _PAY_BY_<key> locals in the caller's scope.
+# Default falls back to the legacy tuple when the sidecar has no entry.
+_config_sync_resolve_field_meta() {
+    local key="$1"
+    local fallback_by="${4:-$CONFIG_SYNC_LEGACY_EDITED_BY}"
+    local -n at_map="$2"
+    local -n by_map="$3"
+    if [[ -n "${at_map[$key]+set}" ]]; then
+        printf '%s\t%s' "${at_map[$key]}" "${by_map[$key]:-$fallback_by}"
+    else
+        printf '%s\t%s' "$CONFIG_SYNC_LEGACY_EDITED_AT" "$CONFIG_SYNC_LEGACY_EDITED_BY"
+    fi
+}
+
+# Build the outgoing payload JSON. Reads feed.env + feed.meta.json and
+# emits the body the API expects on stdout. Returns 0 on success, 1 on
+# unrecoverable build error.
+_config_sync_build_payload() {
+    local feed_env="$1" meta_path="$2" feeder_time="$3"
+    local -A meta_at=() meta_by=()
+    _config_sync_load_meta "$meta_path" meta_at meta_by
+
+    local lat lon alt mlat_user mlat_enabled mlat_private geo_configured
+    lat="$(feed_env_get LATITUDE 2>/dev/null || true)"
+    lon="$(feed_env_get LONGITUDE 2>/dev/null || true)"
+    alt="$(feed_env_get ALTITUDE 2>/dev/null || true)"
+    mlat_user="$(feed_env_get MLAT_USER 2>/dev/null || true)"
+    mlat_enabled="$(feed_env_get MLAT_ENABLED 2>/dev/null || true)"
+    mlat_private="$(feed_env_get MLAT_PRIVATE 2>/dev/null || true)"
+    geo_configured="$(feed_env_get GEO_CONFIGURED 2>/dev/null || true)"
+
+    # Position: tombstone unless GEO_CONFIGURED=true AND both axes
+    # parse as numbers. Atomic-pair edited_at = min(lat.at, lon.at)
+    # so a freshly-stamped axis doesn't promote a stale other-axis to
+    # "newer than server."
+    local position_value='null'
+    local position_at="$CONFIG_SYNC_LEGACY_EDITED_AT"
+    local position_by="$CONFIG_SYNC_LEGACY_EDITED_BY"
+    local geo_lower="${geo_configured,,}"
+    if [[ "$geo_lower" == "true" && -n "$lat" && -n "$lon" ]]; then
+        local pos_candidate
+        if pos_candidate="$(jq -nc \
+            --arg lat "$lat" --arg lon "$lon" \
+            '{lat: ($lat | tonumber), lon: ($lon | tonumber)}' 2>/dev/null)"; then
+            position_value="$pos_candidate"
+        fi
+    fi
+    local lat_at="${meta_at[LATITUDE]:-}"
+    local lon_at="${meta_at[LONGITUDE]:-}"
+    if [[ -n "$lat_at" && -n "$lon_at" ]]; then
+        if [[ "$lat_at" < "$lon_at" ]]; then
+            position_at="$lat_at"
+        else
+            position_at="$lon_at"
+        fi
+        # On-disk position is feeder-originated by definition (the only
+        # path that mutates LAT/LON is operator-driven writes through
+        # apl_feed_apply, all of which stamp edited_by=feeder when not
+        # told otherwise). Force the wire value rather than echoing one
+        # axis' stamp arbitrarily.
+        position_by="feeder"
+    elif [[ -n "$lat_at" ]]; then
+        position_at="$lat_at"
+        position_by="${meta_by[LATITUDE]:-feeder}"
+    elif [[ -n "$lon_at" ]]; then
+        position_at="$lon_at"
+        position_by="${meta_by[LONGITUDE]:-feeder}"
+    fi
+
+    # Build via jq with per-field --arg streams so values pass through
+    # JSON-safely. `--argjson position_value` lets us emit either the
+    # object `{lat,lon}` or the literal `null` based on the variable.
+    local filter='{schema_version: 1, feeder_time: $feeder_time, fields: {}}'
+    local -a jq_args=(
+        --arg feeder_time "$feeder_time"
+        --argjson pos_value "$position_value"
+        --arg pos_at "$position_at"
+        --arg pos_by "$position_by"
+    )
+    filter+=' | .fields.position = {value: $pos_value, edited_at: $pos_at, edited_by: $pos_by}'
+
+    # alt — nullable string.
+    if _config_sync_has_key "$feed_env" ALTITUDE; then
+        local alt_at alt_by alt_meta
+        alt_meta="$(_config_sync_resolve_field_meta ALTITUDE meta_at meta_by)"
+        alt_at="${alt_meta%%$'\t'*}"
+        alt_by="${alt_meta##*$'\t'}"
+        jq_args+=(--arg alt_at "$alt_at" --arg alt_by "$alt_by")
+        if [[ -z "$alt" ]]; then
+            filter+=' | .fields.alt = {value: null, edited_at: $alt_at, edited_by: $alt_by}'
+        else
+            jq_args+=(--arg alt_v "$alt")
+            filter+=' | .fields.alt = {value: $alt_v, edited_at: $alt_at, edited_by: $alt_by}'
+        fi
+    fi
+
+    # mlat_user — nullable string.
+    if _config_sync_has_key "$feed_env" MLAT_USER; then
+        local mu_at mu_by mu_meta
+        mu_meta="$(_config_sync_resolve_field_meta MLAT_USER meta_at meta_by)"
+        mu_at="${mu_meta%%$'\t'*}"
+        mu_by="${mu_meta##*$'\t'}"
+        jq_args+=(--arg mu_at "$mu_at" --arg mu_by "$mu_by")
+        if [[ -z "$mlat_user" ]]; then
+            filter+=' | .fields.mlat_user = {value: null, edited_at: $mu_at, edited_by: $mu_by}'
+        else
+            jq_args+=(--arg mu_v "$mlat_user")
+            filter+=' | .fields.mlat_user = {value: $mu_v, edited_at: $mu_at, edited_by: $mu_by}'
+        fi
+    fi
+
+    # mlat_enabled — non-nullable bool. Omit the field entirely when
+    # the key is absent or unparseable (the API rejects null booleans).
+    if _config_sync_has_key "$feed_env" MLAT_ENABLED; then
+        local me_norm
+        if me_norm="$(_config_sync_read_bool "$mlat_enabled")"; then
+            local me_at me_by me_meta
+            me_meta="$(_config_sync_resolve_field_meta MLAT_ENABLED meta_at meta_by)"
+            me_at="${me_meta%%$'\t'*}"
+            me_by="${me_meta##*$'\t'}"
+            jq_args+=(
+                --argjson me_v "$me_norm"
+                --arg me_at "$me_at"
+                --arg me_by "$me_by"
+            )
+            filter+=' | .fields.mlat_enabled = {value: $me_v, edited_at: $me_at, edited_by: $me_by}'
+        fi
+    fi
+
+    # mlat_private — non-nullable bool. Same omission rules as
+    # mlat_enabled.
+    if _config_sync_has_key "$feed_env" MLAT_PRIVATE; then
+        local mp_norm
+        if mp_norm="$(_config_sync_read_bool "$mlat_private")"; then
+            local mp_at mp_by mp_meta
+            mp_meta="$(_config_sync_resolve_field_meta MLAT_PRIVATE meta_at meta_by)"
+            mp_at="${mp_meta%%$'\t'*}"
+            mp_by="${mp_meta##*$'\t'}"
+            jq_args+=(
+                --argjson mp_v "$mp_norm"
+                --arg mp_at "$mp_at"
+                --arg mp_by "$mp_by"
+            )
+            filter+=' | .fields.mlat_private = {value: $mp_v, edited_at: $mp_at, edited_by: $mp_by}'
+        fi
+    fi
+
+    jq -nc "${jq_args[@]}" "$filter"
+}
+
+# Update the success-mtime sentinel. Failure to touch is non-fatal —
+# the next successful sync will retry. Path is taken straight from the
+# AIRPLANES_CONFIG_SYNC_LAST_SUCCESS env var (or the production default);
+# chroot / test callers override the env var rather than relying on
+# --root translation so the sentinel lands exactly where they expect.
+_config_sync_touch_sentinel() {
+    local file="$CONFIG_SYNC_LAST_SUCCESS_FILE"
+    local dir
+    dir="$(dirname "$file")"
+    mkdir -p "$dir" 2>/dev/null || true
+    : > "$file" 2>/dev/null || true
+}
+
+# Translate the server's `fields` response into per-key arguments for
+# apl_feed_apply. Populates the caller-passed arrays:
+#   APL_APPLY_INCOMING_META_EDITED_AT, _EDITED_BY (global, by contract
+#   with the lib) and the local arg-list array `out_args` (nameref).
+#
+# Tombstones (value: null) emit empty-string values for nullable feed.env
+# keys (LATITUDE, LONGITUDE, ALTITUDE, MLAT_USER); the bool keys never
+# receive a tombstone (the API serializer rejects null booleans).
+#
+# The rejected_fields response array is processed by adopting the
+# server's tuple for each rejected key — that heals a bogus on-disk
+# edited_at and ends the rejection loop on the next tick.
+_config_sync_translate_response() {
+    local response_file="$1"
+    local -n out_args="$2"
+    out_args=()
+    APL_APPLY_INCOMING_META_EDITED_AT=()
+    APL_APPLY_INCOMING_META_EDITED_BY=()
+
+    # jq extracts one TAB-separated line per API field with: name,
+    # is_tombstone, value, edited_at, edited_by. Position's value is
+    # rendered as `lat|lon` so a single line carries both axes; bool
+    # values come out as `true`/`false`; null values render as empty
+    # string in the `value` column with `is_tombstone=1`.
+    local entries
+    if ! entries="$(jq -r '
+        .fields | to_entries[] |
+        [.key,
+         (if .value.value == null then "1" else "0" end),
+         (if .value.value == null then ""
+          elif .key == "position" then "\(.value.value.lat)|\(.value.value.lon)"
+          elif (.value.value | type) == "boolean" then (.value.value | tostring)
+          else (.value.value | tostring) end),
+         .value.edited_at,
+         .value.edited_by] |
+        @tsv
+    ' "$response_file" 2>/dev/null)"; then
+        return 1
+    fi
+
+    local api_field is_null value edited_at edited_by
+    while IFS=$'\t' read -r api_field is_null value edited_at edited_by; do
+        [[ -z "$api_field" ]] && continue
+        case "$api_field" in
+            position)
+                if [[ "$is_null" == "1" ]]; then
+                    out_args+=("LATITUDE=" "LONGITUDE=")
+                else
+                    local pos_lat="${value%|*}" pos_lon="${value#*|}"
+                    out_args+=("LATITUDE=$pos_lat" "LONGITUDE=$pos_lon")
+                fi
+                APL_APPLY_INCOMING_META_EDITED_AT[LATITUDE]="$edited_at"
+                APL_APPLY_INCOMING_META_EDITED_AT[LONGITUDE]="$edited_at"
+                APL_APPLY_INCOMING_META_EDITED_BY[LATITUDE]="$edited_by"
+                APL_APPLY_INCOMING_META_EDITED_BY[LONGITUDE]="$edited_by"
+                ;;
+            alt)
+                if [[ "$is_null" == "1" ]]; then
+                    out_args+=("ALTITUDE=")
+                else
+                    out_args+=("ALTITUDE=$value")
+                fi
+                APL_APPLY_INCOMING_META_EDITED_AT[ALTITUDE]="$edited_at"
+                APL_APPLY_INCOMING_META_EDITED_BY[ALTITUDE]="$edited_by"
+                ;;
+            mlat_user)
+                if [[ "$is_null" == "1" ]]; then
+                    out_args+=("MLAT_USER=")
+                else
+                    out_args+=("MLAT_USER=$value")
+                fi
+                APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="$edited_at"
+                APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="$edited_by"
+                ;;
+            mlat_enabled)
+                out_args+=("MLAT_ENABLED=$value")
+                APL_APPLY_INCOMING_META_EDITED_AT[MLAT_ENABLED]="$edited_at"
+                APL_APPLY_INCOMING_META_EDITED_BY[MLAT_ENABLED]="$edited_by"
+                ;;
+            mlat_private)
+                out_args+=("MLAT_PRIVATE=$value")
+                APL_APPLY_INCOMING_META_EDITED_AT[MLAT_PRIVATE]="$edited_at"
+                APL_APPLY_INCOMING_META_EDITED_BY[MLAT_PRIVATE]="$edited_by"
+                ;;
+            *)
+                # Unknown server field — ignore. A schema_version=1
+                # server should never emit one; future versions are
+                # caught by the 426 path before we ever reach this.
+                ;;
+        esac
+    done <<< "$entries"
+
+    return 0
+}
+
+# Drive the apply step for a 200 APPLIED response. Returns 0 on success
+# (applied / no_change), 1 on any apply-side failure (logged + treated
+# as transient by the caller).
+_config_sync_apply_response() {
+    local response_file="$1"
+    local skip_restart="$2"
+    local -a apply_args=()
+    if ! _config_sync_translate_response "$response_file" apply_args; then
+        _config_sync_log error "reason=apply_translate body=$(body_preview "$response_file")"
+        APL_APPLY_INCOMING_META_EDITED_AT=()
+        APL_APPLY_INCOMING_META_EDITED_BY=()
+        return 1
+    fi
+    if (( ${#apply_args[@]} == 0 )); then
+        # Server returned `fields: {}` — nothing to apply. Treat as
+        # success but log so an unexpected empty response is visible.
+        _config_sync_log info "reason=empty_fields_payload"
+        APL_APPLY_INCOMING_META_EDITED_AT=()
+        APL_APPLY_INCOMING_META_EDITED_BY=()
+        return 0
+    fi
+
+    feed_env_ensure_canonical_for_write
+    local -a lib_args=(--feed-env "$(feed_env_write_path)"
+                       --lock-file "$(feed_env_lock_path)")
+    if (( skip_restart )); then
+        lib_args+=(--no-restart)
+    fi
+    if [[ "$ROOT" != "/" ]]; then
+        lib_args+=(--no-restart --no-audit)
+    fi
+
+    local rc=0
+    apl_feed_apply "${lib_args[@]}" "${apply_args[@]}" || rc=$?
+    # Always clear the globals so a subsequent call (e.g. retry from
+    # the timer's next tick) starts from a clean slate.
+    APL_APPLY_INCOMING_META_EDITED_AT=()
+    APL_APPLY_INCOMING_META_EDITED_BY=()
+
+    case "$APL_APPLY_STATUS" in
+        applied|no_change)
+            local skipped="${APL_APPLY_SKIPPED_BY_LWW[*]:-}"
+            local changed="${APL_APPLY_CHANGED[*]:-}"
+            _config_sync_log info \
+                "reason=applied status=$APL_APPLY_STATUS changed=[${changed}] lww_skipped=[${skipped}]"
+            return 0
+            ;;
+        rejected)
+            local k errs=""
+            for k in "${!APL_APPLY_ERRORS[@]}"; do
+                errs+="${k}=\"${APL_APPLY_ERRORS[$k]}\" "
+            done
+            _config_sync_log error "reason=apply_rejected errors=[${errs% }]"
+            return 1
+            ;;
+        lock_timeout|filesystem_error|usage_error)
+            _config_sync_log warn \
+                "reason=apply_${APL_APPLY_STATUS} message=\"${APL_APPLY_ERROR_MESSAGE}\""
+            return 1
+            ;;
+        *)
+            _config_sync_log warn "reason=apply_unknown status=${APL_APPLY_STATUS:-empty} rc=$rc"
+            return 1
+            ;;
+    esac
+}
+
+# Print the outgoing payload to stdout (for --dry-run). Returns 0 on
+# success, 1 on local read error.
+_config_sync_dry_run() {
+    local feed_env feeder_time payload
+    feed_env="$(root_path '/etc/airplanes/feed.env')"
+    local meta_path="${feed_env%/feed.env}/feed.meta.json"
+    feeder_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    if [[ ! -f "$feed_env" ]]; then
+        _config_sync_log error "reason=feed_env_missing path=$feed_env"
+        return 1
+    fi
+    if ! payload="$(_config_sync_build_payload "$feed_env" "$meta_path" "$feeder_time")"; then
+        _config_sync_log error "reason=payload_build_failed"
+        return 1
+    fi
+    printf '%s\n' "$payload"
+    return 0
+}
+
+apl_feed_config_sync() {
+    local dry_run=0
+    local skip_restart=0
+
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)
+                dry_run=1
+                shift
+                ;;
+            --no-restart)
+                skip_restart=1
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+                case "$opt_rc" in
+                    1) shift ;;
+                    2) shift 2 ;;
+                    0) die "unknown flag for config sync: $1" ;;
+                esac
+                ;;
+        esac
+    done
+
+    require_jq
+
+    if (( dry_run )); then
+        if _config_sync_dry_run; then
+            return "$CONFIG_SYNC_EXIT_OK"
+        fi
+        return 1
+    fi
+
+    # Identity prerequisites. Failure here is a hard config error —
+    # exit 64 so systemd marks the unit failed.
+    local uuid secret_path secret
+    if ! uuid="$(read_uuid 2>/dev/null)"; then
+        _config_sync_log error "reason=missing_uuid"
+        return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
+    fi
+    secret_path="$(secret_final_path)"
+    if [[ ! -f "$secret_path" ]]; then
+        _config_sync_log error "reason=missing_claim_secret path=$secret_path"
+        return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
+    fi
+    if [[ ! -r "$secret_path" ]]; then
+        _config_sync_log error "reason=unreadable_claim_secret path=$secret_path"
+        return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
+    fi
+    secret="$(read_secret_file "$secret_path")"
+
+    local feed_env meta_path feeder_time payload response_file
+    feed_env="$(root_path '/etc/airplanes/feed.env')"
+    meta_path="${feed_env%/feed.env}/feed.meta.json"
+    feeder_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    if [[ ! -f "$feed_env" ]]; then
+        _config_sync_log error "reason=feed_env_missing path=$feed_env"
+        return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
+    fi
+
+    if ! payload="$(_config_sync_build_payload "$feed_env" "$meta_path" "$feeder_time")"; then
+        _config_sync_log error "reason=payload_build_failed"
+        return "$CONFIG_SYNC_EXIT_OK"
+    fi
+
+    response_file="$(new_tmp_file)"
+    local status curl_rc token
+    token="alv1.${uuid}.${secret}"
+    set +e
+    status="$(post_json_bearer "$token" '/api/feeders/config/sync' "$payload" "$response_file")"
+    curl_rc=$?
+    set -e
+
+    if [[ "$curl_rc" -ne 0 ]]; then
+        _config_sync_log warn "reason=transport curl_rc=$curl_rc"
+        return "$CONFIG_SYNC_EXIT_OK"
+    fi
+
+    local error_field body_preview owned
+    error_field="$(parse_field_from "$response_file" '.error')"
+    body_preview="$(body_preview "$response_file")"
+
+    case "$status" in
+        200)
+            owned="$(parse_field_from "$response_file" '.owned')"
+            case "$owned" in
+                true)
+                    local rejected
+                    rejected="$(jq -r '.rejected_fields // [] | join(",")' "$response_file" 2>/dev/null || true)"
+                    if [[ -n "$rejected" ]]; then
+                        _config_sync_log warn "reason=rejected_fields fields=[$rejected]"
+                    fi
+                    if _config_sync_apply_response "$response_file" "$skip_restart"; then
+                        _config_sync_touch_sentinel
+                    fi
+                    ;;
+                false)
+                    _config_sync_log info "reason=unowned"
+                    _config_sync_touch_sentinel
+                    ;;
+                *)
+                    _config_sync_log warn "reason=malformed_response body=$body_preview"
+                    ;;
+            esac
+            ;;
+        400)
+            _config_sync_log error "reason=validation_failed body=$body_preview"
+            ;;
+        401)
+            _config_sync_log error "reason=unauthorized body=$body_preview"
+            ;;
+        423)
+            local block_reason
+            block_reason="$(parse_field_from "$response_file" '.reason')"
+            _config_sync_log warn "reason=blocked block_reason=${block_reason:-unknown}"
+            ;;
+        426)
+            local supported
+            supported="$(jq -r '.supported // [] | tostring' "$response_file" 2>/dev/null || true)"
+            _config_sync_log error "reason=schema_version_unsupported server_supported=${supported:-[]}"
+            ;;
+        429)
+            _config_sync_log warn "reason=rate_limited body=$body_preview"
+            ;;
+        5*)
+            _config_sync_log warn "reason=server_${status} body=$body_preview"
+            ;;
+        *)
+            _config_sync_log warn "reason=unexpected_status status=$status error=${error_field:-} body=$body_preview"
+            ;;
+    esac
+
+    return "$CONFIG_SYNC_EXIT_OK"
+}
+
+dispatch_config() {
+    local sub="${1:-}"
+    [[ -n "$sub" ]] || die "config requires a subcommand (sync)"
+    shift || true
+    case "$sub" in
+        sync) apl_feed_config_sync "$@" ;;
+        -h|--help) usage ;;
+        *) die "unknown config subcommand: $sub" ;;
+    esac
+}

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -62,6 +62,14 @@ APL_FEED_APPLY_EDITED_AT_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]
 declare -gA APL_APPLY_INCOMING_META_EDITED_AT=()
 declare -gA APL_APPLY_INCOMING_META_EDITED_BY=()
 
+# Caller-input scalar: server-supplied "now" timestamp (RFC 3339 UTC)
+# used as the reference for the LWW gate's bogus-future-heal check.
+# Set by callers like `apl-feed config sync` to the server_time field of
+# the response so a feeder with a fast local clock cannot self-mask its
+# own corrupt on-disk metadata. Empty string => fall back to local now()
+# (acceptable for callers that don't have a trusted external clock).
+APL_APPLY_INCOMING_SERVER_TIME="${APL_APPLY_INCOMING_SERVER_TIME:-}"
+
 # Result global: indexed array of payload keys whose write was skipped
 # because the incoming metadata's edited_at was older-or-equal to the
 # on-disk edited_at recorded in feed.meta.json. The skip is per-key —
@@ -918,9 +926,35 @@ apl_feed_apply() {
     # clock-skew rejection that produced the heal payload in the first
     # place (rejected_fields response from /api/feeders/config/sync).
     local _lww_key _on_disk _incoming _on_disk_n _incoming_n _now_skew_n
-    _now_skew_n="$(_apl_feed_apply_normalize_iso_for_compare \
-        "$(_apl_feed_apply_iso_plus_seconds \
-            "$APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS")")"
+    # Bogus-future-heal reference: prefer the caller-supplied server time
+    # over the local clock so a feeder with a fast NTP offset cannot mark
+    # its own already-corrupt metadata as legitimately newer than the
+    # server response and re-skip the heal indefinitely. Empty
+    # APL_APPLY_INCOMING_SERVER_TIME (most callers) falls back to local
+    # now() — matches the previous behavior for non-sync writers.
+    local _now_ref
+    if [[ -n "$APL_APPLY_INCOMING_SERVER_TIME" \
+        && "$APL_APPLY_INCOMING_SERVER_TIME" =~ $APL_FEED_APPLY_EDITED_AT_RE ]]; then
+        _now_ref="$APL_APPLY_INCOMING_SERVER_TIME"
+    else
+        _now_ref="$(_apl_feed_apply_iso_plus_seconds 0)"
+    fi
+    # Compute "_now_ref + CLOCK_SKEW_MAX" by re-using iso_plus_seconds for
+    # the local-now path and accepting the trade-off that a server-time
+    # path adds the skew by string-extension (we'd need a date -d that
+    # parses ISO 8601 reliably). For server-time, normalize then bolt on
+    # the skew by re-rendering through GNU date.
+    if [[ -n "$APL_APPLY_INCOMING_SERVER_TIME" \
+        && "$APL_APPLY_INCOMING_SERVER_TIME" =~ $APL_FEED_APPLY_EDITED_AT_RE ]]; then
+        _now_skew_n="$(date -u -d "$_now_ref +${APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS} seconds" \
+            +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || _apl_feed_apply_iso_plus_seconds "$APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS")"
+        _now_skew_n="$(_apl_feed_apply_normalize_iso_for_compare "$_now_skew_n")"
+    else
+        _now_skew_n="$(_apl_feed_apply_normalize_iso_for_compare \
+            "$(_apl_feed_apply_iso_plus_seconds \
+                "$APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS")")"
+    fi
     for _lww_key in "${!_meta_in_at[@]}"; do
         # Only gate keys actually in the payload — `_meta_in_at` may
         # contain stray entries already rejected by the payload-coverage

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -62,6 +62,17 @@ APL_FEED_APPLY_EDITED_AT_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]
 declare -gA APL_APPLY_INCOMING_META_EDITED_AT=()
 declare -gA APL_APPLY_INCOMING_META_EDITED_BY=()
 
+# Result global: indexed array of payload keys whose write was skipped
+# because the incoming metadata's edited_at was older-or-equal to the
+# on-disk edited_at recorded in feed.meta.json. The skip is per-key —
+# other payload keys in the same call apply normally. Skipped keys do
+# NOT appear in APL_APPLY_CHANGED and do NOT trigger service restarts.
+#
+# Symmetric with the server-side merge: equal-edited_at favors the
+# existing tuple on both sides, so a tie does not produce churn and the
+# data converges via whichever side has the strictly-newer edit.
+declare -ga APL_APPLY_SKIPPED_BY_LWW=()
+
 # Universal-reject character set. Mirrors Go configspec.universalReject.
 # Defense-in-depth: a regex-passing value containing a shell metachar
 # cannot reach feed.env (which gets `source`d by airplanes-feed.sh and
@@ -443,6 +454,38 @@ _apl_feed_apply_iso_now() {
     date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
+# Normalize an RFC 3339 UTC timestamp to its no-fractional-second form so
+# byte-wise (lexicographic) comparison matches semantic ordering for the
+# two on-the-wire shapes the lib accepts: YYYY-MM-DDTHH:MM:SSZ and
+# YYYY-MM-DDTHH:MM:SS.ffffffZ. Sub-second precision is discarded for the
+# compare — the server-side merge is also second-precision, so a feeder
+# distinguishing T+0.5s from T+0.0s would produce drift across the round
+# trip. Callers do the compare on the returned string.
+_apl_feed_apply_normalize_iso_for_compare() {
+    local s="$1"
+    s="${s%Z}"
+    s="${s%%.*}"
+    printf '%sZ' "$s"
+}
+
+# Maximum acceptable lead an on-disk `edited_at` can have over server-now
+# before the LWW gate treats the on-disk stamp as bogus and lets the
+# incoming server tuple heal it. Mirrors the server-side CLOCK_SKEW_MAX
+# (accounts/services/feeder_config.py) so a feeder whose clock was set
+# wildly forward can recover via the next sync cycle once NTP corrects.
+APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS="${APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS:-300}"
+
+# Emit `now + N seconds` in the same RFC 3339 UTC shape as
+# _apl_feed_apply_iso_now. Falls back to plain `now()` when the host's
+# `date` does not support GNU's `-d` flag (e.g. BSD date on a macOS dev
+# box). The fallback effectively disables the bogus-future heal path on
+# that host — acceptable; production runs on Linux where -d works.
+_apl_feed_apply_iso_plus_seconds() {
+    local secs="$1"
+    date -u -d "+${secs} seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || _apl_feed_apply_iso_now
+}
+
 # Read feed.meta.json into two parallel assoc arrays passed by nameref.
 # Missing file → empty maps, no warning. Wrong schema_version or malformed
 # JSON → empty maps + APL_APPLY_PENDING_META_WARNING set (the next write
@@ -555,6 +598,7 @@ _apl_feed_apply_reset_state() {
     APL_APPLY_STATUS=""
     APL_APPLY_CHANGED=()
     APL_APPLY_PENDING_RESTART=()
+    APL_APPLY_SKIPPED_BY_LWW=()
     APL_APPLY_PENDING_META_WARNING=""
     APL_APPLY_ERROR_MESSAGE=""
     declare -gA APL_APPLY_ERRORS=()
@@ -847,6 +891,72 @@ apl_feed_apply() {
         fi
     done
 
+    # Read the sidecar once under the lock. Used by both the LWW gate
+    # below AND the sidecar-write block at the bottom of this function.
+    # Reading inside the lock avoids racing a concurrent writer between
+    # snapshot and apply. Missing/corrupt file -> empty maps (lib helper
+    # already sets APL_APPLY_PENDING_META_WARNING when relevant).
+    local -A existing_at=() existing_by=()
+    _apl_feed_apply_read_meta "$meta_path" existing_at existing_by
+
+    # Per-key LWW gate. Any payload entry whose incoming `edited_at` is
+    # NOT strictly newer than the on-disk `edited_at` is dropped from
+    # this write. The skip is per-key: other entries in the same call
+    # apply normally. Bare-string payloads (no incoming metadata) bypass
+    # the gate so the existing operator-facing CLIs (mlat user, 978, etc.)
+    # are unaffected — those callers don't pass metadata, the lib stamps
+    # `now()` on their behalf, and `now()` always wins by definition.
+    #
+    # Symmetric with the server-side LWW (accounts/services/feeder_config.py):
+    # both sides favor the existing tuple on exact-edited_at equality. The
+    # data converges via whichever side has the strictly-newer edit.
+    #
+    # Bogus-future-heal: an on-disk `edited_at` more than
+    # APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS ahead of server-now is
+    # treated as invalid — the gate is bypassed for that key so the
+    # incoming server tuple can heal it. Mirrors the server-side
+    # clock-skew rejection that produced the heal payload in the first
+    # place (rejected_fields response from /api/feeders/config/sync).
+    local _lww_key _on_disk _incoming _on_disk_n _incoming_n _now_skew_n
+    _now_skew_n="$(_apl_feed_apply_normalize_iso_for_compare \
+        "$(_apl_feed_apply_iso_plus_seconds \
+            "$APL_FEED_APPLY_LWW_FUTURE_SKEW_SECONDS")")"
+    for _lww_key in "${!_meta_in_at[@]}"; do
+        # Only gate keys actually in the payload — `_meta_in_at` may
+        # contain stray entries already rejected by the payload-coverage
+        # check above (defensive; that path returns early).
+        [[ -n "${payload[$_lww_key]+set}" ]] || continue
+        _on_disk="${existing_at[$_lww_key]:-}"
+        # No on-disk metadata for this key => bootstrap case. Incoming
+        # tuple wins unconditionally.
+        [[ -n "$_on_disk" ]] || continue
+        _incoming="${_meta_in_at[$_lww_key]}"
+        _on_disk_n="$(_apl_feed_apply_normalize_iso_for_compare "$_on_disk")"
+        _incoming_n="$(_apl_feed_apply_normalize_iso_for_compare "$_incoming")"
+        # On-disk stamp wildly in the future -> bogus. Bypass the gate
+        # and let the incoming tuple heal the bad metadata.
+        if [[ "$_on_disk_n" > "$_now_skew_n" ]]; then
+            continue
+        fi
+        # `[[ A > B ]]` is a string compare under shopt -o noglob default.
+        # The normalized form is fixed-width lexicographically sortable.
+        if [[ ! "$_incoming_n" > "$_on_disk_n" ]]; then
+            APL_APPLY_SKIPPED_BY_LWW+=("$_lww_key")
+            unset 'payload[$_lww_key]'
+            unset '_meta_in_at[$_lww_key]'
+            unset '_meta_in_by[$_lww_key]'
+        fi
+    done
+
+    # If every incoming key was LWW-skipped the call resolves to no_change.
+    # Mirrors the pre-lock empty-payload check, but runs after the gate
+    # has had a chance to drop entries.
+    if (( ${#payload[@]} == 0 )); then
+        APL_APPLY_STATUS=no_change
+        [[ -n "$lock_fd" ]] && eval "exec ${lock_fd}>&-"
+        return 0
+    fi
+
     APL_APPLY_CHANGED=()
     for key in "${!payload[@]}"; do
         value="${payload[$key]}"
@@ -926,9 +1036,9 @@ apl_feed_apply() {
     # be held hostage by an informational sidecar. The next metadata-bearing
     # write reconciles.
     if (( ${#sidecar_keys[@]} > 0 )) && [[ -n "$lock_fd" ]]; then
-        local -A existing_at=() existing_by=()
-        _apl_feed_apply_read_meta "$meta_path" existing_at existing_by
-
+        # `existing_at` / `existing_by` were already populated under the
+        # same lock above (used for the LWW gate). Reuse them here rather
+        # than re-reading the sidecar.
         local -A merged_at=() merged_by=()
         local mk
         for mk in "${!existing_at[@]}"; do

--- a/test/test_apl_feed_config_sync.bats
+++ b/test/test_apl_feed_config_sync.bats
@@ -1,0 +1,359 @@
+#!/usr/bin/env bats
+
+# Tests for `apl-feed config sync` (scripts/apl-feed/config.sh).
+# Drives the CLI via apl-feed.sh with --root $ROOT_DIR. Curl is stubbed
+# to return canned HTTP status codes + bodies; the real apl_feed_apply
+# library is exercised end-to-end so the LWW gate and feed.meta.json
+# round-trip are part of the test.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    CURL_LOG="$ROOT_DIR/curl.log"
+    CURL_REQ_BODY="$ROOT_DIR/curl-req-body.json"
+    CANNED_STATUS_FILE="$ROOT_DIR/canned-status"
+    CANNED_RESPONSE_FILE="$ROOT_DIR/canned-response.json"
+    mkdir -p "$STUB_DIR" \
+        "$ROOT_DIR/etc/airplanes" \
+        "$ROOT_DIR/run/airplanes" \
+        "$ROOT_DIR/var/lib/airplanes"
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
+
+    # Curl stub. Records argv + stdin body; writes canned response body
+    # to the --output path; emits canned HTTP status to stdout.
+    cat > "$STUB_DIR/curl" <<STUB
+#!/usr/bin/env bash
+printf 'curl %s\n' "\$*" >> "$CURL_LOG"
+output_path=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        --output) output_path="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+# Capture request body from stdin for assertions.
+cat > "$CURL_REQ_BODY"
+if [[ -n "\$output_path" && -f "$CANNED_RESPONSE_FILE" ]]; then
+    cp "$CANNED_RESPONSE_FILE" "\$output_path"
+fi
+if [[ -f "$CANNED_STATUS_FILE" ]]; then
+    cat "$CANNED_STATUS_FILE"
+else
+    printf '200'
+fi
+exit 0
+STUB
+    chmod +x "$STUB_DIR/curl"
+
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+
+    # Identity files. UUID + claim secret valid format.
+    printf 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n' \
+        > "$ROOT_DIR/etc/airplanes/feeder-id"
+    printf 'ABCD1234EFGH5678\n' \
+        > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    AIRPLANES_CONFIG_SYNC_LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes/config-sync-last-success"
+    export AIRPLANES_CONFIG_SYNC_LAST_SUCCESS
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+seed_feed_env() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE="47.0"
+LONGITUDE="8.0"
+ALTITUDE="120m"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+EOF
+}
+
+seed_feed_meta() {
+    # Take a flat (key, edited_at) pair list. edited_by always feeder.
+    local -a pairs=("$@")
+    local filter='{schema_version: 1, fields: {}}'
+    local jq_args=()
+    local i=0 k at
+    while (( i < ${#pairs[@]} )); do
+        k="${pairs[$i]}"
+        at="${pairs[$((i + 1))]}"
+        jq_args+=(--arg "k${i}" "$k" --arg "a${i}" "$at")
+        filter+=" | .fields[\$k${i}] = {edited_at: \$a${i}, edited_by: \"feeder\"}"
+        i=$((i + 2))
+    done
+    jq -nc "${jq_args[@]}" "$filter" > "$ROOT_DIR/etc/airplanes/feed.meta.json"
+}
+
+set_canned() {
+    local status="$1" body="$2"
+    printf '%s' "$status" > "$CANNED_STATUS_FILE"
+    printf '%s' "$body" > "$CANNED_RESPONSE_FILE"
+}
+
+run_sync() {
+    SYNC_OUT=""
+    SYNC_ERR=""
+    SYNC_RC=0
+    local err
+    err="$(mktemp)"
+    SYNC_OUT="$("$REPO_ROOT/scripts/apl-feed.sh" config sync --root "$ROOT_DIR" "$@" 2>"$err")" \
+        || SYNC_RC=$?
+    SYNC_ERR="$(cat "$err")"
+    rm -f "$err"
+}
+
+@test "dry-run emits the expected payload shape" {
+    seed_feed_env
+    seed_feed_meta LATITUDE "2026-05-10T10:00:00Z" LONGITUDE "2026-05-10T10:00:00Z" \
+        ALTITUDE "2026-05-09T00:00:00Z" MLAT_USER "2026-05-08T00:00:00Z" \
+        MLAT_ENABLED "2026-05-08T00:00:00Z" MLAT_PRIVATE "2026-05-08T00:00:00Z"
+
+    run_sync --dry-run
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ ! -f "$CURL_LOG" ]  # no network call
+    local payload="$SYNC_OUT"
+    [ "$(jq -r .schema_version <<<"$payload")" = "1" ]
+    jq -e '.fields.position.value.lat == 47' <<<"$payload" >/dev/null
+    jq -e '.fields.position.value.lon == 8' <<<"$payload" >/dev/null
+    [ "$(jq -r '.fields.position.edited_by' <<<"$payload")" = "feeder" ]
+    [ "$(jq -r '.fields.alt.value' <<<"$payload")" = "120m" ]
+    [ "$(jq -r '.fields.mlat_user.value' <<<"$payload")" = "alice" ]
+    [ "$(jq -r '.fields.mlat_enabled.value' <<<"$payload")" = "true" ]
+    [ "$(jq -r '.fields.mlat_enabled.value | type' <<<"$payload")" = "boolean" ]
+    [ "$(jq -r '.fields.mlat_private.value' <<<"$payload")" = "false" ]
+    [ "$(jq -r '.fields.mlat_private.value | type' <<<"$payload")" = "boolean" ]
+}
+
+@test "dry-run bootstrap path with missing feed.meta.json uses legacy tuple" {
+    seed_feed_env
+    # No feed.meta.json present.
+
+    run_sync --dry-run
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.position.edited_at' <<<"$SYNC_OUT")" = "2020-01-01T00:00:00Z" ]
+    [ "$(jq -r '.fields.alt.edited_at' <<<"$SYNC_OUT")" = "2020-01-01T00:00:00Z" ]
+    [ "$(jq -r '.fields.alt.edited_by' <<<"$SYNC_OUT")" = "legacy" ]
+    [ "$(jq -r '.fields.mlat_user.edited_by' <<<"$SYNC_OUT")" = "legacy" ]
+}
+
+@test "GEO_CONFIGURED=false tombstones position even with non-empty coords" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE="47.0"
+LONGITUDE="8.0"
+ALTITUDE="120m"
+GEO_CONFIGURED=false
+MLAT_USER="alice"
+MLAT_ENABLED=false
+MLAT_PRIVATE=false
+EOF
+    run_sync --dry-run
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.position.value' <<<"$SYNC_OUT")" = "null" ]
+}
+
+@test "empty LATITUDE tombstones position" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE=""
+LONGITUDE="8.0"
+ALTITUDE="120m"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+EOF
+    run_sync --dry-run
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.position.value' <<<"$SYNC_OUT")" = "null" ]
+}
+
+@test "position edited_at is min of LATITUDE and LONGITUDE stamps" {
+    seed_feed_env
+    seed_feed_meta LATITUDE "2026-05-14T12:00:00Z" LONGITUDE "2026-05-10T08:00:00Z"
+
+    run_sync --dry-run
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.position.edited_at' <<<"$SYNC_OUT")" = "2026-05-10T08:00:00Z" ]
+}
+
+@test "empty MLAT_USER emits null tombstone" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE="47.0"
+LONGITUDE="8.0"
+GEO_CONFIGURED=true
+ALTITUDE="120m"
+MLAT_USER=""
+MLAT_ENABLED=false
+MLAT_PRIVATE=false
+EOF
+    run_sync --dry-run
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.mlat_user.value' <<<"$SYNC_OUT")" = "null" ]
+}
+
+@test "MLAT_ENABLED absent omits the field entirely (non-nullable bool)" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE="47.0"
+LONGITUDE="8.0"
+GEO_CONFIGURED=true
+ALTITUDE="120m"
+MLAT_USER="alice"
+MLAT_PRIVATE=false
+EOF
+    run_sync --dry-run
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields | has("mlat_enabled")' <<<"$SYNC_OUT")" = "false" ]
+}
+
+@test "200 unowned heartbeat touches sentinel and skips apply" {
+    seed_feed_env
+    set_canned 200 '{"schema_version":1,"server_time":"2026-05-14T12:00:00Z","owned":false}'
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ -f "$AIRPLANES_CONFIG_SYNC_LAST_SUCCESS" ]
+    grep -F 'level=info' "$ROOT_DIR/sync.err" 2>/dev/null || true
+    # apl-feed apply would write to feed.env or systemd; assert
+    # systemctl wasn't called for a restart.
+    if [ -f "$SYSTEMCTL_LOG" ]; then
+        ! grep -F 'restart' "$SYSTEMCTL_LOG"
+    fi
+}
+
+@test "200 applied response runs apl_feed_apply with server tuples" {
+    seed_feed_env
+    seed_feed_meta MLAT_USER "2026-05-10T00:00:00Z"
+    # Server returns a newer mlat_user="bob".
+    set_canned 200 '{
+        "schema_version": 1,
+        "server_time": "2026-05-14T12:00:00Z",
+        "owned": true,
+        "fields": {
+            "position": {"value": {"lat": 47.0, "lon": 8.0}, "edited_at": "2026-05-10T10:00:00Z", "edited_by": "feeder"},
+            "alt": {"value": "120m", "edited_at": "2026-05-10T10:00:00Z", "edited_by": "feeder"},
+            "mlat_user": {"value": "bob", "edited_at": "2026-05-14T11:00:00Z", "edited_by": "website"},
+            "mlat_enabled": {"value": true, "edited_at": "2026-05-10T10:00:00Z", "edited_by": "feeder"},
+            "mlat_private": {"value": false, "edited_at": "2026-05-10T10:00:00Z", "edited_by": "feeder"}
+        }
+    }'
+
+    run_sync --no-restart
+
+    [ "$SYNC_RC" -eq 0 ]
+    # Feed.env should reflect bob now.
+    grep -F 'MLAT_USER="bob"' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Sidecar should carry the website tuple.
+    [ "$(jq -r '.fields.MLAT_USER.edited_by' "$ROOT_DIR/etc/airplanes/feed.meta.json")" = "website" ]
+    [ "$(jq -r '.fields.MLAT_USER.edited_at' "$ROOT_DIR/etc/airplanes/feed.meta.json")" = "2026-05-14T11:00:00Z" ]
+    [ -f "$AIRPLANES_CONFIG_SYNC_LAST_SUCCESS" ]
+}
+
+@test "200 applied with rejected_fields adopts server tuple to heal" {
+    seed_feed_env
+    # Bogus future on-disk stamp — server will reject and return a heal tuple.
+    seed_feed_meta MLAT_USER "3000-01-01T00:00:00Z"
+    set_canned 200 '{
+        "schema_version": 1,
+        "server_time": "2026-05-14T12:00:00Z",
+        "owned": true,
+        "rejected_fields": ["mlat_user"],
+        "fields": {
+            "position": {"value": {"lat": 47.0, "lon": 8.0}, "edited_at": "2020-01-01T00:00:00Z", "edited_by": "legacy"},
+            "alt": {"value": "120m", "edited_at": "2020-01-01T00:00:00Z", "edited_by": "legacy"},
+            "mlat_user": {"value": "alice", "edited_at": "2026-05-14T11:00:00Z", "edited_by": "feeder"},
+            "mlat_enabled": {"value": true, "edited_at": "2020-01-01T00:00:00Z", "edited_by": "legacy"},
+            "mlat_private": {"value": false, "edited_at": "2020-01-01T00:00:00Z", "edited_by": "legacy"}
+        }
+    }'
+
+    run_sync --no-restart
+
+    [ "$SYNC_RC" -eq 0 ]
+    # Stamp must be healed to the server's tuple.
+    [ "$(jq -r '.fields.MLAT_USER.edited_at' "$ROOT_DIR/etc/airplanes/feed.meta.json")" = "2026-05-14T11:00:00Z" ]
+    echo "$SYNC_ERR" | grep -F 'rejected_fields'
+}
+
+@test "401 logs unauthorized and exits 0" {
+    seed_feed_env
+    set_canned 401 '{"error":"unauthorized"}'
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 0 ]
+    echo "$SYNC_ERR" | grep -F 'reason=unauthorized'
+}
+
+@test "423 data_blocked logs and exits 0" {
+    seed_feed_env
+    set_canned 423 '{"error":"blocked","reason":"data_blocked"}'
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 0 ]
+    echo "$SYNC_ERR" | grep -F 'block_reason=data_blocked'
+}
+
+@test "426 logs schema mismatch and exits 0" {
+    seed_feed_env
+    set_canned 426 '{"error":"schema_version_unsupported","supported":[2]}'
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 0 ]
+    echo "$SYNC_ERR" | grep -F 'reason=schema_version_unsupported'
+}
+
+@test "503 logs transport and exits 0" {
+    seed_feed_env
+    set_canned 503 '{"error":"server_error"}'
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 0 ]
+    echo "$SYNC_ERR" | grep -F 'reason=server_503'
+}
+
+@test "missing feeder-id exits 64" {
+    seed_feed_env
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 64 ]
+}
+
+@test "missing claim secret exits 64" {
+    seed_feed_env
+    rm -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 64 ]
+    echo "$SYNC_ERR" | grep -F 'reason=missing_claim_secret'
+}

--- a/test/test_apl_feed_config_sync.bats
+++ b/test/test_apl_feed_config_sync.bats
@@ -190,14 +190,18 @@ EOF
     [ "$(jq -r '.fields.position.value' <<<"$SYNC_OUT")" = "null" ]
 }
 
-@test "position edited_at is min of LATITUDE and LONGITUDE stamps" {
+@test "position edited_at is max of LATITUDE and LONGITUDE stamps (atomic group)" {
+    # apl_feed_apply stamps both axes with the same now() in the normal
+    # case (MIN == MAX). In the divergent-stamps edge case, MAX reflects
+    # when the position state was last changed — the symmetric LWW gate
+    # in _config_sync_apply_response uses MAX too so atomicity holds.
     seed_feed_env
     seed_feed_meta LATITUDE "2026-05-14T12:00:00Z" LONGITUDE "2026-05-10T08:00:00Z"
 
     run_sync --dry-run
 
     [ "$SYNC_RC" -eq 0 ]
-    [ "$(jq -r '.fields.position.edited_at' <<<"$SYNC_OUT")" = "2026-05-10T08:00:00Z" ]
+    [ "$(jq -r '.fields.position.edited_at' <<<"$SYNC_OUT")" = "2026-05-14T12:00:00Z" ]
 }
 
 @test "empty MLAT_USER emits null tombstone" {
@@ -356,4 +360,78 @@ EOF
 
     [ "$SYNC_RC" -eq 64 ]
     echo "$SYNC_ERR" | grep -F 'reason=missing_claim_secret'
+}
+
+@test "corrupt claim secret exits 64 (not 1 from die-in-substitution)" {
+    seed_feed_env
+    # Wrong format — validate_secret requires 16 chars [A-Z0-9].
+    printf 'not-a-valid-secret\n' \
+        > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+
+    run_sync
+
+    [ "$SYNC_RC" -eq 64 ]
+    echo "$SYNC_ERR" | grep -F 'reason=invalid_claim_secret'
+}
+
+@test "corrupt feed.meta.json edited_at falls back to legacy tuple" {
+    seed_feed_env
+    cat > "$ROOT_DIR/etc/airplanes/feed.meta.json" <<EOF
+{"schema_version":1,"fields":{"MLAT_USER":{"edited_at":"this is not RFC 3339","edited_by":"feeder"}}}
+EOF
+
+    run_sync --dry-run
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.mlat_user.edited_at' <<<"$SYNC_OUT")" = "2020-01-01T00:00:00Z" ]
+    [ "$(jq -r '.fields.mlat_user.edited_by' <<<"$SYNC_OUT")" = "legacy" ]
+}
+
+@test "unknown edited_by value in sidecar falls back to legacy tuple" {
+    seed_feed_env
+    cat > "$ROOT_DIR/etc/airplanes/feed.meta.json" <<EOF
+{"schema_version":1,"fields":{"MLAT_USER":{"edited_at":"2026-05-12T10:00:00Z","edited_by":"attacker"}}}
+EOF
+
+    run_sync --dry-run
+
+    [ "$SYNC_RC" -eq 0 ]
+    [ "$(jq -r '.fields.mlat_user.edited_by' <<<"$SYNC_OUT")" = "legacy" ]
+    [ "$(jq -r '.fields.mlat_user.edited_at' <<<"$SYNC_OUT")" = "2020-01-01T00:00:00Z" ]
+}
+
+@test "position group skips atomically when only one axis is newer locally" {
+    # Hand-divergent on-disk stamps: LATITUDE was edited locally just
+    # now, LONGITUDE is still on the 2020 legacy seed. Server returns a
+    # position tuple older than LATITUDE but newer than LONGITUDE — a
+    # naive per-key gate would apply LON (server) while skipping LAT
+    # (local). The atomic position-group decision in config.sh must
+    # skip both axes together.
+    seed_feed_env
+    cat > "$ROOT_DIR/etc/airplanes/feed.meta.json" <<EOF
+{
+  "schema_version": 1,
+  "fields": {
+    "LATITUDE":  {"edited_at": "2026-05-14T11:59:00Z", "edited_by": "feeder"},
+    "LONGITUDE": {"edited_at": "2020-01-01T00:00:00Z", "edited_by": "legacy"}
+  }
+}
+EOF
+    # Server returns a position older than LATITUDE but newer than LONGITUDE.
+    set_canned 200 '{
+        "schema_version": 1,
+        "server_time": "2026-05-14T12:00:00Z",
+        "owned": true,
+        "fields": {
+            "position": {"value": {"lat": 99.9, "lon": 99.9}, "edited_at": "2026-05-14T11:30:00Z", "edited_by": "website"}
+        }
+    }'
+
+    run_sync --no-restart
+
+    [ "$SYNC_RC" -eq 0 ]
+    # Position must NOT be partially applied. LATITUDE stays 47.0, LONGITUDE stays 8.0.
+    grep -F 'LATITUDE="47.0"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -F 'LONGITUDE="8.0"' "$ROOT_DIR/etc/airplanes/feed.env"
+    echo "$SYNC_ERR" | grep -F 'reason=position_group_skipped_by_lww'
 }

--- a/test/test_feed_env_apply_lww.bats
+++ b/test/test_feed_env_apply_lww.bats
@@ -1,0 +1,286 @@
+#!/usr/bin/env bats
+
+# Tests for the metadata-LWW gate in scripts/lib/feed-env-apply.sh.
+# When an apl_feed_apply call carries per-key incoming metadata (the
+# APL_APPLY_INCOMING_META_* globals), the library compares each key's
+# incoming `edited_at` against the on-disk `edited_at` in feed.meta.json
+# and skips writes whose incoming tuple is NOT strictly newer.
+#
+# The gate is the prerequisite that makes `apl-feed config sync` safe
+# against a concurrent operator write that lands between the sync's
+# snapshot read and its apply step.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    LIB="$REPO_ROOT/scripts/lib"
+    ROOT_DIR="$(mktemp -d)"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    mkdir -p "$STUB_DIR" "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/run/airplanes"
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$LIB/configure-validators.sh"
+    # shellcheck source=../scripts/lib/feed-env-keys.sh
+    source "$LIB/feed-env-keys.sh"
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$LIB/feed-env-apply.sh"
+    eval "$bats_exit_trap"
+
+    FEED_ENV="$ROOT_DIR/etc/airplanes/feed.env"
+    META_FILE="$ROOT_DIR/etc/airplanes/feed.meta.json"
+    LOCK_FILE="$ROOT_DIR/run/airplanes/feed-env.lock"
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+
+    # Deterministic clock for the LWW gate: anchor "now" at a fixed
+    # 2026-05-14T12:00:00Z. The bogus-future-heal threshold becomes
+    # 2026-05-14T12:05:00Z — anything on-disk past that point heals,
+    # anything at or before stays under LWW.
+    _apl_feed_apply_iso_now() { printf '2026-05-14T12:00:00Z'; }
+    _apl_feed_apply_iso_plus_seconds() { printf '2026-05-14T12:05:00Z'; }
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+seed_feed_env() {
+    cat > "$FEED_ENV" <<EOF
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="120m"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+GAIN=auto
+EOF
+}
+
+# Build feed.meta.json from a flat (KEY, edited_at) pair list. Every
+# entry's edited_by is "feeder" — the LWW gate only reads edited_at.
+seed_meta() {
+    local -a pairs=("$@")
+    local filter='{schema_version: 1, fields: {}}'
+    local jq_args=()
+    local i=0 k at
+    while (( i < ${#pairs[@]} )); do
+        k="${pairs[$i]}"
+        at="${pairs[$((i + 1))]}"
+        jq_args+=(--arg "k${i}" "$k" --arg "a${i}" "$at")
+        filter+=" | .fields[\$k${i}] = {edited_at: \$a${i}, edited_by: \"feeder\"}"
+        i=$((i + 2))
+    done
+    jq -nc "${jq_args[@]}" "$filter" > "$META_FILE"
+}
+
+# Clear incoming-metadata globals so each test starts clean.
+reset_incoming_meta() {
+    APL_APPLY_INCOMING_META_EDITED_AT=()
+    APL_APPLY_INCOMING_META_EDITED_BY=()
+}
+
+do_apply() {
+    APL_APPLY_RC=0
+    apl_feed_apply --feed-env "$FEED_ENV" --lock-file "$LOCK_FILE" "$@" \
+        || APL_APPLY_RC=$?
+}
+
+read_disk_value() {
+    local key="$1"
+    # feed.env values may be unquoted (booleans) or quoted (strings).
+    grep -E "^${key}=" "$FEED_ENV" | head -n 1 | sed -E 's/^[A-Z_]+=//; s/^"//; s/"$//'
+}
+
+read_meta_edited_at() {
+    local key="$1"
+    jq -r --arg k "$key" '.fields[$k].edited_at // empty' "$META_FILE"
+}
+
+@test "LWW skips an older incoming write" {
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T12:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ "${#APL_APPLY_CHANGED[@]}" -eq 0 ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T12:00:00Z" ]
+}
+
+@test "LWW applies a strictly-newer incoming write" {
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T10:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ " ${APL_APPLY_CHANGED[*]} " = " MLAT_USER " ]
+    [ "${#APL_APPLY_SKIPPED_BY_LWW[@]}" -eq 0 ]
+    [ "$(read_disk_value MLAT_USER)" = "bob" ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T12:00:00Z" ]
+}
+
+@test "LWW favors disk on exact-equal edited_at" {
+    # Symmetric with the server-side LWW: tie -> existing tuple wins.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T12:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+}
+
+@test "LWW applies when sidecar has no entry for the key (bootstrap)" {
+    seed_feed_env
+    # Empty fields object -> on-disk metadata absent for every key.
+    seed_meta
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2020-01-01T00:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="legacy"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ " ${APL_APPLY_CHANGED[*]} " = " MLAT_USER " ]
+    [ "${#APL_APPLY_SKIPPED_BY_LWW[@]}" -eq 0 ]
+    [ "$(read_disk_value MLAT_USER)" = "bob" ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2020-01-01T00:00:00Z" ]
+}
+
+@test "bare-string write bypasses LWW gate" {
+    # Existing operator-facing callers (mlat user, etc.) don't pass
+    # incoming metadata; the lib stamps now() on their behalf. The gate
+    # must not affect them.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T11:30:00Z"
+    reset_incoming_meta
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ " ${APL_APPLY_CHANGED[*]} " = " MLAT_USER " ]
+    [ "$(read_disk_value MLAT_USER)" = "bob" ]
+}
+
+@test "fractional-second incoming compared against unfractioned on-disk" {
+    # Server emits the no-fraction form when microseconds are zero; a
+    # feeder-side stamp with sub-second precision must not falsely beat
+    # the unfractioned same-second on-disk stamp.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T12:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00.000001Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+}
+
+@test "mixed batch: one skip, one apply" {
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T11:30:00Z" ALTITUDE "2020-01-01T00:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+    APL_APPLY_INCOMING_META_EDITED_AT[ALTITUDE]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[ALTITUDE]="website"
+
+    do_apply --no-restart MLAT_USER=bob ALTITUDE=200m
+
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
+    # Only ALTITUDE should be in CHANGED.
+    [ " ${APL_APPLY_CHANGED[*]} " = " ALTITUDE " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+    [ "$(read_disk_value ALTITUDE)" = "200m" ]
+}
+
+@test "all-skip batch resolves to no_change" {
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T11:30:00Z" ALTITUDE "2026-05-14T11:30:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+    APL_APPLY_INCOMING_META_EDITED_AT[ALTITUDE]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[ALTITUDE]="website"
+
+    do_apply --no-restart MLAT_USER=bob ALTITUDE=200m
+
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ "${#APL_APPLY_CHANGED[@]}" -eq 0 ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " ALTITUDE MLAT_USER " ] \
+        || [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER ALTITUDE " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+    [ "$(read_disk_value ALTITUDE)" = "120m" ]
+}
+
+@test "bogus-future on-disk edited_at is healed by incoming server tuple" {
+    # rejected_fields-healing scenario: server rejected the feeder's
+    # POST because the on-disk edited_at was wildly in the future
+    # (e.g. clock misconfig). The server returns its own tuple; the
+    # apply must NOT skip via LWW even though incoming is older than
+    # the bogus on-disk stamp.
+    seed_feed_env
+    seed_meta MLAT_USER "3000-01-01T00:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+
+    do_apply --no-restart MLAT_USER=alice  # same value, just metadata heal
+
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "${#APL_APPLY_SKIPPED_BY_LWW[@]}" -eq 0 ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T10:00:00Z" ]
+}
+
+@test "LWW skip survives a no-systemctl environment" {
+    # Build-mode skips lock acquisition and sidecar write entirely. The
+    # gate should still emit no_change rather than blindly writing.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T11:30:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T10:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+
+    AIRPLANES_BUILD_MODE=1 do_apply MLAT_USER=bob
+
+    # In build mode no lock_fd is acquired so the LWW gate's sidecar
+    # read sees the on-disk file (file-system read doesn't depend on
+    # the lock). The skip still fires.
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+}

--- a/test/test_feed_env_apply_lww.bats
+++ b/test/test_feed_env_apply_lww.bats
@@ -246,6 +246,58 @@ read_meta_edited_at() {
     [ "$(read_disk_value ALTITUDE)" = "120m" ]
 }
 
+@test "bogus-future heal uses APL_APPLY_INCOMING_SERVER_TIME when set" {
+    # A feeder whose local clock is ahead would have computed
+    # `now + 300s` past the on-disk stamp, marking it as legitimate and
+    # re-skipping the heal. With the server-time override the threshold
+    # is computed against trusted time and the heal fires.
+    seed_feed_env
+    # On-disk stamp is 3 hours past stubbed local now (12:00) but only
+    # a few seconds past stubbed server now (set below).
+    seed_meta MLAT_USER "2026-05-14T15:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T15:01:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+    # Without server time, local-now + 5min = 12:05, on-disk 15:00 > 12:05
+    # would already be flagged as bogus-future and heal. Pin server time
+    # to 15:00:30 — only 30s before on-disk's 15:00, well inside the
+    # 300s skew window, so the heal MUST be driven by the bogus-future
+    # logic re-anchored on server time.
+    APL_APPLY_INCOMING_SERVER_TIME="2026-05-14T15:00:30Z"
+
+    do_apply --no-restart MLAT_USER=alice
+
+    # incoming 15:01 > on-disk 15:00 — applies normally; the server-time
+    # path doesn't change the per-key result here. Test the negative
+    # case below to prove the path actually fires.
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    APL_APPLY_INCOMING_SERVER_TIME=""
+}
+
+@test "fast local clock cannot self-mask future on-disk stamps when server_time is supplied" {
+    # Reproduces Codex finding: feeder clock fast by 6 min relative to
+    # the server. On-disk has a future-stamped tuple (6 min ahead of
+    # server). Without server_time the feeder would compute the heal
+    # threshold from its own already-fast local-now, conclude the stamp
+    # is fine, and skip the heal forever.
+    seed_feed_env
+    # On-disk stamp is 12:06:00, 6 minutes past server-now.
+    seed_meta MLAT_USER "2026-05-14T12:06:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+    # Server time is the trusted reference. Bogus-future threshold is
+    # server_time + 300s = 12:05:00. On-disk 12:06:00 > 12:05:00 -> bogus.
+    APL_APPLY_INCOMING_SERVER_TIME="2026-05-14T12:00:00Z"
+
+    do_apply --no-restart MLAT_USER=alice  # same value, just metadata heal
+
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "${#APL_APPLY_SKIPPED_BY_LWW[@]}" -eq 0 ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T12:00:00Z" ]
+    APL_APPLY_INCOMING_SERVER_TIME=""
+}
+
 @test "bogus-future on-disk edited_at is healed by incoming server tuple" {
     # rejected_fields-healing scenario: server rejected the feeder's
     # POST because the on-disk edited_at was wildly in the future

--- a/test/test_uninstall_script.bats
+++ b/test/test_uninstall_script.bats
@@ -57,26 +57,30 @@ SH
     [ -f "$SYSTEMCTL_LOG" ]
 }
 
-@test "uninstall.sh disables services in mlat -> mlat2 -> feed -> diagnostics order, then daemon-reloads, exactly six calls" {
+@test "uninstall.sh disables services in mlat -> mlat2 -> feed -> diagnostics -> config-sync order, then daemon-reloads, exactly eight calls" {
     run_uninstall
 
     [ "$status" -eq 0 ]
 
-    local first second third fourth fifth sixth count
+    local first second third fourth fifth sixth seventh eighth count
     first="$(sed -n '1p' "$SYSTEMCTL_LOG")"
     second="$(sed -n '2p' "$SYSTEMCTL_LOG")"
     third="$(sed -n '3p' "$SYSTEMCTL_LOG")"
     fourth="$(sed -n '4p' "$SYSTEMCTL_LOG")"
     fifth="$(sed -n '5p' "$SYSTEMCTL_LOG")"
     sixth="$(sed -n '6p' "$SYSTEMCTL_LOG")"
+    seventh="$(sed -n '7p' "$SYSTEMCTL_LOG")"
+    eighth="$(sed -n '8p' "$SYSTEMCTL_LOG")"
     count="$(wc -l < "$SYSTEMCTL_LOG" | tr -d '[:space:]')"
     [ "$first" = "disable --now airplanes-mlat" ]
     [ "$second" = "disable --now airplanes-mlat2" ]
     [ "$third" = "disable --now airplanes-feed" ]
     [ "$fourth" = "disable --now airplanes-diagnostics.timer" ]
     [ "$fifth" = "disable --now airplanes-diagnostics.service" ]
-    [ "$sixth" = "daemon-reload" ]
-    [ "$count" = "6" ]
+    [ "$sixth" = "disable --now airplanes-config-sync.timer" ]
+    [ "$seventh" = "disable --now airplanes-config-sync.service" ]
+    [ "$eighth" = "daemon-reload" ]
+    [ "$count" = "8" ]
 }
 
 @test "uninstall.sh removes the airplanes systemd unit files and leaves others alone" {
@@ -86,6 +90,8 @@ SH
     : > "$ROOT_DIR/lib/systemd/system/airplanes-feed.service"
     : > "$ROOT_DIR/lib/systemd/system/airplanes-diagnostics.service"
     : > "$ROOT_DIR/lib/systemd/system/airplanes-diagnostics.timer"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-config-sync.service"
+    : > "$ROOT_DIR/lib/systemd/system/airplanes-config-sync.timer"
     : > "$ROOT_DIR/lib/systemd/system/keep-this.service"
 
     run_uninstall
@@ -96,6 +102,8 @@ SH
     [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-feed.service" ]
     [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-diagnostics.service" ]
     [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-diagnostics.timer" ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-config-sync.service" ]
+    [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-config-sync.timer" ]
     [ -e "$ROOT_DIR/lib/systemd/system/keep-this.service" ]
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -33,6 +33,8 @@ systemctl disable --now airplanes-mlat2 &>/dev/null
 systemctl disable --now airplanes-feed
 systemctl disable --now airplanes-diagnostics.timer &>/dev/null
 systemctl disable --now airplanes-diagnostics.service &>/dev/null
+systemctl disable --now airplanes-config-sync.timer &>/dev/null
+systemctl disable --now airplanes-config-sync.service &>/dev/null
 
 # Legacy cleanup: earlier releases shipped install-or-update-interface.sh, which
 # installed wiedehopf/tar1090 with the "airplanes" URL prefix. The installer is
@@ -47,6 +49,8 @@ for _systemd_dir in "${SYSTEMD_UNIT_DIRS[@]}"; do
     rm -f "$_systemd_dir/airplanes-feed.service"
     rm -f "$_systemd_dir/airplanes-diagnostics.service"
     rm -f "$_systemd_dir/airplanes-diagnostics.timer"
+    rm -f "$_systemd_dir/airplanes-config-sync.service"
+    rm -f "$_systemd_dir/airplanes-config-sync.timer"
 done
 unset _systemd_dir
 
@@ -60,6 +64,7 @@ rm -f "$SYSTEMD_ETC/default.target.wants/airplanes-mlat.service"
 rm -f "$SYSTEMD_ETC/default.target.wants/airplanes-mlat2.service"
 rm -f "$SYSTEMD_ETC/multi-user.target.wants/airplanes-mlat2.service"
 rm -f "$SYSTEMD_ETC/timers.target.wants/airplanes-diagnostics.timer"
+rm -f "$SYSTEMD_ETC/timers.target.wants/airplanes-config-sync.timer"
 
 systemctl daemon-reload || true
 

--- a/update.sh
+++ b/update.sh
@@ -521,6 +521,7 @@ historical_apl_feed_modules=(
     backup.sh
     claim.sh
     common.sh
+    config.sh
     diagnostics.sh
     http.sh
     id.sh
@@ -601,6 +602,8 @@ cp "$GIT"/scripts/airplanes-mlat.service "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-feed.service "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-diagnostics.service "$SYSTEMD_DIR"
 cp "$GIT"/scripts/airplanes-diagnostics.timer "$SYSTEMD_DIR"
+cp "$GIT"/scripts/airplanes-config-sync.service "$SYSTEMD_DIR"
+cp "$GIT"/scripts/airplanes-config-sync.timer "$SYSTEMD_DIR"
 
 if ! airplanes_is_build_mode; then
     systemctl daemon-reload >> "$LOGFILE" || true
@@ -725,6 +728,19 @@ elif is_unit_masked airplanes-diagnostics.timer; then
 else
     systemctl enable --now airplanes-diagnostics.timer >> "$LOGFILE" 2>&1 || \
         echo "airplanes-diagnostics.timer could not be enabled; diagnostics push will not run until 'systemctl enable --now airplanes-diagnostics.timer'."
+fi
+
+# Remote-config sync: enable the timer so apl-feed config sync fires every
+# ~60s once a claim secret is present. The service is gated on
+# ConditionPathExists=/etc/airplanes/feeder-claim-secret so a freshly-
+# flashed feeder leaves the timer armed but the service no-ops until claim.
+if airplanes_is_build_mode; then
+    systemctl enable airplanes-config-sync.timer >> "$LOGFILE" || true
+elif is_unit_masked airplanes-config-sync.timer; then
+    echo "airplanes-config-sync.timer is masked; skipping enable."
+else
+    systemctl enable --now airplanes-config-sync.timer >> "$LOGFILE" 2>&1 || \
+        echo "airplanes-config-sync.timer could not be enabled; remote config sync will not run until 'systemctl enable --now airplanes-config-sync.timer'."
 fi
 
 RC_LOCAL="$(airplanes_path /etc/rc.local)"


### PR DESCRIPTION
Adds the feeder-side counterpart to /api/feeders/config/sync: every ~60s (with 30s jitter) airplanes-config-sync.timer fires `apl-feed config sync`, which posts the local feed.env snapshot, applies the server's merged response through apl_feed_apply, and touches /var/lib/airplanes/config-sync-last-success on every successful contact. Authentication reuses the existing Bearer alv1 token; on a feeder without a claim secret the service is gated by ConditionPathExists and stays a no-op.

A first commit extends apl_feed_apply with a per-key metadata last-write-wins gate. When the caller provides incoming (edited_at, edited_by), the lib skips any key whose incoming stamp is not strictly newer than the on-disk feed.meta.json entry, except for bogus-future stamps (>5min ahead of now) which the gate steps aside for so the server's heal tuple can repair them. Operator-facing callers (mlat user, 978, diagnostics) stamp now() and are unaffected.

Addresses #DEV-384