### PR TITLE
feat(status): reorder by data flow, sharpen reception signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ OK    Feed service         running
 OK    ADS-B uplink         connected
 OK    Feeder ID            11111111-2222-3333-4444-555555555555
 OK    Claim secret         present
-OK    Website claim        registered, not yet claimed (v1)
+OK    Website claim        registered, not yet claimed
 OK    Server reception     currently receiving (last data seen 1m ago)
 OK    MLAT service         running (name: public)
 OK    Diagnostics push     enabled (default), last push 4m ago

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ Example:
 ```
 airplanes.live feed check
 
-OK    Feed service         running
-OK    MLAT service         running
 OK    Receiver input       connected at 127.0.0.1:30005
-OK    Airplanes.live link  connected
+OK    Receiver activity    data flowing (256b in 2s sample)
+OK    Feed service         running
+OK    ADS-B uplink         connected
 OK    Feeder ID            11111111-2222-3333-4444-555555555555
 OK    Claim secret         present
 OK    Website claim        registered, not yet claimed (v1)
-OK    Website feed         last data seen 1m ago
+OK    Server reception     currently receiving (last data seen 1m ago)
+OK    MLAT service         running (name: public)
+OK    Diagnostics push     enabled (default), last push 4m ago
 
 Result: feeding looks healthy
 ```

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -266,9 +266,9 @@ mlat_status_line() {
 # _mlat_privacy_suffix — read the daemon's published privacy posture
 # from /run/airplanes-mlat/state and render the inline suffix appended
 # to a "running" MLAT line. Empty string when the state file is
-# unreadable or the value is missing; mlat_status_line already covers
-# the "daemon down" actionable signal so we don't want to double-warn
-# from a privacy probe.
+# unreadable, the value is missing, or the value is unrecognised (an
+# unknown value is surfaced separately via _mlat_privacy_unknown_value
+# so forward-schema visibility isn't lost when the suffix is folded in).
 _mlat_privacy_suffix() {
     local state_file mlat_private
     state_file="$(root_path /run/airplanes-mlat/state)"
@@ -281,6 +281,21 @@ _mlat_privacy_suffix() {
     esac
 }
 
+# _mlat_privacy_unknown_value — if the state file's mlat_private key
+# carries a token we don't recognise, return it for the caller to
+# surface as a warn line. Empty when absent or recognised.
+_mlat_privacy_unknown_value() {
+    local state_file mlat_private
+    state_file="$(root_path /run/airplanes-mlat/state)"
+    if ! mlat_private="$(airplanes_read_state "$state_file" mlat_private 2>/dev/null)"; then
+        return 0
+    fi
+    case "$mlat_private" in
+        ''|true|false) return 0 ;;
+        *) printf '%s' "$mlat_private" ;;
+    esac
+}
+
 _render_mlat_decision() {
     local active_state="$1" decision="$2" reason="$3"
     local label="MLAT service"
@@ -288,6 +303,11 @@ _render_mlat_decision() {
         enabled)
             if [[ "$active_state" == "active" ]]; then
                 status_line ok "$label" "running$(_mlat_privacy_suffix)"
+                local unknown
+                unknown="$(_mlat_privacy_unknown_value)"
+                if [[ -n "$unknown" ]]; then
+                    status_line warn "MLAT name privacy" "unknown value: $unknown"
+                fi
             else
                 status_line warn "$label" "starting up ($active_state)"
             fi
@@ -369,9 +389,11 @@ receiver_activity_status_line() {
     local timeout_secs="${RECEIVER_ACTIVITY_TIMEOUT:-2}"
     local sample_bytes="${RECEIVER_ACTIVITY_SAMPLE_BYTES:-256}"
 
-    if [[ "$STATUS_RECEIVER_INPUT_STATE" == "fail" ]]; then
-        # Connection-level failure is already reported on the line above;
-        # an activity check on an unreachable socket has nothing to add.
+    if [[ "$STATUS_RECEIVER_INPUT_STATE" != "ok" ]]; then
+        # Anything other than a clean reachable input on the line above
+        # has already been reported (fail = unreachable, warn = malformed
+        # INPUT or nc unavailable). An activity probe against unresolved
+        # or unreachable input only adds a misleading second line.
         return
     fi
     if [[ -z "${STATUS_RECEIVER_INPUT_IP:-}" || -z "${STATUS_RECEIVER_INPUT_PORT:-}" ]]; then
@@ -408,23 +430,33 @@ receiver_activity_status_line() {
 # adsb_uplink_status_line — checks for an established outbound TCP
 # socket to the ADS-B aggregator ports. TARGET in airplanes-feed.sh
 # binds to feed.airplanes.live:30004 with failover to
-# feed2.airplanes.live:64004; either established socket means the feed
-# binary has wired its uplink. MLAT (:31090) is intentionally excluded
-# here — the MLAT service line already speaks for that path; a MLAT-only
-# connection used to flip this check to ok and hid an ADS-B-down state.
+# feed2.airplanes.live:64004; either established peer socket means the
+# feed binary has wired its uplink. MLAT (:31090) is intentionally
+# excluded — the MLAT service line already speaks for that path; a
+# MLAT-only connection used to flip this check to ok and hid an
+# ADS-B-down state.
+#
+# Matches the PEER address:port (last column of `ss -tn`) so a local
+# listener on :30004 / :64004 (a different process binding the same port
+# locally) can't false-positive. `ss -tn state established` already
+# filters by state; the netstat fallback enforces ESTABLISHED itself.
 adsb_uplink_status_line() {
     local label="ADS-B uplink"
-    local output
+    local peer_ports
     if command -v ss >/dev/null 2>&1; then
-        output="$(ss -tn state established 2>/dev/null || true)"
+        # ss output: State Recv-Q Send-Q Local-Address:Port Peer-Address:Port
+        # The peer address:port is the LAST whitespace-separated field.
+        peer_ports="$(ss -tn state established 2>/dev/null | awk 'NR>1 {print $NF}' || true)"
     elif command -v netstat >/dev/null 2>&1; then
-        output="$(netstat -t -n 2>/dev/null || true)"
+        # netstat -t -n output (Linux): Proto Recv-Q Send-Q Local-Address Foreign-Address State
+        # Filter to ESTABLISHED, then take the foreign address:port (5th field).
+        peer_ports="$(netstat -t -n 2>/dev/null | awk '$NF=="ESTABLISHED" {print $5}' || true)"
     else
         status_line warn "$label" "ss/netstat unavailable"
         return
     fi
 
-    if printf '%s\n' "$output" | grep -Eq ':(30004|64004)([[:space:]]|$)'; then
+    if printf '%s\n' "$peer_ports" | grep -Eq ':(30004|64004)$'; then
         status_line ok "$label" "connected"
     else
         status_line warn "$label" "no connection found yet"

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -563,10 +563,16 @@ claim_registration_status_line() {
                 STATUS_CLAIM_VERSION="$version"
                 STATUS_OWNER_PRESENT="$owner_present"
                 write_version_file "$version"
+                # Claim-secret version is internal bookkeeping; exposed
+                # via --json (.claim.version) and the local mirror file
+                # ($IPATH/feeder-claim-secret.version) for tooling.
+                # Omitting it from the human line keeps the output
+                # readable — a `v1`-vs-`vN` number tells operators
+                # nothing actionable.
                 if [[ "$owner_present" == "true" ]]; then
-                    status_line ok "Website claim" "registered and claimed (v$version)"
+                    status_line ok "Website claim" "registered and claimed"
                 else
-                    status_line ok "Website claim" "registered, not yet claimed (v$version)"
+                    status_line ok "Website claim" "registered, not yet claimed"
                 fi
                 if [[ -n "$reset_until" && "$reset_until" != "null" ]]; then
                     status_line warn "Claim reset" "locked until $reset_until"

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -21,12 +21,17 @@ STATUS_CHECKS_FILE=''
 STATUS_FAIL_COUNT=0
 STATUS_WARN_COUNT=0
 STATUS_FEEDER_UUID=''
+STATUS_RECEIVER_INPUT_IP=''
+STATUS_RECEIVER_INPUT_PORT=''
+STATUS_RECEIVER_INPUT_STATE=''
+STATUS_RECEIVER_ACTIVITY_STATE=''
+STATUS_RECEIVER_ACTIVITY_BYTES=''
 STATUS_CLAIM_REGISTERED=''
 STATUS_CLAIM_VERSION=''
 STATUS_OWNER_PRESENT=''
 STATUS_LAST_SEEN_AT=''
 STATUS_LAST_SEEN_AGE_SECONDS=''
-STATUS_WEBSITE_FEED_STATE=''
+STATUS_SERVER_RECEPTION_STATE=''
 STATUS_DIAGNOSTICS_TOGGLE=''
 STATUS_DIAGNOSTICS_LAST_PUSH_AGE_SECONDS=''
 
@@ -35,12 +40,17 @@ status_init() {
     STATUS_FAIL_COUNT=0
     STATUS_WARN_COUNT=0
     STATUS_FEEDER_UUID=''
+    STATUS_RECEIVER_INPUT_IP=''
+    STATUS_RECEIVER_INPUT_PORT=''
+    STATUS_RECEIVER_INPUT_STATE=''
+    STATUS_RECEIVER_ACTIVITY_STATE=''
+    STATUS_RECEIVER_ACTIVITY_BYTES=''
     STATUS_CLAIM_REGISTERED=''
     STATUS_CLAIM_VERSION=''
     STATUS_OWNER_PRESENT=''
     STATUS_LAST_SEEN_AT=''
     STATUS_LAST_SEEN_AGE_SECONDS=''
-    STATUS_WEBSITE_FEED_STATE=''
+    STATUS_SERVER_RECEPTION_STATE=''
     STATUS_DIAGNOSTICS_TOGGLE=''
     STATUS_DIAGNOSTICS_LAST_PUSH_AGE_SECONDS=''
 }
@@ -89,12 +99,15 @@ status_finish() {
         jq -s \
             --arg overall "$overall" \
             --arg feeder_uuid "$STATUS_FEEDER_UUID" \
+            --arg receiver_input_state "$STATUS_RECEIVER_INPUT_STATE" \
+            --arg receiver_activity_state "$STATUS_RECEIVER_ACTIVITY_STATE" \
+            --arg receiver_activity_bytes "$STATUS_RECEIVER_ACTIVITY_BYTES" \
             --arg claim_registered "$STATUS_CLAIM_REGISTERED" \
             --arg claim_version "$STATUS_CLAIM_VERSION" \
             --arg owner_present "$STATUS_OWNER_PRESENT" \
             --arg last_seen_at "$STATUS_LAST_SEEN_AT" \
             --arg last_seen_age_seconds "$STATUS_LAST_SEEN_AGE_SECONDS" \
-            --arg website_feed_state "$STATUS_WEBSITE_FEED_STATE" \
+            --arg reception_state "$STATUS_SERVER_RECEPTION_STATE" \
             --arg diagnostics_toggle "$STATUS_DIAGNOSTICS_TOGGLE" \
             --arg diagnostics_last_push_age "$STATUS_DIAGNOSTICS_LAST_PUSH_AGE_SECONDS" \
             '
@@ -106,16 +119,21 @@ status_finish() {
               else null end;
             def numberish: if . == "" then null else tonumber end;
             {
-              schema_version: 1,
+              schema_version: 2,
               overall: $overall,
               feeder_uuid: ($feeder_uuid | nullempty),
+              receiver: {
+                input_state: ($receiver_input_state | nullempty),
+                activity_state: ($receiver_activity_state | nullempty),
+                activity_bytes: ($receiver_activity_bytes | numberish)
+              },
               claim: {
                 registered: ($claim_registered | boolish),
                 version: ($claim_version | numberish),
                 owner_present: ($owner_present | boolish)
               },
               website: {
-                feed_state: ($website_feed_state | nullempty),
+                reception_state: ($reception_state | nullempty),
                 last_seen_at: ($last_seen_at | nullempty),
                 last_seen_age_seconds: ($last_seen_age_seconds | numberish)
               },
@@ -245,13 +263,31 @@ mlat_status_line() {
     esac
 }
 
+# _mlat_privacy_suffix — read the daemon's published privacy posture
+# from /run/airplanes-mlat/state and render the inline suffix appended
+# to a "running" MLAT line. Empty string when the state file is
+# unreadable or the value is missing; mlat_status_line already covers
+# the "daemon down" actionable signal so we don't want to double-warn
+# from a privacy probe.
+_mlat_privacy_suffix() {
+    local state_file mlat_private
+    state_file="$(root_path /run/airplanes-mlat/state)"
+    if ! mlat_private="$(airplanes_read_state "$state_file" mlat_private 2>/dev/null)"; then
+        return 0
+    fi
+    case "$mlat_private" in
+        true)  printf ' (name: private)' ;;
+        false) printf ' (name: public)' ;;
+    esac
+}
+
 _render_mlat_decision() {
     local active_state="$1" decision="$2" reason="$3"
     local label="MLAT service"
     case "$decision" in
         enabled)
             if [[ "$active_state" == "active" ]]; then
-                status_line ok "$label" "running"
+                status_line ok "$label" "running$(_mlat_privacy_suffix)"
             else
                 status_line warn "$label" "starting up ($active_state)"
             fi
@@ -288,25 +324,6 @@ _render_mlat_misconfig_reason() {
     esac
 }
 
-# Read the daemon's published privacy posture from /run/airplanes-mlat/state.
-# Daemon-state-file rule: never fall back to feed.env. If the state file
-# is unavailable (daemon down, partial install) we emit no privacy line
-# at all rather than re-deriving — mlat_status_line already covers the
-# "daemon down" actionable signal.
-mlat_privacy_status_line() {
-    local state_file mlat_private
-    state_file="$(root_path /run/airplanes-mlat/state)"
-    if ! mlat_private="$(airplanes_read_state "$state_file" mlat_private)"; then
-        return 0
-    fi
-    case "$mlat_private" in
-        true)  status_line ok "MLAT name privacy" "private (--privacy; name hidden on map)" ;;
-        false) status_line ok "MLAT name privacy" "public (name shown on map)" ;;
-        '')    return 0 ;;
-        *)     status_line warn "MLAT name privacy" "unknown value: $mlat_private" ;;
-    esac
-}
-
 receiver_status_line() {
     local input input_ip input_port
     input="$(feed_env_get INPUT || true)"
@@ -314,58 +331,142 @@ receiver_status_line() {
     input_ip="${input%:*}"
     input_port="${input##*:}"
 
+    STATUS_RECEIVER_INPUT_IP="$input_ip"
+    STATUS_RECEIVER_INPUT_PORT="$input_port"
+
     if [[ -z "$input_ip" || -z "$input_port" || "$input_ip" == "$input_port" ]]; then
+        STATUS_RECEIVER_INPUT_STATE='warn'
         status_line warn "Receiver input" "could not parse INPUT from $(feed_env_path)"
         return
     fi
     if ! command -v nc >/dev/null 2>&1; then
+        STATUS_RECEIVER_INPUT_STATE='warn'
         status_line warn "Receiver input" "nc unavailable; expected input is $input"
         return
     fi
     if timeout 3 nc -z "$input_ip" "$input_port" >/dev/null 2>&1; then
+        STATUS_RECEIVER_INPUT_STATE='ok'
         status_line ok "Receiver input" "connected at $input"
     else
+        STATUS_RECEIVER_INPUT_STATE='fail'
         status_line fail "Receiver input" "no data source reachable at $input"
     fi
 }
 
-airplanes_link_status_line() {
+# receiver_activity_status_line — protocol-agnostic byte sniff of the
+# INPUT socket. Answers "is the source emitting data right now?", not
+# "how many aircraft" (Beast is binary; INPUT is consumed as beast_in
+# in airplanes-feed.sh, so a BaseStation MSG parser would silently warn
+# on the default-feeder happy path).
+#
+# `head -c N` early-exits as soon as any bytes arrive (sub-second on a
+# healthy feeder) by closing the pipe and SIGPIPE'ing nc; `timeout`
+# caps the no-data case. Both produce a non-zero pipeline by design,
+# so the helper is wrapped in `set +o pipefail` and the rc is
+# deliberately not checked — $bytes is the only signal.
+receiver_activity_status_line() {
+    local label="Receiver activity"
+    local timeout_secs="${RECEIVER_ACTIVITY_TIMEOUT:-2}"
+    local sample_bytes="${RECEIVER_ACTIVITY_SAMPLE_BYTES:-256}"
+
+    if [[ "$STATUS_RECEIVER_INPUT_STATE" == "fail" ]]; then
+        # Connection-level failure is already reported on the line above;
+        # an activity check on an unreachable socket has nothing to add.
+        return
+    fi
+    if [[ -z "${STATUS_RECEIVER_INPUT_IP:-}" || -z "${STATUS_RECEIVER_INPUT_PORT:-}" ]]; then
+        STATUS_RECEIVER_ACTIVITY_STATE='warn'
+        status_line warn "$label" "INPUT not resolved"
+        return
+    fi
+    if ! command -v nc >/dev/null 2>&1; then
+        STATUS_RECEIVER_ACTIVITY_STATE='warn'
+        status_line warn "$label" "nc unavailable"
+        return
+    fi
+
+    local bytes pipefail_was_set=0
+    if [[ -o pipefail ]]; then pipefail_was_set=1; fi
+    set +o pipefail
+    bytes="$(timeout "$timeout_secs" nc "$STATUS_RECEIVER_INPUT_IP" "$STATUS_RECEIVER_INPUT_PORT" 2>/dev/null \
+        | head -c "$sample_bytes" \
+        | wc -c \
+        | tr -d ' ')"
+    if (( pipefail_was_set )); then set -o pipefail; fi
+    : "${bytes:=0}"
+
+    STATUS_RECEIVER_ACTIVITY_BYTES="$bytes"
+    if (( bytes > 0 )); then
+        STATUS_RECEIVER_ACTIVITY_STATE='ok'
+        status_line ok "$label" "data flowing (${bytes}b in ${timeout_secs}s sample)"
+    else
+        STATUS_RECEIVER_ACTIVITY_STATE='warn'
+        status_line warn "$label" "no data (last ${timeout_secs}s)"
+    fi
+}
+
+# adsb_uplink_status_line — checks for an established outbound TCP
+# socket to the ADS-B aggregator ports. TARGET in airplanes-feed.sh
+# binds to feed.airplanes.live:30004 with failover to
+# feed2.airplanes.live:64004; either established socket means the feed
+# binary has wired its uplink. MLAT (:31090) is intentionally excluded
+# here — the MLAT service line already speaks for that path; a MLAT-only
+# connection used to flip this check to ok and hid an ADS-B-down state.
+adsb_uplink_status_line() {
+    local label="ADS-B uplink"
     local output
     if command -v ss >/dev/null 2>&1; then
         output="$(ss -tn state established 2>/dev/null || true)"
     elif command -v netstat >/dev/null 2>&1; then
         output="$(netstat -t -n 2>/dev/null || true)"
     else
-        status_line warn "Airplanes.live link" "ss/netstat unavailable"
+        status_line warn "$label" "ss/netstat unavailable"
         return
     fi
 
-    if printf '%s\n' "$output" | grep -Eq ':(30004|31090)([[:space:]]|$)'; then
-        status_line ok "Airplanes.live link" "connected"
+    if printf '%s\n' "$output" | grep -Eq ':(30004|64004)([[:space:]]|$)'; then
+        status_line ok "$label" "connected"
     else
-        status_line warn "Airplanes.live link" "no connection found yet"
+        status_line warn "$label" "no connection found yet"
     fi
 }
 
-website_feed_status_line() {
+# server_reception_status_line — renders the server-side data-reception
+# signal from STATUS_LAST_SEEN_AT / STATUS_LAST_SEEN_AGE_SECONDS, which
+# claim_registration_status_line populates from POST /api/feeders/status.
+#
+# Tier thresholds reflect the aether → Redis snapshot → feeder_sync cron
+# pipeline that powers Feeder.last_seen on the website side
+# (FEEDER_SYNC_REDIS_URL cron runs every 5 min — see the website's
+# project settings). Healthy feeders therefore see last_seen_age in the
+# 0–~5 min range; the ok ceiling absorbs one cron interval plus slack:
+#
+#   ≤ 480 s   (8 min)  → ok    currently receiving
+#   480-1200 s (≤20m)  → warn  lagging
+#   > 1200 s            → fail  not receiving
+server_reception_status_line() {
+    local label="Server reception"
     local age_text
     if [[ -z "$STATUS_LAST_SEEN_AT" ]]; then
-        STATUS_WEBSITE_FEED_STATE='not_seen'
-        status_line warn "Website feed" "not seen yet"
+        STATUS_SERVER_RECEPTION_STATE='not_seen'
+        status_line warn "$label" "not seen yet (server confirms reception ~5–8 min after first connect)"
         return
     fi
     if [[ "$STATUS_LAST_SEEN_AGE_SECONDS" =~ ^[0-9]+$ ]]; then
         age_text="$(human_duration_ago "$STATUS_LAST_SEEN_AGE_SECONDS")"
-        if (( STATUS_LAST_SEEN_AGE_SECONDS <= 900 )); then
-            STATUS_WEBSITE_FEED_STATE='recent'
-            status_line ok "Website feed" "last data seen $age_text"
+        if (( STATUS_LAST_SEEN_AGE_SECONDS <= 480 )); then
+            STATUS_SERVER_RECEPTION_STATE='recent'
+            status_line ok "$label" "currently receiving (last data seen $age_text)"
+        elif (( STATUS_LAST_SEEN_AGE_SECONDS <= 1200 )); then
+            STATUS_SERVER_RECEPTION_STATE='lagging'
+            status_line warn "$label" "lagging (last data seen $age_text)"
         else
-            STATUS_WEBSITE_FEED_STATE='stale'
-            status_line warn "Website feed" "last data seen $age_text"
+            STATUS_SERVER_RECEPTION_STATE='stale'
+            status_line fail "$label" "not receiving (last data seen $age_text)"
         fi
     else
-        STATUS_WEBSITE_FEED_STATE='unknown'
-        status_line warn "Website feed" "last data time unavailable"
+        STATUS_SERVER_RECEPTION_STATE='unknown'
+        status_line warn "$label" "last data time unavailable"
     fi
 }
 
@@ -444,7 +545,7 @@ claim_registration_status_line() {
                     last_seen_age="$(parse_field_from "$response_file" '.last_seen_age_seconds')"
                     STATUS_LAST_SEEN_AT="$last_seen_at"
                     STATUS_LAST_SEEN_AGE_SECONDS="$last_seen_age"
-                    website_feed_status_line
+                    server_reception_status_line
                 fi
             else
                 status_line warn "Website claim" "registered, but local secret did not authenticate"
@@ -574,12 +675,16 @@ feed_status() {
         echo "airplanes.live feed check"
         echo
     fi
-    service_status_line airplanes-feed "Feed service"
-    mlat_status_line
-    mlat_privacy_status_line
+    # Order models the ADS-B data path top-to-bottom: source → mover →
+    # outbound socket, then identity (gates the server-side ack query),
+    # then the server-side reception ack, then MLAT (parallel feed) and
+    # diagnostics (telemetry side-channel) below.
     receiver_status_line
-    airplanes_link_status_line
+    receiver_activity_status_line
+    service_status_line airplanes-feed "Feed service"
+    adsb_uplink_status_line
     claim_registration_status_line
+    mlat_status_line
     diagnostics_status_line
     status_finish
 }

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -34,13 +34,23 @@ case "$*" in
 esac
 exit 0
 STUB
+    # nc serves two callers in status.sh: `nc -z <ip> <port>` for the
+    # receiver connectivity probe (exit 0 = reachable), and bare
+    # `nc <ip> <port>` for the receiver-activity byte sniff (must emit
+    # some bytes so the data-flowing branch is exercised).
     cat > "$STUB_BIN_DIR/nc" <<'STUB'
 #!/usr/bin/env bash
+if [[ "$1" == "-z" ]]; then
+    exit 0
+fi
+printf 'beast-bytes-fixture'
 exit 0
 STUB
+    # ADS-B uplink check greps for :30004 (primary) or :64004 (failover);
+    # default-healthy fixture emits an established socket to :30004.
     cat > "$STUB_BIN_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
-printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090 \n'
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004\n'
 exit 0
 STUB
     chmod +x "$STUB_BIN_DIR/systemctl" "$STUB_BIN_DIR/nc" "$STUB_BIN_DIR/ss"
@@ -252,7 +262,8 @@ PY
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Website claim" ]]
     [[ "$output" =~ "registered and claimed (v3)" ]]
-    [[ "$output" =~ "Website feed" ]]
+    [[ "$output" =~ "Server reception" ]]
+    [[ "$output" =~ "currently receiving" ]]
     [[ "$output" =~ "last data seen 1m ago" ]]
     [[ "$output" =~ "Result: feeding looks healthy" ]]
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")" = "3" ]
@@ -292,10 +303,11 @@ EOF
     run "$SCRIPT" status --json --root "$ROOT_DIR" --website-url "$(mock_url)"
 
     [ "$status" -eq 0 ]
-    [ "$(jq -r '.schema_version' <<< "$output")" = "1" ]
+    [ "$(jq -r '.schema_version' <<< "$output")" = "2" ]
     [ "$(jq -r '.claim.version' <<< "$output")" = "3" ]
-    [ "$(jq -r '.website.feed_state' <<< "$output")" = "recent" ]
+    [ "$(jq -r '.website.reception_state' <<< "$output")" = "recent" ]
     [ "$(jq -r '.website.last_seen_age_seconds' <<< "$output")" = "90" ]
+    [ "$(jq -r '.receiver | type' <<< "$output")" = "object" ]
     [[ ! "$output" =~ "ABCDEFGHIJKLMNOP" ]]
     [[ ! "$output" =~ "ABCD-EFGH-IJKL-MNOP" ]]
 }

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -46,10 +46,13 @@ fi
 printf 'beast-bytes-fixture'
 exit 0
 STUB
-    # ADS-B uplink check greps for :30004 (primary) or :64004 (failover);
-    # default-healthy fixture emits an established socket to :30004.
+    # ADS-B uplink check parses ss's last column (peer address:port) and
+    # accepts :30004 (primary) or :64004 (failover); default-healthy
+    # fixture emits an established socket to :30004 with the header row
+    # the awk parser expects to skip.
     cat > "$STUB_BIN_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
+printf 'State Recv-Q Send-Q Local-Address:Port Peer-Address:Port\n'
 printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004\n'
 exit 0
 STUB

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -264,7 +264,11 @@ PY
 
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Website claim" ]]
-    [[ "$output" =~ "registered and claimed (v3)" ]]
+    [[ "$output" =~ "registered and claimed" ]]
+    # Version is internal bookkeeping — surfaced via --json
+    # (.claim.version, exercised in the json test below) and the local
+    # mirror file. Not in the human line.
+    [[ ! "$output" =~ "(v3)" ]]
     [[ "$output" =~ "Server reception" ]]
     [[ "$output" =~ "currently receiving" ]]
     [[ "$output" =~ "last data seen 1m ago" ]]

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -989,7 +989,10 @@ setup_claim_state() {
     STATUS_OUTPUT_JSON=0
     run claim_registration_status_line
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'registered and claimed (v5)'* ]]
+    [[ "$output" == *'registered and claimed'* ]]
+    # Version intentionally omitted from human output — it's internal
+    # bookkeeping; the JSON path (.claim.version) keeps it for tooling.
+    [[ "$output" != *'(v'* ]]
 }
 
 @test "claim_registration_status_line: 200 + registered:true + version + owner_present:false → ok 'not yet claimed'" {
@@ -999,7 +1002,8 @@ setup_claim_state() {
     STATUS_OUTPUT_JSON=0
     run claim_registration_status_line
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'not yet claimed (v5)'* ]]
+    [[ "$output" == *'not yet claimed'* ]]
+    [[ "$output" != *'(v'* ]]
 }
 
 @test "claim_registration_status_line: 200 + registered:true + missing version → warn 'did not authenticate'" {
@@ -1141,5 +1145,5 @@ stop_python_mock() {
     run claim_registration_status_line
     stop_python_mock
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'registered and claimed (v5)'* ]]
+    [[ "$output" == *'registered and claimed'* ]]
 }

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -824,10 +824,22 @@ STUB
     [[ "$output" == *'no connection'* ]]
 }
 
