### PR TITLE
Move /api/feeders/secret POSTs to Bearer alv1 auth

### DIFF
--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -71,9 +71,14 @@ claim_register() {
     backoff=1
 
     while true; do
-        body="$(printf '{"uuid":"%s","current_secret":null,"new_secret":"%s"}' "$uuid" "$secret")"
+        # v2 wire shape: Authorization: Bearer alv1.<uuid>.<auth_secret> +
+        # body {"new_secret":...}. For register there is no prior secret
+        # to authenticate with — the bearer carries the same value being
+        # registered ("tautology"). The server ignores the bearer secret
+        # on the CREATE branch and stores hash(body.new_secret).
+        body="$(printf '{"new_secret":"%s"}' "$secret")"
         set +e
-        status="$(post_json '/api/feeders/secret' "$body" "$response_file")"
+        status="$(post_json_bearer "alv1.${uuid}.${secret}" '/api/feeders/secret' "$body" "$response_file")"
         curl_rc=$?
         set -e
 
@@ -281,9 +286,16 @@ claim_rotate() {
     backoff=1
 
     while true; do
-        body="$(printf '{"uuid":"%s","current_secret":"%s","new_secret":"%s"}' "$uuid" "$current" "$next")"
+        # v2 wire shape: Authorization: Bearer alv1.<uuid>.<current> +
+        # body {"new_secret": next}. Server verifies hash(current) against
+        # the stored hash for the rotate path. The replay-after-network-
+        # failure path (server already accepted next; client retries) is
+        # preserved verbatim — server's NOOP_REPLAY check runs before the
+        # rotate-current-check, so a stale bearer with the matching body
+        # new_secret still returns 200.
+        body="$(printf '{"new_secret":"%s"}' "$next")"
         set +e
-        status="$(post_json '/api/feeders/secret' "$body" "$response_file")"
+        status="$(post_json_bearer "alv1.${uuid}.${current}" '/api/feeders/secret' "$body" "$response_file")"
         curl_rc=$?
         set -e
 

--- a/test/contracts/feeder-api-v1.json
+++ b/test/contracts/feeder-api-v1.json
@@ -4,9 +4,9 @@
     "create_success": {
       "request": {
         "uuid": "11111111-2222-3333-4444-555555555555",
-        "current_secret": null,
         "new_secret": "ABCDEFGHIJKLMNOP"
       },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
       "response": {
         "status": 201,
         "body": {
@@ -17,9 +17,9 @@
     "noop_replay": {
       "request": {
         "uuid": "11111111-2222-3333-4444-555555555555",
-        "current_secret": null,
         "new_secret": "ABCDEFGHIJKLMNOP"
       },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
       "response": {
         "status": 200,
         "body": {
@@ -30,13 +30,29 @@
     "rotate_success": {
       "request": {
         "uuid": "11111111-2222-3333-4444-555555555555",
-        "current_secret": "ABCDEFGHIJKLMNOP",
         "new_secret": "QRSTUVWXYZ012345"
       },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
       "response": {
         "status": 200,
         "body": {
           "version": 2
+        }
+      }
+    },
+    "missing_authorization": {
+      "response": {
+        "status": 400,
+        "body": {
+          "error": "missing_authorization"
+        }
+      }
+    },
+    "malformed_authorization": {
+      "response": {
+        "status": 400,
+        "body": {
+          "error": "malformed_authorization"
         }
       }
     },

--- a/test/contracts/feeder-api-v1.json
+++ b/test/contracts/feeder-api-v1.json
@@ -1,4 +1,5 @@
 {
+  "_doc": "Fixture shape for /api/feeders/secret (DEV-427): request.uuid is the bearer UUID identifier and is NOT a body field. The body sent on the wire is exactly {\"new_secret\": <request.new_secret>}. The Authorization header is Bearer alv1.<request.uuid>.<bearer_secret>. Mirrors the /status fixture shape used elsewhere.",
   "schema_version": 1,
   "secret": {
     "create_success": {

--- a/test/script-install.sh
+++ b/test/script-install.sh
@@ -62,13 +62,39 @@ chmod +x /usr/local/sbin/nc
 python3 - <<'PY' &
 import http.server
 import json
+import re
+
+# v2 wire shape (DEV-427): require Authorization: Bearer alv1.<uuid>.<secret>
+# and reject legacy body fields. A bare 201 response would let a client
+# silently regress to the v1 body shape.
+BEARER_RE = re.compile(r"^Bearer alv1\.[0-9a-fA-F-]{32,36}\.[A-Za-z0-9]{1,64}$")
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
-        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length > 0 else b""
         if self.path != "/api/feeders/secret":
             self.send_response(404)
             self.end_headers()
+            return
+        auth = self.headers.get("Authorization", "")
+        if not BEARER_RE.match(auth):
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "missing_or_malformed_authorization"}).encode())
+            return
+        try:
+            body = json.loads(raw or b"{}")
+        except Exception:
+            body = {}
+        # v2 body must contain ONLY new_secret. current_secret / uuid are
+        # legacy keys and prove the client never picked up the migration.
+        if not isinstance(body, dict) or set(body.keys()) != {"new_secret"}:
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "invalid_request"}).encode())
             return
         self.send_response(201)
         self.send_header("Content-Type", "application/json")

--- a/test/script-install.sh
+++ b/test/script-install.sh
@@ -82,7 +82,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_response(400)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
-            self.wfile.write(json.dumps({"error": "missing_or_malformed_authorization"}).encode())
+            self.wfile.write(json.dumps({"error": "missing_authorization"}).encode())
             return
         try:
             body = json.loads(raw or b"{}")

--- a/test/script-upgrade.sh
+++ b/test/script-upgrade.sh
@@ -107,7 +107,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_response(400)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
-            self.wfile.write(json.dumps({"error": "missing_or_malformed_authorization"}).encode())
+            self.wfile.write(json.dumps({"error": "missing_authorization"}).encode())
             return
         try:
             body = json.loads(raw or b"{}")

--- a/test/script-upgrade.sh
+++ b/test/script-upgrade.sh
@@ -88,13 +88,36 @@ chmod +x /usr/local/sbin/nc
 python3 - <<'PY' &
 import http.server
 import json
+import re
+
+# v2 wire shape (DEV-427): require Authorization: Bearer alv1.<uuid>.<secret>
+# and reject legacy body fields.
+BEARER_RE = re.compile(r"^Bearer alv1\.[0-9a-fA-F-]{32,36}\.[A-Za-z0-9]{1,64}$")
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
-        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length > 0 else b""
         if self.path != "/api/feeders/secret":
             self.send_response(404)
             self.end_headers()
+            return
+        auth = self.headers.get("Authorization", "")
+        if not BEARER_RE.match(auth):
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "missing_or_malformed_authorization"}).encode())
+            return
+        try:
+            body = json.loads(raw or b"{}")
+        except Exception:
+            body = {}
+        if not isinstance(body, dict) or set(body.keys()) != {"new_secret"}:
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "invalid_request"}).encode())
             return
         self.send_response(201)
         self.send_header("Content-Type", "application/json")

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -114,7 +114,7 @@ start_claim_server() {
     python3 - "$port_file" "$secret_status" "$secret_body" \
         "$active_secret" "$active_version" "$pending_secret" "$pending_version" \
         "$req_file" <<'PY' &
-import http.server, json, sys
+import http.server, json, re, sys
 port_file = sys.argv[1]
 secret_status = int(sys.argv[2])
 secret_body = sys.argv[3]
@@ -123,6 +123,14 @@ active_version = sys.argv[5]
 pending_secret = sys.argv[6]
 pending_version = sys.argv[7]
 req_file = sys.argv[8]
+
+# v2 wire-shape gate (DEV-427): the shared claim stub used by every
+# rotation/recovery test enforces Bearer + slim body for /secret. Without
+# this, a regression that flips claim_rotate back to body-auth would
+# silently pass every rotation test except the one that explicitly
+# inspects MOCK_REQ_FILE.
+BEARER_RE = re.compile(r"^Bearer alv1\.[0-9a-fA-F-]{32,36}\.[A-Za-z0-9]{1,64}$")
+
 class H(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
@@ -135,6 +143,20 @@ class H(http.server.BaseHTTPRequestHandler):
         with open(req_file, "a") as f:
             f.write(f"{self.path}\t{auth}\t{raw.decode('utf-8', errors='replace')}\n")
         if self.path == "/api/feeders/secret":
+            # Enforce v2 wire shape at the stub. Anything else means the
+            # client has regressed back to v1 body-auth.
+            if not BEARER_RE.match(auth):
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "missing_authorization"}).encode())
+                return
+            if not isinstance(body, dict) or set(body.keys()) != {"new_secret"}:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "invalid_request"}).encode())
+                return
             self.send_response(secret_status)
             self.send_header("Content-Type", "application/json")
             self.end_headers()

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -14,6 +14,10 @@ setup() {
     touch "$ROOT_DIR/var/lib/airplanes/diagnostics-last-success"
     MOCK_PORT_FILE="$(mktemp)"
     MOCK_PID_FILE="$(mktemp)"
+    # Mock servers append one "PATH<TAB>AUTH<TAB>BODY" line per POST here,
+    # so tests can pin the v2 wire shape (Authorization: Bearer alv1.X.Y +
+    # slim {"new_secret": ...} body for /api/feeders/secret).
+    MOCK_REQ_FILE="$(mktemp)"
 
     # Stub external commands `apl-feed status` calls so the result-text
     # assertions don't depend on whether the host runner has systemctl,
@@ -47,7 +51,7 @@ STUB
 teardown() {
     stop_mock_server || true
     rm -rf "$ROOT_DIR" "$STUB_BIN_DIR"
-    rm -f "$MOCK_PORT_FILE" "$MOCK_PID_FILE"
+    rm -f "$MOCK_PORT_FILE" "$MOCK_PID_FILE" "$MOCK_REQ_FILE"
 }
 
 stop_mock_server() {
@@ -106,8 +110,10 @@ start_claim_server() {
     local pending_version="$6"
     local port_file="$MOCK_PORT_FILE"
     local pid_file="$MOCK_PID_FILE"
+    local req_file="$MOCK_REQ_FILE"
     python3 - "$port_file" "$secret_status" "$secret_body" \
-        "$active_secret" "$active_version" "$pending_secret" "$pending_version" <<'PY' &
+        "$active_secret" "$active_version" "$pending_secret" "$pending_version" \
+        "$req_file" <<'PY' &
 import http.server, json, sys
 port_file = sys.argv[1]
 secret_status = int(sys.argv[2])
@@ -116,6 +122,7 @@ active_secret = sys.argv[4]
 active_version = sys.argv[5]
 pending_secret = sys.argv[6]
 pending_version = sys.argv[7]
+req_file = sys.argv[8]
 class H(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
@@ -123,6 +130,10 @@ class H(http.server.BaseHTTPRequestHandler):
             body = json.loads(raw.decode() or "{}")
         except Exception:
             body = {}
+        # Record (path, auth, body) for test-side wire-shape assertions.
+        auth = self.headers.get("Authorization", "")
+        with open(req_file, "a") as f:
+            f.write(f"{self.path}\t{auth}\t{raw.decode('utf-8', errors='replace')}\n")
         if self.path == "/api/feeders/secret":
             self.send_response(secret_status)
             self.send_header("Content-Type", "application/json")
@@ -279,6 +290,31 @@ EOF
     [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending" ]
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")" = "2" ]
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" != "ABCDEFGHIJKLMNOP" ]
+}
+
+@test "claim rotate POST sends v2 bearer with current secret + slim body" {
+    # Pin the v2 wire shape for rotation (DEV-427): bearer carries the
+    # *current* (pre-rotation) secret, body has only new_secret with the
+    # next value. No legacy current_secret / uuid keys in the body.
+    echo "ABCDEFGHIJKLMNOP" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    start_claim_server 200 '{"version": 2}' \
+        "ABCDEFGHIJKLMNOP" 1 "" 0
+
+    run "$SCRIPT" claim rotate --root "$ROOT_DIR" --server-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    # Filter to the /secret POST line; /status probes are not relevant here
+    # but may also appear in the capture if the rotate flow probes.
+    secret_line="$(grep -F $'/api/feeders/secret\t' "$MOCK_REQ_FILE" | head -1)"
+    [ -n "$secret_line" ]
+    # Bearer = alv1.<uuid>.<current_secret>.
+    auth="$(printf '%s' "$secret_line" | awk -F'\t' '{print $2}')"
+    [[ "$auth" = "Bearer alv1.11111111-2222-3333-4444-555555555555.ABCDEFGHIJKLMNOP" ]]
+    # Body = {"new_secret":"<16-char>"} with no other keys.
+    body="$(printf '%s' "$secret_line" | awk -F'\t' '{print $3}')"
+    [[ "$body" =~ ^\{\"new_secret\":\"[A-Z0-9]{16}\"\}$ ]]
+    [[ ! "$body" =~ current_secret ]]
+    [[ ! "$body" =~ \"uuid\" ]]
 }
 
 @test "claim rotate finalizes pending after lost response" {

--- a/test/test_claim_register.bats
+++ b/test/test_claim_register.bats
@@ -12,36 +12,48 @@ setup() {
     MOCK_RESP_FILE="$(mktemp)"
     MOCK_PORT_FILE="$(mktemp)"
     MOCK_PID_FILE="$(mktemp)"
+    # Capture of the most recent request the mock server received. Each
+    # successful POST overwrites this file with the parsed Authorization
+    # header on line 1 and the request body on line 2. Tests grep this
+    # to assert v2 wire shape (DEV-427).
+    MOCK_REQ_FILE="$(mktemp)"
 }
 
 teardown() {
     stop_mock_server || true
     rm -rf "$ROOT_DIR"
-    rm -f "$MOCK_RESP_FILE" "$MOCK_PORT_FILE" "$MOCK_PID_FILE"
+    rm -f "$MOCK_RESP_FILE" "$MOCK_PORT_FILE" "$MOCK_PID_FILE" "$MOCK_REQ_FILE"
 }
 
 # Inline mock HTTP server. Reads its (status, body) response from
 # $MOCK_RESP_FILE on each request, so a test can sequence responses by
 # rewriting the file between polls. For one-shot tests we just write once
-# before starting the server.
+# before starting the server. Records the inbound Authorization header
+# and body to $MOCK_REQ_FILE so tests can pin the v2 wire shape.
 start_mock_server() {
     local port_file="$MOCK_PORT_FILE"
     local resp_file="$MOCK_RESP_FILE"
+    local req_file="$MOCK_REQ_FILE"
     local pid_file="$MOCK_PID_FILE"
-    python3 - "$port_file" "$resp_file" <<'PY' &
+    python3 - "$port_file" "$resp_file" "$req_file" <<'PY' &
 import http.server, json, sys
-port_file, resp_file = sys.argv[1], sys.argv[2]
+port_file, resp_file, req_file = sys.argv[1], sys.argv[2], sys.argv[3]
 class H(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         with open(resp_file) as f:
             spec = json.load(f)
-        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length > 0 else b""
+        auth = self.headers.get("Authorization", "")
+        with open(req_file, "w") as f:
+            f.write(f"AUTH: {auth}\n")
+            f.write(f"BODY: {body.decode('utf-8', errors='replace')}\n")
         self.send_response(spec["status"])
         ct = spec.get("content_type", "application/json")
         self.send_header("Content-Type", ct)
         self.end_headers()
-        body = spec.get("body", {})
-        out = body if isinstance(body, str) else json.dumps(body)
+        resp_body = spec.get("body", {})
+        out = resp_body if isinstance(resp_body, str) else json.dumps(resp_body)
         self.wfile.write(out.encode())
     def log_message(self, *a, **kw): pass
 
@@ -174,6 +186,29 @@ mock_url() {
     run "$SCRIPT" claim register --root "$ROOT_DIR" --server-url "$(mock_url)"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "SUCCESS" ]]
+}
+
+@test "register POST sends v2 bearer + slim body (no legacy fields)" {
+    # Pin the v2 wire shape (DEV-427): Authorization carries the bearer,
+    # body has only new_secret. Legacy current_secret / uuid keys must
+    # be absent — a v2 server rejects them with 400 invalid_request.
+    write_contract_response secret create_success
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --server-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    # Authorization header is alv1.<uuid>.<secret>; the register tautology
+    # means the bearer secret equals the body new_secret.
+    grep -E '^AUTH: Bearer alv1\.11111111-2222-3333-4444-555555555555\.[A-Z0-9]{16}$' "$MOCK_REQ_FILE"
+    # Body shape: {"new_secret":"..."} with no other keys.
+    body_line="$(grep '^BODY: ' "$MOCK_REQ_FILE" | head -1 | sed 's/^BODY: //')"
+    [[ "$body_line" =~ ^\{\"new_secret\":\"[A-Z0-9]{16}\"\}$ ]]
+    [[ ! "$body_line" =~ current_secret ]]
+    [[ ! "$body_line" =~ \"uuid\" ]]
+    # Register tautology: the bearer secret and the body new_secret are
+    # the same value.
+    auth_secret="$(grep '^AUTH: ' "$MOCK_REQ_FILE" | sed -E 's/.*alv1\.[^.]+\.([A-Z0-9]+)$/\1/')"
+    body_secret="$(echo "$body_line" | sed -E 's/.*"new_secret":"([^"]+)".*/\1/')"
+    [ "$auth_secret" = "$body_secret" ]
 }
 
 @test "200 NOOP_REPLAY exits 0 (treated as success)" {

--- a/test/test_wire_endpoints.bats
+++ b/test/test_wire_endpoints.bats
@@ -40,3 +40,20 @@ setup() {
 @test "claim CLI posts to /api/feeders/secret" {
     grep -q "/api/feeders/secret" "$REPO_ROOT/scripts/apl-feed/claim.sh"
 }
+
+@test "claim CLI uses post_json_bearer (v2 wire shape) for /api/feeders/secret" {
+    # DEV-427 migrated /secret from body-auth to bearer. claim.sh must
+    # ship every /secret call through post_json_bearer; a post_json call
+    # to /secret would send the v1 body shape and the server now returns
+    # 400 missing_authorization.
+    [ "$(grep -cE "post_json_bearer .+ '/api/feeders/secret'" \
+        "$REPO_ROOT/scripts/apl-feed/claim.sh")" -ge 2 ]
+    # Negative guard: no legacy post_json call to /secret.
+    [ "$(grep -cE "post_json '/api/feeders/secret'" \
+        "$REPO_ROOT/scripts/apl-feed/claim.sh")" -eq 0 ]
+    # Negative guard: no legacy body-field current_secret in the wire
+    # payload. (The string appears once in a user-facing error message
+    # explaining a 409 rotation_rejected response — that's not a body
+    # key. We match the JSON-key shape `"current_secret":` only.)
+    [ "$(grep -cE '"current_secret":' "$REPO_ROOT/scripts/apl-feed/claim.sh")" -eq 0 ]
+}


### PR DESCRIPTION
apl-feed claim register and apl-feed claim rotate now send Authorization: Bearer alv1.<uuid>.<auth_secret> and POST a slim {"new_secret": ...} body. Bearer carries the secret being registered for first registration (tautology — no prior secret to authenticate with) and the current active secret for rotation. Matches the bearer shape /api/feeders/{status,diagnostics,config/sync} already use.

Replay-after-network-failure for rotation is preserved verbatim: the server still returns 200 noop_replay when the new_secret in the body already matches the stored hash, regardless of what the bearer carries. The 409 rotation_rejected branch keeps its existing status-probe recovery in claim.sh.

The Python stubs in the install/upgrade smoke scripts and the BATS in-test stubs now reject missing or malformed Authorization headers and reject body keys outside {"new_secret"}, so a regression back to body-auth shows up as a stub failure instead of silently passing.

This is the client half of a cross-repo change. The airplanes-live/website server change must merge first so production accepts the v2 shape before this lands.

Addresses #DEV-427