### PR TITLE
fix(status): detect outbound feed link when port is last on line

### DIFF
--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -340,7 +340,7 @@ airplanes_link_status_line() {
         return
     fi
 
-    if printf '%s\n' "$output" | grep -Eq ':(30004|31090)[[:space:]]'; then
+    if printf '%s\n' "$output" | grep -Eq ':(30004|31090)([[:space:]]|$)'; then
         status_line ok "Airplanes.live link" "connected"
     else
         status_line warn "Airplanes.live link" "no connection found yet"

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -564,7 +564,7 @@ STUB
 @test "airplanes_link_status_line: ss output shows :30004 → ok" {
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
-printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004 \n'
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004\n'
 exit 0
 STUB
     chmod +x "$STUB_DIR/ss"
@@ -578,7 +578,7 @@ STUB
 @test "airplanes_link_status_line: ss output shows :31090 → ok (mlat)" {
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
-printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090 \n'
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090\n'
 exit 0
 STUB
     chmod +x "$STUB_DIR/ss"


### PR DESCRIPTION
`apl-feed status` previously reported `CHECK Airplanes.live link  no connection found yet` even when the feeder was actively pushing data upstream. The check greps `ss -tn state established` for `:30004` / `:31090` followed by `[[:space:]]`, but the peer `address:port` is the last token on each line — grep matches per-line, so there was never a whitespace character after the port for the regex to satisfy.

Anchor the regex on end-of-line as well as whitespace, and drop the stray trailing space in the bats stubs (which was the only reason CI had been green).
