### PR TITLE
Add REMOTE_CONFIG_ENABLED opt-in gate for remote config sync

### DIFF
--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -32,6 +32,28 @@ CONFIG_SYNC_LEGACY_EDITED_BY="legacy"
 CONFIG_SYNC_EXIT_OK=0
 CONFIG_SYNC_EXIT_BAD_CONFIG=64
 
+# parse_opt_in RAW
+#   echoes one of: enabled, disabled, invalid, empty
+#   Mirrors parse_report_status in airplanes-diagnostics.sh.
+#   Callers map "empty" to disabled — REMOTE_CONFIG_ENABLED is opt-in,
+#   so absence means "not consented" rather than "default on".
+_config_sync_parse_opt_in() {
+    local raw="$1"
+    if [[ -z "$raw" ]]; then
+        printf '%s' 'empty'
+        return
+    fi
+    local lower
+    lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+    lower="${lower#"${lower%%[![:space:]]*}"}"
+    lower="${lower%"${lower##*[![:space:]]}"}"
+    case "$lower" in
+        true|yes|1|on) printf '%s' 'enabled' ;;
+        false|no|0|off) printf '%s' 'disabled' ;;
+        *) printf '%s' 'invalid' ;;
+    esac
+}
+
 # Sentinel mtime path. Overridable for tests + chroot smokes.
 CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-/var/lib/airplanes/config-sync-last-success}"
 
@@ -584,6 +606,27 @@ apl_feed_config_sync() {
         esac
     done
 
+    # Opt-in gate. REMOTE_CONFIG_ENABLED must be explicitly true before
+    # this CLI contacts the website. Absent / empty / false all short-
+    # circuit silently with exit 0 — the timer keeps ticking, the
+    # collector exits silently each tick, no payload leaves the feeder.
+    # An unparseable value surfaces as a hard config error (exit 64) so
+    # operators see it in `apl-feed status` / `systemctl status`.
+    local opt_in opt_in_state
+    opt_in="$(feed_env_get REMOTE_CONFIG_ENABLED 2>/dev/null || true)"
+    opt_in_state="$(_config_sync_parse_opt_in "$opt_in")"
+    case "$opt_in_state" in
+        disabled|empty)
+            _config_sync_log info "status=disabled reason=opt_in_required"
+            return "$CONFIG_SYNC_EXIT_OK"
+            ;;
+        invalid)
+            _config_sync_log error "status=bad_config key=REMOTE_CONFIG_ENABLED value=${opt_in}"
+            return "$CONFIG_SYNC_EXIT_BAD_CONFIG"
+            ;;
+        enabled) ;;
+    esac
+
     require_jq
 
     if (( dry_run )); then
@@ -705,12 +748,100 @@ apl_feed_config_sync() {
     return "$CONFIG_SYNC_EXIT_OK"
 }
 
