### PR TITLE
chore(update): point post-update banner at apl-feed status

### DIFF
--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -40,7 +40,7 @@ exit 0
 STUB
     cat > "$STUB_BIN_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
-printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090 \n'
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090\n'
 exit 0
 STUB
     chmod +x "$STUB_BIN_DIR/systemctl" "$STUB_BIN_DIR/nc" "$STUB_BIN_DIR/ss"

--- a/update.sh
+++ b/update.sh
@@ -760,10 +760,11 @@ echo "---------------------"
 ENDTEXT="
 Thanks for choosing to share your data with airplanes.live!
 
-Your feed should be active within 5 minutes. To verify, run:
-sudo apl-feed status
+Check your feeder's status:
+  sudo apl-feed status
 
-You can also check on the web at https://airplanes.live/myfeed/
+Claim your feeder for more insights and statistics:
+  ${APL_FEED_WEBSITE_URL:-https://airplanes.live}/feeder/claim/
 
 Question? Issues? Go here:
 https://discord.gg/jfVRF2XRwF

--- a/update.sh
+++ b/update.sh
@@ -760,10 +760,10 @@ echo "---------------------"
 ENDTEXT="
 Thanks for choosing to share your data with airplanes.live!
 
-Check https://airplanes.live/myfeed/ for feeder status!
+Your feed should be active within 5 minutes. To verify, run:
+sudo apl-feed status
 
-Your feed should be active within 5 minutes, you can confirm by running the following command and looking for the IP address 78.46.234.18
-netstat -t -n | grep -E '30004|31090'
+You can also check on the web at https://airplanes.live/myfeed/
 
 Question? Issues? Go here:
 https://discord.gg/jfVRF2XRwF


### PR DESCRIPTION
The post-update banner instructed users to confirm feeding by running `netstat -t -n | grep -E '30004|31090'` against the hardcoded production IP `78.46.234.18`. That IP is wrong for anyone running custom infrastructure, and the advice predates `apl-feed status`, which now covers the outbound link, website-side ingest, claim state, and diagnostics push in one command. The old `/myfeed/` pointer only worked from the feeder's public IP, whereas the CLI works from anywhere and is strictly more informative.

The replacement banner gives the user two clear next steps: run `sudo apl-feed status` to verify, and visit `/feeder/claim/` on the configured website to claim the feeder for full statistics and account features. The claim URL is derived from `APL_FEED_WEBSITE_URL` so custom-backend deployments resolve to the right host.

Also drops a stray trailing space in the `test_apl_feed_cli.bats` `ss` stub, for consistency with the sibling stubs in `test_apl_feed_status.bats`.