+# Helper: hide ss from `command -v` so the netstat fallback branch is
+# reachable in tests. Necessary because CI runners (and most dev boxes)
+# have /usr/bin/ss preinstalled — rm'ing the STUB_DIR/ss stub isn't
+# enough; the system ss is still on PATH. Defines a `command` function
+# in the current shell that BATS `run` inherits into its subshell.
+_hide_ss_from_command_v() {
+    command() {
+        if [[ "$1" = "-v" && "$2" = "ss" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+}
+
 @test "adsb_uplink_status_line: netstat TIME_WAIT to :30004 → warn (only ESTABLISHED counts)" {
-    # Scope PATH to STUB_DIR only — otherwise the system ss is still on
-    # PATH and command -v ss matches first, skipping the netstat branch.
-    rm -f "$STUB_DIR/ss"
+    _hide_ss_from_command_v
     cat > "$STUB_DIR/netstat" <<'STUB'
 #!/usr/bin/env bash
 printf 'Active Internet connections (w/o servers)\n'
@@ -836,18 +848,15 @@ printf 'tcp 0 0 127.0.0.1:43530 78.46.234.18:30004 TIME_WAIT\n'
 exit 0
 STUB
     chmod +x "$STUB_DIR/netstat"
-    # Mirror minimal posix utilities the function needs (printf, grep,
-    # awk) from /usr/bin if STUB_DIR lacks them — but they're builtins
-    # or core utils available in BATS's shell already.
     status_init
     STATUS_OUTPUT_JSON=0
-    output="$(PATH="$STUB_DIR:/usr/bin:/bin" adsb_uplink_status_line)"
+    run adsb_uplink_status_line
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'no connection'* ]]
 }
 
 @test "adsb_uplink_status_line: netstat ESTABLISHED to :30004 → ok" {
-    rm -f "$STUB_DIR/ss"
+    _hide_ss_from_command_v
     cat > "$STUB_DIR/netstat" <<'STUB'
 #!/usr/bin/env bash
 printf 'Active Internet connections (w/o servers)\n'
@@ -858,7 +867,7 @@ STUB
     chmod +x "$STUB_DIR/netstat"
     status_init
     STATUS_OUTPUT_JSON=0
-    output="$(PATH="$STUB_DIR:/usr/bin:/bin" adsb_uplink_status_line)"
+    run adsb_uplink_status_line
     [[ "$output" == *'OK'* ]]
     [[ "$output" == *'connected'* ]]
 }

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -515,6 +515,24 @@ STUB
     [[ "$output" != *'(name:'* ]]
 }
 