+# Operator-facing toggle for the REMOTE_CONFIG_ENABLED opt-in. Mirrors
+# _diagnostics_apply / _diagnostics_emit_result in apl-feed/diagnostics.sh:
+# routes the sparse update through apl_feed_apply so the canonical
+# privileged writer handles locking, validation, and atomic rewrite.
+# REMOTE_CONFIG_ENABLED is registered as a no-restart key in
+# feed-env-keys.sh — the next sync tick (within ~60s) reads the new
+# value at the top-of-function gate.
+_config_toggle_apply() {
+    feed_env_ensure_canonical_for_write
+    local -a args=()
+    args+=(--feed-env "$(feed_env_write_path)")
+    args+=(--lock-file "$(feed_env_lock_path)")
+    if [[ "$ROOT" != "/" ]]; then
+        args+=(--no-restart --no-audit)
+        echo "Skipping service restart (--root=$ROOT, not the host root)" >&2
+    fi
+    CONFIG_TOGGLE_APPLY_RC=0
+    apl_feed_apply "${args[@]}" "$@" || CONFIG_TOGGLE_APPLY_RC=$?
+}
+
+_config_toggle_emit_result() {
+    local success_msg="$1"
+    case "$APL_APPLY_STATUS" in
+        applied)
+            echo "$success_msg"
+            if (( ${#APL_APPLY_PENDING_RESTART[@]} > 0 )); then
+                echo "Warning: failed to restart ${APL_APPLY_PENDING_RESTART[*]} — re-run: sudo systemctl restart ${APL_APPLY_PENDING_RESTART[*]}" >&2
+            fi
+            apl_feed_apply_emit_meta_warning
+            return 0
+            ;;
+        no_change)
+            return 0
+            ;;
+        rejected)
+            local k
+            for k in "${!APL_APPLY_ERRORS[@]}"; do
+                echo "ERROR: $k: ${APL_APPLY_ERRORS[$k]}" >&2
+            done
+            return 1
+            ;;
+        lock_timeout)
+            echo "ERROR: could not acquire feed.env lock: $APL_APPLY_ERROR_MESSAGE" >&2
+            return 1
+            ;;
+        filesystem_error)
+            echo "ERROR: $APL_APPLY_ERROR_MESSAGE" >&2
+            return 1
+            ;;
+        *)
+            echo "ERROR: ${APL_APPLY_ERROR_MESSAGE:-apply failed with status ${APL_APPLY_STATUS:-<unset>}}" >&2
+            return 1
+            ;;
+    esac
+}
+
+apl_feed_config_enable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for config enable: $1" ;;
+        esac
+    done
+
+    _config_toggle_apply REMOTE_CONFIG_ENABLED=true
+    _config_toggle_emit_result "REMOTE_CONFIG_ENABLED set to true (remote config sync enabled; next tick within ~60s will contact the website)"
+}
+
+apl_feed_config_disable() {
+    local opt_rc
+    while [[ $# -gt 0 ]]; do
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for config disable: $1" ;;
+        esac
+    done
+
+    _config_toggle_apply REMOTE_CONFIG_ENABLED=false
+    _config_toggle_emit_result "REMOTE_CONFIG_ENABLED set to false (remote config sync disabled; the timer stays armed but the sync CLI exits silently each tick)"
+}
+
 dispatch_config() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "config requires a subcommand (sync)"
+    [[ -n "$sub" ]] || die "config requires a subcommand (enable|disable|sync)"
     shift || true
     case "$sub" in
-        sync) apl_feed_config_sync "$@" ;;
+        enable)  apl_feed_config_enable  "$@" ;;
+        disable) apl_feed_config_disable "$@" ;;
+        sync)    apl_feed_config_sync    "$@" ;;
         -h|--help) usage ;;
         *) die "unknown config subcommand: $sub" ;;
     esac

