### PR TITLE
Extract apl_auth_token; report readsb + airplanes-978 in diagnostics

### DIFF
--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -747,7 +747,7 @@ main() {
     # `ps`.
     local response_file token status curl_rc
     response_file="$(new_tmp_file)"
-    token="alv1.${uuid}.${secret}"
+    token="$(apl_auth_token "$uuid" "$secret")"
 
     set +e
     status="$(post_json_bearer "$token" '/api/feeders/diagnostics' "$payload" "$response_file")"

--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -329,7 +329,9 @@ get_service_version() {
     ipath="$(root_path /usr/local/share/airplanes)"
     local version_file=''
     case "$service" in
-        airplanes-feed) version_file="$ipath/readsb_version" ;;
+        # airplanes-feed, readsb, and airplanes-978 all run a readsb-derived
+        # binary; they share the same install-time version file.
+        airplanes-feed|readsb|airplanes-978) version_file="$ipath/readsb_version" ;;
         airplanes-mlat) version_file="$ipath/mlat_version" ;;
     esac
     if [[ -n "$version_file" && -r "$version_file" ]]; then
@@ -602,10 +604,24 @@ main() {
         collect_disk || true
         collect_network || true
 
-        local svc_feed svc_mlat svc_978
+        local svc_feed svc_mlat svc_readsb svc_dump978 svc_978
         svc_feed="$(build_service_json airplanes-feed)"
         svc_mlat="$(build_service_json airplanes-mlat)"
-        svc_978="$(build_service_json dump978-fa)"
+        svc_readsb="$(build_service_json readsb)"
+        svc_dump978="$(build_service_json dump978-fa)"
+        # airplanes-978 is the readsb UAT instance — only relevant when
+        # the user has actually configured UAT. Without this gate, every
+        # non-UAT feeder would report a "stopped" airplanes-978 unit
+        # because the image ships the unit file even when UAT is off
+        # (the unit self-disables at runtime). Gating here keeps the
+        # dashboard quiet for the common no-978-dongle case until the
+        # collector grows a per-service `configured` field.
+        local uat_input
+        uat_input="$(feed_env_get UAT_INPUT 2>/dev/null || true)"
+        svc_978='null'
+        if [[ -n "$uat_input" ]]; then
+            svc_978="$(build_service_json airplanes-978)"
+        fi
 
         local pi_health_json
         pi_health_json="$(build_pi_health_json)"
@@ -645,6 +661,8 @@ main() {
             --argjson wifi_rssi "$(nullable_num "$NET_WIFI_RSSI_DBM")" \
             --argjson svc_feed "$svc_feed" \
             --argjson svc_mlat "$svc_mlat" \
+            --argjson svc_readsb "$svc_readsb" \
+            --argjson svc_dump978 "$svc_dump978" \
             --argjson svc_978 "$svc_978" \
             --argjson pi_health "$pi_health_json" \
             --arg feed_scripts "${feed_scripts_version:-}" \
@@ -680,7 +698,7 @@ main() {
                     connection_type: $net_connection_type,
                     wifi_rssi_dbm: $wifi_rssi
                 },
-                services: [$svc_feed, $svc_mlat, $svc_978] | map(select(. != null)),
+                services: [$svc_feed, $svc_mlat, $svc_readsb, $svc_dump978, $svc_978] | map(select(. != null)),
                 versions: {
                     feed_scripts: $feed_scripts,
                     os_pretty_name: $os_pretty_name,

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -77,8 +77,10 @@ claim_register() {
         # registered ("tautology"). The server ignores the bearer secret
         # on the CREATE branch and stores hash(body.new_secret).
         body="$(printf '{"new_secret":"%s"}' "$secret")"
+        local token
+        token="$(apl_auth_token "$uuid" "$secret")"
         set +e
-        status="$(post_json_bearer "alv1.${uuid}.${secret}" '/api/feeders/secret' "$body" "$response_file")"
+        status="$(post_json_bearer "$token" '/api/feeders/secret' "$body" "$response_file")"
         curl_rc=$?
         set -e
 
@@ -294,8 +296,10 @@ claim_rotate() {
         # rotate-current-check, so a stale bearer with the matching body
         # new_secret still returns 200.
         body="$(printf '{"new_secret":"%s"}' "$next")"
+        local token
+        token="$(apl_auth_token "$uuid" "$current")"
         set +e
-        status="$(post_json_bearer "alv1.${uuid}.${current}" '/api/feeders/secret' "$body" "$response_file")"
+        status="$(post_json_bearer "$token" '/api/feeders/secret' "$body" "$response_file")"
         curl_rc=$?
         set -e
 

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -341,6 +341,20 @@ feed_env_get() {
     printf '%s\n' "$output" | tail -n 1
 }
 
+apl_auth_token() {
+    # Build the v1 Authorization: Bearer token shape `alv1.<uuid>.<secret>`
+    # from a raw uuid + secret pair. Canonicalizes both internally so call
+    # sites can't accidentally send unnormalized inputs. Returns 0 with the
+    # assembled token on stdout, 1 if either input fails its canonical-form
+    # check (caller should fail loud — the server would 401 either way).
+    local raw_uuid="${1:-}" raw_secret="${2:-}"
+    local uuid secret
+    uuid="$(canonicalize_uuid "$raw_uuid")" || return 1
+    secret="$(canonicalize_secret "$raw_secret")"
+    validate_secret "$secret" || return 1
+    printf 'alv1.%s.%s' "$uuid" "$secret"
+}
+
 canonicalize_uuid() {
     # Strip whitespace + braces + hyphens are kept; lowercase hex; require
     # the canonical 8-4-4-4-12 shape after normalization. Returns 0 with

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -680,7 +680,7 @@ apl_feed_config_sync() {
 
     response_file="$(new_tmp_file)"
     local status curl_rc token
-    token="alv1.${uuid}.${secret}"
+    token="$(apl_auth_token "$uuid" "$secret")"
     set +e
     status="$(post_json_bearer "$token" '/api/feeders/config/sync' "$payload" "$response_file")"
     curl_rc=$?

--- a/scripts/apl-feed/http.sh
+++ b/scripts/apl-feed/http.sh
@@ -82,7 +82,7 @@ status_probe_version() {
     response_file="$(mktemp)"
     # Body carries only the UUID; auth is in the Bearer header.
     body="$(printf '{"uuid":"%s"}' "$uuid")"
-    token="alv1.${uuid}.${secret}"
+    token="$(apl_auth_token "$uuid" "$secret")"
     set +e
     status="$(post_json_bearer "$token" '/api/feeders/status' "$body" "$response_file")"
     curl_rc=$?

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -403,7 +403,7 @@ claim_registration_status_line() {
     response_file="$(new_tmp_file)"
     # Body carries only the UUID; auth is in the Bearer header.
     body="$(printf '{"uuid":"%s"}' "$uuid")"
-    token="alv1.${uuid}.${secret}"
+    token="$(apl_auth_token "$uuid" "$secret")"
     set +e
     status="$(post_json_bearer "$token" '/api/feeders/status' "$body" "$response_file")"
     curl_rc=$?

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -539,6 +539,71 @@ SH
     [ "$output" = '0a1b2c3d4e5f6a7b8c9d' ]
 }
 
+@test "POST body includes readsb when its unit is installed" {
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+    "show airplanes-feed "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-mlat "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show readsb "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=1\n' ;;
+    "show dump978-fa "*) printf 'LoadState=not-found\nUnitFileState=\nActiveState=inactive\nSubState=dead\nNRestarts=0\n' ;;
+    *) ;;
+esac
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '[.services[].name] | sort | join(",")' "$BODY_LOG"
+    [ "$output" = 'airplanes-feed,airplanes-mlat,readsb' ]
+    run jq -er '.services[] | select(.name=="readsb") | .restart_count_total' "$BODY_LOG"
+    [ "$output" = '1' ]
+    # readsb shares the install-time readsb_version file with airplanes-feed.
+    run jq -er '.services[] | select(.name=="readsb") | .version' "$BODY_LOG"
+    [ "$output" = '0a1b2c3d4e5f6a7b8c9d' ]
+}
+
+@test "POST body omits airplanes-978 when UAT_INPUT is empty" {
+    # Default feed.env has REPORT_STATUS=true and no UAT_INPUT.
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+    "show airplanes-feed "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-mlat "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    # The collector must not even probe airplanes-978 when UAT is off —
+    # if it does, this stub would emit it and the assertion below fails.
+    "show airplanes-978 "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=inactive\nSubState=dead\nNRestarts=0\n' ;;
+    *) ;;
+esac
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services | map(select(.name=="airplanes-978")) | length' "$BODY_LOG"
+    [ "$output" = '0' ]
+}
+
+@test "POST body includes airplanes-978 when UAT_INPUT is set" {
+    printf 'REPORT_STATUS=true\nUAT_INPUT=driver=0bda:2838,serial=978\n' \
+        > "$ROOT_DIR/etc/airplanes/feed.env"
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+    "show airplanes-feed "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-mlat "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-978 "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    *) ;;
+esac
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services[] | select(.name=="airplanes-978") | .active_state' "$BODY_LOG"
+    [ "$output" = 'active' ]
+}
+
 @test "POST body versions block reflects /etc/os-release and uname" {
     run_script
     [ "$status" -eq 0 ]

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -631,3 +631,48 @@ STUB
     [ "$status" -eq 0 ]
     [ "$output" = 'banana' ]
 }
+
+# --- apl_auth_token ---
+
+@test "apl_auth_token: builds alv1.<uuid>.<secret> from canonical inputs" {
+    run apl_auth_token \
+        '11111111-2222-3333-4444-555555555555' \
+        'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 0 ]
+    [ "$output" = 'alv1.11111111-2222-3333-4444-555555555555.ABCDEFGHIJKLMNOP' ]
+}
+
+@test "apl_auth_token: canonicalizes uppercase + braces in uuid" {
+    run apl_auth_token \
+        '{11111111-2222-3333-4444-AAAAAAAAAAAA}' \
+        'ABCDEFGHIJKLMNOP'
+    [ "$status" -eq 0 ]
+    [ "$output" = 'alv1.11111111-2222-3333-4444-aaaaaaaaaaaa.ABCDEFGHIJKLMNOP' ]
+}
+
+@test "apl_auth_token: canonicalizes spaces + hyphens + lowercase in secret" {
+    run apl_auth_token \
+        '11111111-2222-3333-4444-555555555555' \
+        '  abcd-efgh ijkl-mnop  '
+    [ "$status" -eq 0 ]
+    [ "$output" = 'alv1.11111111-2222-3333-4444-555555555555.ABCDEFGHIJKLMNOP' ]
+}
+
+@test "apl_auth_token: rejects malformed uuid" {
+    run apl_auth_token 'not-a-uuid' 'ABCDEFGHIJKLMNOP'
+    [ "$status" -ne 0 ]
+}
+
+@test "apl_auth_token: rejects too-short secret after canonicalization" {
+    run apl_auth_token \
+        '11111111-2222-3333-4444-555555555555' \
+        'ABCDEFGH'
+    [ "$status" -ne 0 ]
+}
+
+@test "apl_auth_token: rejects secret with non-alphanumeric chars" {
+    run apl_auth_token \
+        '11111111-2222-3333-4444-555555555555' \
+        'ABCDEFGH!@#$%^&*'
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Two follow-ups to the diagnostics collector landing wave.

`apl_auth_token` is a new shared helper in `apl-feed/common.sh` that canonicalises a uuid + secret pair and builds the `alv1.<uuid>.<secret>` bearer string. The six call sites in `claim.sh`, `http.sh`, `status.sh`, `config.sh`, and the diagnostics collector now go through it instead of each one concatenating the parts inline. Pure refactor; no wire-format change.

The diagnostics collector now reports two more services: `readsb` (local decoder, always emitted when the unit is installed) and `airplanes-978` (UAT readsb instance, only emitted when `UAT_INPUT` is non-empty in feed.env). Without the gate, every non-UAT feeder would surface a stopped `airplanes-978` chip for a unit that the user never asked to run.