+@test "mlat_status_line: enabled + active + unknown mlat_private value → 'running' + warn 'unknown value' (forward-compat)" {
+    # An unrecognised mlat_private token (future schema) must not be
+    # silently swallowed when the privacy suffix is folded into the
+    # MLAT service line. _mlat_privacy_unknown_value surfaces it as a
+    # separate CHECK so a forward-compat regression stays visible.
+    write_mlat_state enabled ok futureschema
+    stub_systemctl_active_state active
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run mlat_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'running'* ]]
+    [[ "$output" != *'running (name:'* ]]
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'MLAT name privacy'* ]]
+    [[ "$output" == *'unknown value: futureschema'* ]]
+}
+
 # --- receiver_status_line ---
 
 @test "receiver_status_line: default INPUT (no env), nc fails → fail" {
@@ -639,6 +657,19 @@ STUB
     [ -z "$output" ]
 }
 
+@test "receiver_activity_status_line: STATUS_RECEIVER_INPUT_STATE=warn → skipped (malformed INPUT etc.)" {
+    # `warn` covers malformed INPUT or nc-missing on the input line; the
+    # parsed IP/PORT may be garbage. Running the activity probe against
+    # garbage produces a misleading second "no data" line — skip instead.
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='warn'
+    STATUS_RECEIVER_INPUT_IP='badvalue'
+    STATUS_RECEIVER_INPUT_PORT='badvalue'
+    run receiver_activity_status_line
+    [ -z "$output" ]
+}
+
 @test "receiver_activity_status_line: INPUT IP/PORT unresolved → warn (defensive)" {
     status_init
     STATUS_OUTPUT_JSON=0
@@ -704,9 +735,10 @@ STUB
 
 # --- adsb_uplink_status_line ---
 
-@test "adsb_uplink_status_line: ss output shows :30004 → ok" {
+@test "adsb_uplink_status_line: ss output shows :30004 in peer column → ok" {
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
+printf 'State Recv-Q Send-Q Local-Address:Port Peer-Address:Port\n'
 printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004\n'
 exit 0
 STUB
@@ -719,9 +751,10 @@ STUB
     [[ "$output" == *'connected'* ]]
 }
 
-@test "adsb_uplink_status_line: ss output shows :64004 (failover) → ok" {
+@test "adsb_uplink_status_line: ss output shows :64004 (failover) in peer column → ok" {
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
+printf 'State Recv-Q Send-Q Local-Address:Port Peer-Address:Port\n'
 printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.19:64004\n'
 exit 0
 STUB
@@ -739,6 +772,7 @@ STUB
     # ADS-B-down state — the narrowed grep prevents that regression.
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
+printf 'State Recv-Q Send-Q Local-Address:Port Peer-Address:Port\n'
 printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090\n'
 exit 0
 STUB
@@ -770,6 +804,63 @@ STUB
     output="$(PATH="$ROOT_DIR/empty" adsb_uplink_status_line)"
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'ss/netstat unavailable'* ]]
+}
+
+@test "adsb_uplink_status_line: local listener on :30004 (peer port is different) → warn" {
+    # A local process listening on :30004 puts that port in the LOCAL
+    # column, peer port is unrelated. Old grep matched anywhere on the
+    # line and false-positived; the peer-column parser must not.
+    cat > "$STUB_DIR/ss" <<'STUB'
+#!/usr/bin/env bash
+printf 'State Recv-Q Send-Q Local-Address:Port Peer-Address:Port\n'
+printf 'ESTAB 0 0 127.0.0.1:30004 1.2.3.4:55555\n'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/ss"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run adsb_uplink_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'no connection'* ]]
+}
+
+@test "adsb_uplink_status_line: netstat TIME_WAIT to :30004 → warn (only ESTABLISHED counts)" {
+    # Scope PATH to STUB_DIR only — otherwise the system ss is still on
+    # PATH and command -v ss matches first, skipping the netstat branch.
+    rm -f "$STUB_DIR/ss"
+    cat > "$STUB_DIR/netstat" <<'STUB'
+#!/usr/bin/env bash
+printf 'Active Internet connections (w/o servers)\n'
+printf 'Proto Recv-Q Send-Q Local-Address Foreign-Address State\n'
+printf 'tcp 0 0 127.0.0.1:43530 78.46.234.18:30004 TIME_WAIT\n'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/netstat"
+    # Mirror minimal posix utilities the function needs (printf, grep,
+    # awk) from /usr/bin if STUB_DIR lacks them — but they're builtins
+    # or core utils available in BATS's shell already.
+    status_init
+    STATUS_OUTPUT_JSON=0
+    output="$(PATH="$STUB_DIR:/usr/bin:/bin" adsb_uplink_status_line)"
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'no connection'* ]]
+}
+
+@test "adsb_uplink_status_line: netstat ESTABLISHED to :30004 → ok" {
+    rm -f "$STUB_DIR/ss"
+    cat > "$STUB_DIR/netstat" <<'STUB'
+#!/usr/bin/env bash
+printf 'Active Internet connections (w/o servers)\n'
+printf 'Proto Recv-Q Send-Q Local-Address Foreign-Address State\n'
+printf 'tcp 0 0 127.0.0.1:43530 78.46.234.18:30004 ESTABLISHED\n'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/netstat"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    output="$(PATH="$STUB_DIR:/usr/bin:/bin" adsb_uplink_status_line)"
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'connected'* ]]
 }
 
 # --- server_reception_status_line ---

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -451,58 +451,68 @@ STUB
     [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
 }
 