--- a/scripts/lib/feed-env-keys.sh
+++ b/scripts/lib/feed-env-keys.sh
@@ -28,6 +28,7 @@ declare -ga APL_FEED_WRITABLE_KEYS=(
     DUMP978_SDR_SERIAL
     DUMP978_GAIN
     REPORT_STATUS
+    REMOTE_CONFIG_ENABLED
 )
 
 declare -ga APL_FEED_READABLE_KEYS=(
@@ -45,6 +46,7 @@ declare -ga APL_FEED_READABLE_KEYS=(
     DUMP978_SDR_SERIAL
     DUMP978_GAIN
     REPORT_STATUS
+    REMOTE_CONFIG_ENABLED
 )
 
 declare -gA APL_FEED_KEY_TYPE=(
@@ -60,6 +62,7 @@ declare -gA APL_FEED_KEY_TYPE=(
     [DUMP978_SDR_SERIAL]=dump978_serial
     [DUMP978_GAIN]=dump978_gain
     [REPORT_STATUS]=bool
+    [REMOTE_CONFIG_ENABLED]=bool
 )
 
 # Restart map: a key landing on disk → space-separated list of systemd units
@@ -80,6 +83,7 @@ declare -gA APL_FEED_KEY_RESTART=(
     [DUMP978_SDR_SERIAL]="dump978-fa airplanes-978"
     [DUMP978_GAIN]="dump978-fa"
     [REPORT_STATUS]=""
+    [REMOTE_CONFIG_ENABLED]=""
 )
 
 apl_feed_is_writable_key() {

--- a/test/test_apl_feed_config.bats
+++ b/test/test_apl_feed_config.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+
+# Per-module tests for scripts/apl-feed/config.sh covering the
+# REMOTE_CONFIG_ENABLED opt-in surface:
+#   1. `apl-feed config enable|disable` write the toggle to feed.env via
+#      the canonical apl_feed_apply path. Same shape as
+#      test_apl_feed_diagnostics.bats.
+#   2. `apl-feed config sync` short-circuits silently when the toggle is
+#      absent / empty / false, and exits 64 on an unparseable value.
+#      The integration-shaped happy-path coverage already lives in
+#      test_apl_feed_config_sync.bats; this file only pins the gate.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    STUB_DIR="$ROOT_DIR/bin"
+    SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
+    CURL_LOG="$ROOT_DIR/curl.log"
+    mkdir -p "$TMPDIR" "$STUB_DIR" "$ROOT_DIR/etc/airplanes"
+    export TMPDIR
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/configure-validators.sh"
+    # shellcheck source=../scripts/lib/feed-env-keys.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-keys.sh"
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/config.sh
+    source "$LIB_DIR/config.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    APL_TEST_LOCK_FILE="$ROOT_DIR/feed-env.lock"
+    feed_env_lock_path() { printf '%s\n' "$APL_TEST_LOCK_FILE"; }
+
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    cat > "$STUB_DIR/logger" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/logger"
+    # Curl stub: record every invocation so the gate-blocks-network
+    # assertion can prove no HTTP went out.
+    cat > "$STUB_DIR/curl" <<STUB
+#!/usr/bin/env bash
+printf 'curl %s\n' "\$*" >> "$CURL_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/curl"
+    PATH="$STUB_DIR:$PATH"
+    export PATH
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Baseline feed.env with no REMOTE_CONFIG_ENABLED line (the post-install
+# default state — operator has not opted in).
+write_feed_env_default() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+GEO_CONFIGURED=true
+MLAT_USER="bats-tester"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+EOF
+}
+
+write_feed_env_with_remote_config() {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<EOF
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35m"
+GEO_CONFIGURED=true
+MLAT_USER="bats-tester"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+REMOTE_CONFIG_ENABLED=$1
+EOF
+}
+
+# --- enable ---
+
+@test "config enable: appends REMOTE_CONFIG_ENABLED=true to feed.env from default state" {
+    write_feed_env_default
+    run apl_feed_config_enable
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOTE_CONFIG_ENABLED set to true"* ]]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?true\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "config enable: idempotent (no_change exit 0 when REMOTE_CONFIG_ENABLED=true already)" {
+    write_feed_env_with_remote_config true
+    run apl_feed_config_enable
+    [ "$status" -eq 0 ]
+    ! [[ "$output" == *"REMOTE_CONFIG_ENABLED set to"* ]]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?true\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "config enable: flips REMOTE_CONFIG_ENABLED=false to true and reports applied" {
+    write_feed_env_with_remote_config false
+    run apl_feed_config_enable
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOTE_CONFIG_ENABLED set to true"* ]]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?true\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "config enable: rejects unknown flag" {
+    write_feed_env_default
+    run apl_feed_config_enable --no-such-flag
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown flag"* ]]
+}
+
+# --- disable ---
+
+@test "config disable: writes REMOTE_CONFIG_ENABLED=false to feed.env from default state" {
+    write_feed_env_default
+    run apl_feed_config_disable
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOTE_CONFIG_ENABLED set to false"* ]]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?false\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "config disable: idempotent when REMOTE_CONFIG_ENABLED=false already" {
+    write_feed_env_with_remote_config false
+    run apl_feed_config_disable
+    [ "$status" -eq 0 ]
+    ! [[ "$output" == *"REMOTE_CONFIG_ENABLED set to"* ]]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?false\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "config disable: flips REMOTE_CONFIG_ENABLED=true to false and reports applied" {
+    write_feed_env_with_remote_config true
+    run apl_feed_config_disable
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOTE_CONFIG_ENABLED set to false"* ]]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?false\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+# --- round-trip ---
+
+@test "config enable -> disable -> enable preserves canonical bytes" {
+    write_feed_env_default
+    apl_feed_config_enable  >/dev/null
+    apl_feed_config_disable >/dev/null
+    apl_feed_config_enable  >/dev/null
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?true\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+    local count
+    count="$(grep -Ec '^REMOTE_CONFIG_ENABLED=' "$ROOT_DIR/etc/airplanes/feed.env")"
+    [ "$count" = "1" ]
+}
+
+# --- no daemon restart ---
+
+@test "config enable does NOT restart any service (REMOTE_CONFIG_ENABLED is no-restart in the key registry)" {
+    write_feed_env_default
+    apl_feed_config_enable >/dev/null
+    if [[ -f "$SYSTEMCTL_LOG" ]]; then
+        ! grep -q 'restart' "$SYSTEMCTL_LOG"
+    fi
+}
+
+# --- dispatcher ---
+
+@test "dispatch_config enable routes to apl_feed_config_enable" {
+    write_feed_env_default
+    run dispatch_config enable
+    [ "$status" -eq 0 ]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?true\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "dispatch_config disable routes to apl_feed_config_disable" {
+    write_feed_env_default
+    run dispatch_config disable
+    [ "$status" -eq 0 ]
+    grep -Eq "^REMOTE_CONFIG_ENABLED=\"?false\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "dispatch_config with no subcommand fails with actionable message" {
+    run dispatch_config
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"config requires a subcommand"* ]]
+    [[ "$output" == *"enable"* ]]
+    [[ "$output" == *"disable"* ]]
+    [[ "$output" == *"sync"* ]]
+}
+
+@test "dispatch_config with unknown subcommand fails" {
+    run dispatch_config nuke
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown config subcommand: nuke"* ]]
+}
+
+# --- gate: sync short-circuits without REMOTE_CONFIG_ENABLED=true ---
+
+@test "config sync exits 0 silently when REMOTE_CONFIG_ENABLED is absent (default opt-in semantics)" {
+    write_feed_env_default
+    run apl_feed_config_sync
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"opt_in_required"* ]]
+    [ ! -f "$CURL_LOG" ]
+}
+
+@test "config sync exits 0 silently when REMOTE_CONFIG_ENABLED=false" {
+    write_feed_env_with_remote_config false
+    run apl_feed_config_sync
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"opt_in_required"* ]]
+    [ ! -f "$CURL_LOG" ]
+}
+
+@test "config sync exits 0 silently when REMOTE_CONFIG_ENABLED is empty" {
+    write_feed_env_with_remote_config ""
+    run apl_feed_config_sync
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"opt_in_required"* ]]
+    [ ! -f "$CURL_LOG" ]
+}
+
+@test "config sync exits 64 on unparseable REMOTE_CONFIG_ENABLED value" {
+    write_feed_env_with_remote_config bogus
+    run apl_feed_config_sync
+    [ "$status" -eq 64 ]
+    [[ "$output" == *"bad_config"* ]]
+    [[ "$output" == *"REMOTE_CONFIG_ENABLED"* ]]
+    [ ! -f "$CURL_LOG" ]
+}
+
+@test "config sync with REMOTE_CONFIG_ENABLED=true passes the gate (subsequent identity check is what fails)" {
+    # Confirms the gate is not the blocker: identity files are absent so
+    # the function hits the missing-uuid branch, which exits 64. The
+    # important property is that the gate's "opt_in_required" message is
+    # NOT in the output.
+    write_feed_env_with_remote_config true
+    run apl_feed_config_sync
+    [ "$status" -eq 64 ]
+    ! [[ "$output" == *"opt_in_required"* ]]
+}
+
+# --- gate position relative to dry-run ---
+
+@test "config sync --dry-run also honors the opt-in gate" {
+    # Even dry-run is a payload-build step that touches feed.env beyond
+    # what the operator opted into. The gate sits above the dry-run
+    # branch so a non-opted-in feeder cannot inadvertently emit a payload.
+    write_feed_env_default
+    run apl_feed_config_sync --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"opt_in_required"* ]]
+}

