### PR TITLE
fix(apply): microsecond-precision LWW + sidecar bump regression test

### DIFF
--- a/scripts/apl-feed/apply.sh
+++ b/scripts/apl-feed/apply.sh
@@ -107,7 +107,7 @@ apl_feed_apply_cli() {
               elif (.value.edited_at | type) != "string" then "\(.key): .edited_at must be a string"
               elif (.value.edited_by | type) != "string" then "\(.key): .edited_by must be a string"
               elif ([.value.edited_by] | inside(["feeder","website","legacy"]) | not) then "\(.key): .edited_by must be feeder/website/legacy"
-              elif ((.value.edited_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$")) | not) then "\(.key): .edited_at must be RFC 3339 UTC"
+              elif ((.value.edited_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$")) | not) then "\(.key): .edited_at must be RFC 3339 UTC (max 6 fractional digits)"
               else empty end
             else "\(.key): value must be a string or {value,edited_at,edited_by}"
             end

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -53,7 +53,11 @@ APL_FEED_APPLY_EDITED_BY_ENUM="feeder website legacy"
 
 # RFC 3339 UTC shape required for `edited_at`. Strict — the server side
 # stamps with this exact format; webconfig writes do too.
-APL_FEED_APPLY_EDITED_AT_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$'
+# Accepted edited_at shape: RFC 3339 UTC with optional fractional segment
+# of up to 6 digits (microsecond). The LWW normalize pads/truncates to
+# microsecond precision; longer input would be silently truncated which
+# can collapse strict-newer ordering, so we reject it at the wire.
+APL_FEED_APPLY_EDITED_AT_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{1,6})?Z$'
 
 # Caller-input arrays. Parallel maps keyed by feed.env key. apl_feed_apply
 # snapshots these into locals at entry; the caller MAY free them after the
@@ -776,7 +780,7 @@ apl_feed_apply() {
                 ;;
         esac
         if ! [[ "${_meta_in_at[$_meta_check_key]:-}" =~ $APL_FEED_APPLY_EDITED_AT_RE ]]; then
-            APL_APPLY_ERRORS[$_meta_check_key]="edited_at must be RFC 3339 UTC (YYYY-MM-DDTHH:MM:SS[.fff]Z)"
+            APL_APPLY_ERRORS[$_meta_check_key]="edited_at must be RFC 3339 UTC with at most 6 fractional digits (YYYY-MM-DDTHH:MM:SS[.ffffff]Z)"
             APL_APPLY_STATUS=rejected
             return 2
         fi

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -458,22 +458,45 @@ _apl_feed_apply_is_tracked_key() {
 }
 
 # Emit current time in the RFC 3339 UTC shape the sidecar requires.
+# Microsecond precision so two writes within the same wall-clock-second
+# produce distinct stamps that the LWW gate can order. The feeder runs
+# on Linux Pi (GNU date, %N supported); on BSD date (macOS dev machines)
+# %N is not interpreted and the fallback emits .000000Z so the strict
+# fractional regex in the JSON adapter still matches.
 _apl_feed_apply_iso_now() {
-    date -u +%Y-%m-%dT%H:%M:%SZ
+    local s
+    s="$(date -u +%Y-%m-%dT%H:%M:%S.%6NZ)"
+    if [[ ! "$s" =~ \.[0-9]{1,9}Z$ ]]; then
+        s="$(date -u +%Y-%m-%dT%H:%M:%S.000000Z)"
+    fi
+    printf '%s' "$s"
 }
 
-# Normalize an RFC 3339 UTC timestamp to its no-fractional-second form so
-# byte-wise (lexicographic) comparison matches semantic ordering for the
-# two on-the-wire shapes the lib accepts: YYYY-MM-DDTHH:MM:SSZ and
-# YYYY-MM-DDTHH:MM:SS.ffffffZ. Sub-second precision is discarded for the
-# compare — the server-side merge is also second-precision, so a feeder
-# distinguishing T+0.5s from T+0.0s would produce drift across the round
-# trip. Callers do the compare on the returned string.
+# Normalize an RFC 3339 UTC timestamp into a fixed-width form so byte-wise
+# (lexicographic) comparison matches semantic ordering. Accepted on-wire
+# shapes are YYYY-MM-DDTHH:MM:SSZ (zero fractional) and
+# YYYY-MM-DDTHH:MM:SS.<frac>Z (any fractional precision). The normalized
+# form is always YYYY-MM-DDTHH:MM:SS.<6 digits>Z (microsecond precision,
+# zero-padded if absent, truncated if longer) so callers can compare
+# returned strings with `[[ A > B ]]` and get the right answer for
+# sub-second differences.
+#
+# Microsecond precision matches the server-side merge in
+# accounts/services/feeder_config.py (Python's datetime.now() emits
+# microseconds via isoformat()) so the same-second tie semantics behave
+# symmetrically across the round trip.
 _apl_feed_apply_normalize_iso_for_compare() {
     local s="$1"
     s="${s%Z}"
-    s="${s%%.*}"
-    printf '%sZ' "$s"
+    local base="$s" frac=""
+    if [[ "$s" == *.* ]]; then
+        base="${s%.*}"
+        frac="${s##*.}"
+    fi
+    # Pad to 6 digits (microsecond); truncate longer (e.g. nanosecond) input.
+    frac="${frac}000000"
+    frac="${frac:0:6}"
+    printf '%s.%sZ' "$base" "$frac"
 }
 
 # Maximum acceptable lead an on-disk `edited_at` can have over server-now

--- a/test/test_apl_feed_apply.bats
+++ b/test/test_apl_feed_apply.bats
@@ -181,6 +181,24 @@ META_FILE_FOR_ROOT() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.meta.json"; }
     [ "$(jq -r .status <<<"$APPLY_OUT")" = "parse_error" ]
 }
 
+@test "apply rejects edited_at with more than 6 fractional digits" {
+    # The LWW normalize pads/truncates to microsecond precision. A
+    # nanosecond-precision input would be silently truncated, which
+    # can collapse strict-newer ordering under LWW. Reject at the wire
+    # rather than accept-then-truncate.
+    PAYLOAD='{"updates":{"MLAT_USER":{"value":"bob","edited_at":"2026-05-14T12:00:00.1234567Z","edited_by":"website"}}}'
+    run_apply "$PAYLOAD" --no-restart
+    [ "$APPLY_RC" -eq 5 ]
+    [ "$(jq -r .status <<<"$APPLY_OUT")" = "parse_error" ]
+}
+
+@test "apply accepts edited_at with exactly 6 fractional digits" {
+    PAYLOAD='{"updates":{"MLAT_USER":{"value":"bob","edited_at":"2026-05-14T12:00:00.123456Z","edited_by":"website"}}}'
+    run_apply "$PAYLOAD" --no-restart
+    [ "$APPLY_RC" -eq 0 ]
+    [ "$(jq -r .status <<<"$APPLY_OUT")" = "applied" ]
+}
+
 @test "malformed JSON returns structured parse_error (no bash abort)" {
     run_apply '{"updates":{"MLAT_USER":' --no-restart
     [ "$APPLY_RC" -eq 5 ]

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -713,7 +713,9 @@ EOF
     META="$ROOT_DIR/etc/airplanes/feed.meta.json"
     [ -f "$META" ]
     [ "$(jq -r '.fields.MLAT_PRIVATE.edited_by' "$META")" = "feeder" ]
-    [[ "$(jq -r '.fields.MLAT_PRIVATE.edited_at' "$META")" =~ ^2[0-9]{3}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+    # Microsecond fractional permitted (iso_now uses %6N for sub-second LWW
+    # ordering across same-second writes).
+    [[ "$(jq -r '.fields.MLAT_PRIVATE.edited_at' "$META")" =~ ^2[0-9]{3}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$ ]]
 }
 
 @test "mlat --root targets only the rootfs sidecar, never the host" {

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -492,9 +492,11 @@ EOF
     [ -f "$ROOT_DIR/etc/airplanes/feed.meta.json" ]
     [ "$(jq -r '.fields.MLAT_USER.edited_by' "$ROOT_DIR/etc/airplanes/feed.meta.json")" = "feeder"  ]
     # Current-ish timestamp — assert RFC 3339 shape (regex). Strict equality
-    # would require freezing the clock.
+    # would require freezing the clock. iso_now emits microsecond precision
+    # so two writes within the same second produce distinct stamps under the
+    # LWW gate; the regex permits the optional fractional segment.
     EDITED_AT="$(jq -r '.fields.MLAT_USER.edited_at' "$ROOT_DIR/etc/airplanes/feed.meta.json")"
-    [[ "$EDITED_AT" =~ ^2[0-9]{3}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+    [[ "$EDITED_AT" =~ ^2[0-9]{3}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$ ]]
 }
 
 @test "unchanged tracked key with no incoming metadata leaves prior tuple intact" {

--- a/test/test_feed_env_apply_lww.bats
+++ b/test/test_feed_env_apply_lww.bats
@@ -191,14 +191,70 @@ read_meta_edited_at() {
     [ "$(read_disk_value MLAT_USER)" = "bob" ]
 }
 
-@test "fractional-second incoming compared against unfractioned on-disk" {
-    # Server emits the no-fraction form when microseconds are zero; a
-    # feeder-side stamp with sub-second precision must not falsely beat
-    # the unfractioned same-second on-disk stamp.
+@test "fractional-second incoming beats unfractioned on-disk same-second stamp" {
+    # Microsecond precision is preserved through normalize so a writer
+    # that lands a few microseconds after a same-second on-disk stamp
+    # is ordered correctly. The on-disk no-fraction form normalizes to
+    # `.000000`; an incoming `.000001` is strictly newer.
     seed_feed_env
     seed_meta MLAT_USER "2026-05-14T12:00:00Z"
     reset_incoming_meta
     APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00.000001Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ " ${APL_APPLY_CHANGED[*]} " = " MLAT_USER " ]
+    [ "${#APL_APPLY_SKIPPED_BY_LWW[@]}" -eq 0 ]
+    [ "$(read_disk_value MLAT_USER)" = "bob" ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T12:00:00.000001Z" ]
+}
+
+@test "sub-second LWW orders two same-second incoming writes" {
+    # Two webconfig saves within the same wall-clock-second must not
+    # collide under LWW: the second one is strictly newer and applies.
+    # Without microsecond-preserving normalize the second save was
+    # silently dropped (DEV-383 review finding).
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T12:00:00.100000Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00.500000Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ " ${APL_APPLY_CHANGED[*]} " = " MLAT_USER " ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T12:00:00.500000Z" ]
+}
+
+@test "sub-second LWW skips an older same-second incoming write" {
+    # Mirror of the test above with ordering reversed: an incoming
+    # stamp earlier than the on-disk stamp inside the same second loses.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T12:00:00.500000Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00.100000Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
+
+    do_apply --no-restart MLAT_USER=bob
+
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+}
+
+@test "normalize pads bare on-disk stamps to microsecond width for compare" {
+    # Older sidecar entries written before the microsecond-preserving
+    # normalize landed will have second-precision stamps. They must
+    # still compare correctly against new microsecond stamps. An
+    # incoming `12:00:00.000000Z` ties an on-disk `12:00:00Z` (both
+    # normalize to .000000) and the tie favors disk.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T12:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T12:00:00.000000Z"
     APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="feeder"
 
     do_apply --no-restart MLAT_USER=bob

--- a/test/test_feed_env_apply_lww.bats
+++ b/test/test_feed_env_apply_lww.bats
@@ -336,3 +336,35 @@ read_meta_edited_at() {
     [ " ${APL_APPLY_SKIPPED_BY_LWW[*]} " = " MLAT_USER " ]
     [ "$(read_disk_value MLAT_USER)" = "alice" ]
 }
+
+@test "explicit metadata on unchanged tracked key still bumps sidecar edited_at" {
+    # Pins the load-bearing behavior the image-webconfig metadata
+    # gate depends on (DEV-383): when an incoming object-form payload
+    # carries metadata for a tracked key, the sidecar is updated
+    # regardless of whether the canonical value changed, provided the
+    # LWW gate accepts the incoming edited_at.
+    #
+    # This is what makes the stuck-future-timestamp heal work
+    # (apl-feed config sync reconciles by sending the server tuple
+    # even when value matches). It is ALSO why webconfig must not
+    # attach metadata to unchanged tracked keys — if it did, every
+    # form save would push a fresh edited_at into the sidecar for
+    # untouched fields and clobber legitimate concurrent edits under
+    # LWW. The omission lives in
+    # image-webconfig/internal/feedmeta.BuildApplyPayload; this test
+    # guards the apply-side assumption that omission targets.
+    seed_feed_env
+    seed_meta MLAT_USER "2026-05-14T10:00:00Z"
+    reset_incoming_meta
+    APL_APPLY_INCOMING_META_EDITED_AT[MLAT_USER]="2026-05-14T11:00:00Z"
+    APL_APPLY_INCOMING_META_EDITED_BY[MLAT_USER]="website"
+
+    do_apply --no-restart MLAT_USER=alice  # value unchanged
+
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "${#APL_APPLY_CHANGED[@]}" -eq 0 ]
+    [ "${#APL_APPLY_SKIPPED_BY_LWW[@]}" -eq 0 ]
+    [ "$(read_disk_value MLAT_USER)" = "alice" ]
+    [ "$(read_meta_edited_at MLAT_USER)" = "2026-05-14T11:00:00Z" ]
+}


### PR DESCRIPTION
Two fixes in scripts/lib/feed-env-apply.sh that together pin the metadata contract image-webconfig's DEV-383 work depends on.

iso_now now stamps with microsecond fractional and the normalize helper for LWW compare pads or truncates incoming and on-disk stamps to a fixed-width microsecond form. Without this, two writes to the same tracked key inside one wall-clock-second produced equal post-normalize strings and the strictly-newer LWW rule silently dropped the second one. Matches the server-side merge precision (Python datetime.isoformat()) so same-second tie semantics behave symmetrically across the round trip.

Adds a regression test pinning that an object-form apply payload bumps the feed.meta.json sidecar even when the canonical value matches the on-disk value. This is the path apl-feed config sync uses to heal stuck future timestamps, and image-webconfig now relies on the contrapositive — explicit metadata is load-bearing, so local-writer callers must omit it for unchanged tracked keys.

Addresses [DEV-383](https://airplanes-live.atlassian.net/browse/DEV-383).

[DEV-383]: https://airplanes-live.atlassian.net/browse/DEV-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