-# --- mlat_privacy_status_line: state-file-driven privacy posture ---
+# --- mlat_status_line: privacy suffix folded into the running line ---
+#
+# Privacy was previously emitted on its own "MLAT name privacy" line by
+# mlat_privacy_status_line. That standalone line was folded into
+# mlat_status_line when decision=enabled and active_state=active, so the
+# data-flow output stays compact (one line per concern).
 
-@test "mlat_privacy_status_line: mlat_private=true → OK 'private' line" {
+@test "mlat_status_line: enabled + active + mlat_private=true → 'running (name: private)'" {
     write_mlat_state enabled ok true
+    stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
-    run mlat_privacy_status_line
-    [ "$status" -eq 0 ]
+    run mlat_status_line
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'MLAT name privacy'* ]]
-    [[ "$output" == *'private'* ]]
-    [[ "$output" == *'name hidden'* ]]
+    [[ "$output" == *'running (name: private)'* ]]
 }
 
-@test "mlat_privacy_status_line: mlat_private=false → OK 'public' line" {
+@test "mlat_status_line: enabled + active + mlat_private=false → 'running (name: public)'" {
     write_mlat_state enabled ok false
+    stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
-    run mlat_privacy_status_line
-    [ "$status" -eq 0 ]
+    run mlat_status_line
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'MLAT name privacy'* ]]
-    [[ "$output" == *'public'* ]]
-    [[ "$output" == *'name shown'* ]]
+    [[ "$output" == *'running (name: public)'* ]]
 }
 