--- a/test/test_apl_feed_config_sync.bats
+++ b/test/test_apl_feed_config_sync.bats
@@ -86,6 +86,7 @@ GEO_CONFIGURED=true
 MLAT_USER="alice"
 MLAT_ENABLED=true
 MLAT_PRIVATE=false
+REMOTE_CONFIG_ENABLED=true
 EOF
 }
 
@@ -168,6 +169,7 @@ GEO_CONFIGURED=false
 MLAT_USER="alice"
 MLAT_ENABLED=false
 MLAT_PRIVATE=false
+REMOTE_CONFIG_ENABLED=true
 EOF
     run_sync --dry-run
 
@@ -184,6 +186,7 @@ GEO_CONFIGURED=true
 MLAT_USER="alice"
 MLAT_ENABLED=true
 MLAT_PRIVATE=false
+REMOTE_CONFIG_ENABLED=true
 EOF
     run_sync --dry-run
     [ "$SYNC_RC" -eq 0 ]
@@ -213,6 +216,7 @@ ALTITUDE="120m"
 MLAT_USER=""
 MLAT_ENABLED=false
 MLAT_PRIVATE=false
+REMOTE_CONFIG_ENABLED=true
 EOF
     run_sync --dry-run
     [ "$SYNC_RC" -eq 0 ]
@@ -227,6 +231,7 @@ GEO_CONFIGURED=true
 ALTITUDE="120m"
 MLAT_USER="alice"
 MLAT_PRIVATE=false
+REMOTE_CONFIG_ENABLED=true
 EOF
     run_sync --dry-run
     [ "$SYNC_RC" -eq 0 ]


### PR DESCRIPTION
Addresses [DEV-446](https://airplanes-live.atlassian.net/browse/DEV-446) (REMOTE_CONFIG_ENABLED opt-in toggle). Refs [DEV-384](https://airplanes-live.atlassian.net/browse/DEV-384) (remote config sync CLI).

[DEV-446]: https://airplanes-live.atlassian.net/browse/DEV-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-384]: https://airplanes-live.atlassian.net/browse/DEV-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