-@test "mlat_privacy_status_line: state file absent → no line emitted (silent skip)" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+@test "mlat_status_line: enabled + active + mlat_private missing → bare 'running' (no suffix)" {
+    write_mlat_state enabled ok ''  # no mlat_private key
+    stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
-    run mlat_privacy_status_line
-    [ "$status" -eq 0 ]
-    [ -z "$output" ]
+    run mlat_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'running'* ]]
+    [[ "$output" != *'(name:'* ]]
 }
 
-@test "mlat_privacy_status_line: state file lacks mlat_private key → silent skip" {
-    write_mlat_state enabled ok ''  # no mlat_private key written
+@test "mlat_status_line: disabled + mlat_private=true → 'disabled by config' (no privacy suffix when disabled)" {
+    # Privacy is irrelevant when MLAT is disabled — the daemon publishes
+    # nothing — so the suffix must not appear.
+    write_mlat_state disabled mlat_enabled_false true
+    stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
-    run mlat_privacy_status_line
-    [ "$status" -eq 0 ]
-    [ -z "$output" ]
+    run mlat_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
+    [[ "$output" != *'(name:'* ]]
 }
 
-@test "mlat_privacy_status_line: unknown value → warn (forward-compat)" {
-    write_mlat_state enabled ok futureschema
+@test "mlat_status_line: enabled + activating + mlat_private=true → 'starting up' (no suffix mid-transition)" {
+    # Suffix is only relevant when the daemon is fully running. During
+    # activating/reloading we surface the transitional state instead.
+    write_mlat_state enabled ok true
+    stub_systemctl_active_state activating
     status_init
     STATUS_OUTPUT_JSON=0
-    run mlat_privacy_status_line
+    run mlat_status_line
     [[ "$output" == *'CHECK'* ]]
-    [[ "$output" == *'unknown value'* ]]
-    [[ "$output" == *'futureschema'* ]]
+    [[ "$output" == *'starting up (activating)'* ]]
+    [[ "$output" != *'(name:'* ]]
 }
 
 # --- receiver_status_line ---
@@ -559,9 +569,142 @@ STUB
     [[ "$output" == *'no data source reachable'* ]]
 }
 
-# --- airplanes_link_status_line ---
+@test "receiver_status_line: sets STATUS_RECEIVER_INPUT_STATE for the activity check to consume" {
+    : > "$ROOT_DIR/etc/airplanes/feed.env"
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    receiver_status_line >/dev/null
+    [ "$STATUS_RECEIVER_INPUT_STATE" = "ok" ]
+    [ "$STATUS_RECEIVER_INPUT_IP" = "127.0.0.1" ]
+    [ "$STATUS_RECEIVER_INPUT_PORT" = "30005" ]
+}
 
-@test "airplanes_link_status_line: ss output shows :30004 → ok" {
+# --- receiver_activity_status_line ---
+#
+# Protocol-agnostic byte sniff. Any bytes within the sample window → ok.
+# `head -c` early-exit (SIGPIPE on nc) and `timeout` rc=124 both produce
+# non-zero pipelines by design; the function wraps in `set +o pipefail`
+# and ignores the rc — $bytes is the only signal.
+
+@test "receiver_activity_status_line: nc emits bytes → ok 'data flowing'" {
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+# Emit some Beast-shaped bytes (binary; non-printable is fine).
+printf '\x1a\x32\xa1\xb2\xc3\xd4\xe5\xf6'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='ok'
+    STATUS_RECEIVER_INPUT_IP='127.0.0.1'
+    STATUS_RECEIVER_INPUT_PORT='30005'
+    run receiver_activity_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'Receiver activity'* ]]
+    [[ "$output" == *'data flowing'* ]]
+    [[ "$output" == *'8b in'* ]]
+}
+
+@test "receiver_activity_status_line: nc exits with no output → warn 'no data'" {
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='ok'
+    STATUS_RECEIVER_INPUT_IP='127.0.0.1'
+    STATUS_RECEIVER_INPUT_PORT='30005'
+    run receiver_activity_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'no data'* ]]
+}
+
+@test "receiver_activity_status_line: STATUS_RECEIVER_INPUT_STATE=fail → skipped (no line emitted)" {
+    # Connection-level failure is already on the line above; the activity
+    # check has nothing to add and must not emit a redundant line.
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='fail'
+    STATUS_RECEIVER_INPUT_IP='127.0.0.1'
+    STATUS_RECEIVER_INPUT_PORT='30005'
+    run receiver_activity_status_line
+    [ -z "$output" ]
+}
+
+@test "receiver_activity_status_line: INPUT IP/PORT unresolved → warn (defensive)" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='ok'
+    STATUS_RECEIVER_INPUT_IP=''
+    STATUS_RECEIVER_INPUT_PORT=''
+    run receiver_activity_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'INPUT not resolved'* ]]
+}
+
+@test "receiver_activity_status_line: nc unavailable → warn 'nc unavailable'" {
+    rm -f "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='ok'
+    STATUS_RECEIVER_INPUT_IP='127.0.0.1'
+    STATUS_RECEIVER_INPUT_PORT='30005'
+    output="$(PATH="$STUB_DIR" receiver_activity_status_line)"
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'nc unavailable'* ]]
+}
+
+@test "receiver_activity_status_line: caller's pipefail state is preserved across the sample" {
+    # The sample uses `timeout | nc | head | wc` which routinely fails
+    # under pipefail (timeout exits 124, head SIGPIPEs nc); the function
+    # toggles pipefail off internally and must restore the caller's
+    # original setting. Verifying this protects the production path where
+    # apl-feed.sh sets `set -euo pipefail`.
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+printf 'x'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='ok'
+    STATUS_RECEIVER_INPUT_IP='127.0.0.1'
+    STATUS_RECEIVER_INPUT_PORT='30005'
+    set -o pipefail
+    receiver_activity_status_line >/dev/null
+    [[ -o pipefail ]]
+    set +o pipefail
+}
+
+@test "receiver_activity_status_line: pipefail-off caller stays pipefail-off" {
+    cat > "$STUB_DIR/nc" <<'STUB'
+#!/usr/bin/env bash
+printf 'x'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/nc"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_RECEIVER_INPUT_STATE='ok'
+    STATUS_RECEIVER_INPUT_IP='127.0.0.1'
+    STATUS_RECEIVER_INPUT_PORT='30005'
+    set +o pipefail
+    receiver_activity_status_line >/dev/null
+    ! [[ -o pipefail ]]
+}
+
+# --- adsb_uplink_status_line ---
+
+@test "adsb_uplink_status_line: ss output shows :30004 → ok" {
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
 printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:30004\n'
@@ -570,12 +713,30 @@ STUB
     chmod +x "$STUB_DIR/ss"
     status_init
     STATUS_OUTPUT_JSON=0
-    run airplanes_link_status_line
+    run adsb_uplink_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'ADS-B uplink'* ]]
+    [[ "$output" == *'connected'* ]]
+}
+
+@test "adsb_uplink_status_line: ss output shows :64004 (failover) → ok" {
+    cat > "$STUB_DIR/ss" <<'STUB'
+#!/usr/bin/env bash
+printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.19:64004\n'
+exit 0
+STUB
+    chmod +x "$STUB_DIR/ss"
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run adsb_uplink_status_line
     [[ "$output" == *'OK'* ]]
     [[ "$output" == *'connected'* ]]
 }
 
-@test "airplanes_link_status_line: ss output shows :31090 → ok (mlat)" {
+@test "adsb_uplink_status_line: ss output shows ONLY :31090 (mlat) → warn (no ADS-B)" {
+    # :31090 is the MLAT uplink; this check is ADS-B only. A MLAT-only
+    # connection used to wrongly flip this check to ok and masked an
+    # ADS-B-down state — the narrowed grep prevents that regression.
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
 printf 'ESTAB 0 0 127.0.0.1:43530 78.46.234.18:31090\n'
@@ -584,11 +745,12 @@ STUB
     chmod +x "$STUB_DIR/ss"
     status_init
     STATUS_OUTPUT_JSON=0
-    run airplanes_link_status_line
-    [[ "$output" == *'OK'* ]]
+    run adsb_uplink_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'no connection'* ]]
 }
 
-@test "airplanes_link_status_line: ss output empty → warn" {
+@test "adsb_uplink_status_line: ss output empty → warn" {
     cat > "$STUB_DIR/ss" <<'STUB'
 #!/usr/bin/env bash
 exit 0
@@ -596,58 +758,86 @@ STUB
     chmod +x "$STUB_DIR/ss"
     status_init
     STATUS_OUTPUT_JSON=0
-    run airplanes_link_status_line
+    run adsb_uplink_status_line
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'no connection'* ]]
 }
 
-@test "airplanes_link_status_line: neither ss nor netstat available → warn" {
+@test "adsb_uplink_status_line: neither ss nor netstat available → warn" {
     rm -f "$STUB_DIR/ss"
     status_init
     STATUS_OUTPUT_JSON=0
-    output="$(PATH="$ROOT_DIR/empty" airplanes_link_status_line)"
+    output="$(PATH="$ROOT_DIR/empty" adsb_uplink_status_line)"
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'ss/netstat unavailable'* ]]
 }
 
-# --- website_feed_status_line ---
+# --- server_reception_status_line ---
+#
+# Tier thresholds reflect the 5-min feeder_sync cron on the website
+# side: ok ≤ 480 s, warn ≤ 1200 s, fail > 1200 s.
 
-@test "website_feed_status_line: STATUS_LAST_SEEN_AT empty → not_seen warn" {
+@test "server_reception_status_line: STATUS_LAST_SEEN_AT empty → not_seen warn with first-connect hint" {
     status_init
     STATUS_OUTPUT_JSON=0
     STATUS_LAST_SEEN_AT=''
-    run website_feed_status_line
+    run server_reception_status_line
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'not seen yet'* ]]
+    [[ "$output" == *'first connect'* ]]
 }
 
-@test "website_feed_status_line: age 900 (boundary inclusive) → ok 'recent'" {
+@test "server_reception_status_line: age 480 (ok boundary inclusive) → ok 'currently receiving'" {
     status_init
     STATUS_OUTPUT_JSON=0
     STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
-    STATUS_LAST_SEEN_AGE_SECONDS='900'
-    STATUS_WEBSITE_FEED_STATE=''
-    run website_feed_status_line
+    STATUS_LAST_SEEN_AGE_SECONDS='480'
+    STATUS_SERVER_RECEPTION_STATE=''
+    run server_reception_status_line
     [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'currently receiving'* ]]
 }
 
-@test "website_feed_status_line: age 901 (boundary exclusive) → warn 'stale'" {
+@test "server_reception_status_line: age 481 → warn 'lagging'" {
     status_init
     STATUS_OUTPUT_JSON=0
     STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
-    STATUS_LAST_SEEN_AGE_SECONDS='901'
-    STATUS_WEBSITE_FEED_STATE=''
-    run website_feed_status_line
+    STATUS_LAST_SEEN_AGE_SECONDS='481'
+    STATUS_SERVER_RECEPTION_STATE=''
+    run server_reception_status_line
     [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'lagging'* ]]
 }
 
-@test "website_feed_status_line: non-numeric age → warn 'unavailable'" {
+@test "server_reception_status_line: age 1200 (warn boundary inclusive) → warn 'lagging'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
+    STATUS_LAST_SEEN_AGE_SECONDS='1200'
+    STATUS_SERVER_RECEPTION_STATE=''
+    run server_reception_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'lagging'* ]]
+}
+
+@test "server_reception_status_line: age 1201 → fail 'not receiving'" {
+    status_init
+    STATUS_OUTPUT_JSON=0
+    STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
+    STATUS_LAST_SEEN_AGE_SECONDS='1201'
+    STATUS_SERVER_RECEPTION_STATE=''
+    run server_reception_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'not receiving'* ]]
+}
+
+@test "server_reception_status_line: non-numeric age → warn 'unavailable'" {
     status_init
     STATUS_OUTPUT_JSON=0
     STATUS_LAST_SEEN_AT='2026-04-28T00:00:00Z'
     STATUS_LAST_SEEN_AGE_SECONDS=''
-    STATUS_WEBSITE_FEED_STATE=''
-    run website_feed_status_line
+    STATUS_SERVER_RECEPTION_STATE=''
+    run server_reception_status_line
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'unavailable'* ]]
 }
@@ -732,17 +922,17 @@ setup_claim_state() {
     [[ "$output" == *'not registered'* ]]
 }
 
-@test "claim_registration_status_line: 200 with last_seen_at key absent → no website_feed line" {
+@test "claim_registration_status_line: 200 with last_seen_at key absent → no Server reception line" {
     # When the response omits last_seen_at entirely, json_has_key
-    # returns false and the website_feed line is skipped. (When the
+    # returns false and the server-reception line is skipped. (When the
     # key is present but null, the line IS emitted as warn 'not seen
-    # yet' — see status.sh:271-277.)
+    # yet'.)
     setup_claim_state 1
     stub_post_json 200 '{"registered":true,"version":5,"owner_present":true}'
     status_init
     STATUS_OUTPUT_JSON=0
     run claim_registration_status_line
-    [[ "$output" != *'Website feed'* ]]
+    [[ "$output" != *'Server reception'* ]]
 }
 
 @test "claim_registration_status_line: 200 with last_seen_at:null emits 'not seen yet' warn" {
@@ -751,7 +941,7 @@ setup_claim_state() {
     status_init
     STATUS_OUTPUT_JSON=0
     run claim_registration_status_line
-    [[ "$output" == *'Website feed'* ]]
+    [[ "$output" == *'Server reception'* ]]
     [[ "$output" == *'not seen yet'* ]]
 }
 


### PR DESCRIPTION
The status output now follows the actual data path so a reader can walk it top-to-bottom: receiver input → receiver activity → feed service → ADS-B uplink → identity → server reception → MLAT → diagnostics push.

A new `Receiver activity` line samples the receiver socket for ~2 seconds and reports whether bytes are actually arriving, so an unplugged antenna or silent decoder surfaces as a warning instead of hiding behind a port that still listens.

`Airplanes.live link` is renamed to `ADS-B uplink` and narrowed to ports 30004/64004 — the failover target was missing, and the old check accepted :31090, so a MLAT-only connection used to mask an ADS-B-down state. `Website feed` becomes `Server reception` with tier thresholds raised to match the 5-minute server-side sync (`ok` ≤ 8 min, `warn` ≤ 20 min, `fail` beyond) and a first-connect hint on the not-seen-yet case. MLAT name privacy is folded into the MLAT service line instead of taking its own line.

`apl-feed status --json` is bumped to `schema_version: 2`: `website.feed_state` → `website.reception_state`, plus a new `receiver` block carrying `input_state`, `activity_state`, and `activity_bytes`.
