### PR TITLE
feat(diagnostics): emit per-service state and reason on the wire

### DIFF
--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -59,23 +59,6 @@ source "$_COMMON_SH"
 # shellcheck source=apl-feed/http.sh
 source "$_HTTP_SH"
 
-# state-reader.sh lives in scripts/lib/ (production: lib/ next to this
-# script under /usr/local/share/airplanes/). Defensive: when the lib is
-# missing (mid-update or a partial install), service entries simply omit
-# ``state``/``reason`` and the server falls back to systemd-only
-# classification — same fail-soft posture as the rest of the script.
-for _state_reader in \
-    "$_INSTALL_DIR/lib/state-reader.sh" \
-    "$_INSTALL_DIR/../scripts/lib/state-reader.sh"; do
-    if [[ -r "$_state_reader" ]]; then
-        # shellcheck source=lib/state-reader.sh
-        source "$_state_reader"
-        break
-    fi
-done
-if ! declare -F airplanes_read_state >/dev/null 2>&1; then
-    airplanes_read_state() { return 1; }
-fi
 
 # common.sh unconditionally sets ROOT='/' on source. Reapply the override
 # after sourcing so callers can re-root the script's filesystem reads
@@ -373,17 +356,59 @@ get_service_version() {
     printf '%s' "$raw"
 }
 
+# _read_service_decision <state_file>
+#   Single-open read of the daemon-published state file. Echoes
+#   "<state>|<reason>" on success when BOTH keys are present and the
+#   schema_version line passes. Returns 1 (no stdout) on any read or
+#   validation failure.
+#
+# Single open matters: the state-writer renames a temp file atomically
+# into place, so two separate `airplanes_read_state` calls could pick
+# up `state` from the old file and `reason` from the new one, publishing
+# a mixed pair on the wire. Reading both keys from one open snapshot
+# of the file rules that out. The all-or-nothing return also handles a
+# schema-valid-but-truncated file (e.g. only `reason=` present) without
+# emitting an orphan field.
+#
+# Mirrors state-reader.sh's validation rules: schema_version=1 first
+# line, KEY=VALUE shape with [A-Za-z_][A-Za-z0-9_]* keys, no CR in
+# values. Locally re-implemented rather than calling the lib twice so
+# the read is provably single-open.
+_read_service_decision() {
+    local path="$1"
+    [[ -f "$path" && -r "$path" ]] || return 1
+    local first state='' reason=''
+    {
+        IFS= read -r first || return 1
+        [[ "$first" == "schema_version=1" ]] || return 1
+        local line key val
+        while IFS= read -r line; do
+            [[ "$line" == *=* ]] || continue
+            key="${line%%=*}"
+            val="${line#*=}"
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            case "$val" in *$'\r'*) return 1 ;; esac
+            case "$key" in
+                state)  state="$val" ;;
+                reason) reason="$val" ;;
+            esac
+        done
+    } < "$path"
+    [[ -n "$state" && -n "$reason" ]] || return 1
+    printf '%s|%s' "$state" "$reason"
+}
+
 # Build a single service object as JSON (or print "null" if the unit is
 # load_state=not-found / systemctl unavailable / probe failed).
 #
 # The optional second positional argument is the path to the daemon's
 # runtime state file (``/run/<service>/state``); when readable and
-# schema_version=1 valid, the daemon's published ``state`` / ``reason``
-# tokens are added to the JSON so the dashboard can distinguish
-# user-disabled from runtime hardware-missing without re-deriving
-# either predicate. State-file read failure is silent — the entry simply
-# omits the two fields and the server falls back to systemd-only
-# classification.
+# schema_version=1 valid AND both ``state`` and ``reason`` keys are
+# present, the daemon's published tokens are added to the JSON so the
+# dashboard can distinguish user-disabled from runtime hardware-missing
+# without re-deriving either predicate. Any read failure (missing file,
+# bad schema, orphan field) silently omits both — the server falls back
+# to systemd-only classification.
 build_service_json() {
     local name="$1"
     local state_file="${2:-}"
@@ -407,8 +432,11 @@ build_service_json() {
     version="$(get_service_version "$name" || true)"
     local state='' reason=''
     if [[ -n "$state_file" ]]; then
-        state="$(airplanes_read_state "$state_file" state 2>/dev/null || true)"
-        reason="$(airplanes_read_state "$state_file" reason 2>/dev/null || true)"
+        local pair
+        if pair="$(_read_service_decision "$state_file" 2>/dev/null)"; then
+            state="${pair%%|*}"
+            reason="${pair#*|}"
+        fi
     fi
     jq -nc \
         --arg name "$name" \

--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -59,6 +59,24 @@ source "$_COMMON_SH"
 # shellcheck source=apl-feed/http.sh
 source "$_HTTP_SH"
 
+# state-reader.sh lives in scripts/lib/ (production: lib/ next to this
+# script under /usr/local/share/airplanes/). Defensive: when the lib is
+# missing (mid-update or a partial install), service entries simply omit
+# ``state``/``reason`` and the server falls back to systemd-only
+# classification — same fail-soft posture as the rest of the script.
+for _state_reader in \
+    "$_INSTALL_DIR/lib/state-reader.sh" \
+    "$_INSTALL_DIR/../scripts/lib/state-reader.sh"; do
+    if [[ -r "$_state_reader" ]]; then
+        # shellcheck source=lib/state-reader.sh
+        source "$_state_reader"
+        break
+    fi
+done
+if ! declare -F airplanes_read_state >/dev/null 2>&1; then
+    airplanes_read_state() { return 1; }
+fi
+
 # common.sh unconditionally sets ROOT='/' on source. Reapply the override
 # after sourcing so callers can re-root the script's filesystem reads
 # (useful for tests / chroot smokes).
@@ -357,8 +375,18 @@ get_service_version() {
 
 # Build a single service object as JSON (or print "null" if the unit is
 # load_state=not-found / systemctl unavailable / probe failed).
+#
+# The optional second positional argument is the path to the daemon's
+# runtime state file (``/run/<service>/state``); when readable and
+# schema_version=1 valid, the daemon's published ``state`` / ``reason``
+# tokens are added to the JSON so the dashboard can distinguish
+# user-disabled from runtime hardware-missing without re-deriving
+# either predicate. State-file read failure is silent — the entry simply
+# omits the two fields and the server falls back to systemd-only
+# classification.
 build_service_json() {
     local name="$1"
+    local state_file="${2:-}"
     command -v systemctl >/dev/null 2>&1 || { printf 'null'; return; }
     local show_out
     show_out="$(timeout 3s systemctl show "$name" \
@@ -377,6 +405,11 @@ build_service_json() {
     [[ "$nrestarts" =~ ^[0-9]+$ ]] || nrestarts=0
     local version
     version="$(get_service_version "$name" || true)"
+    local state='' reason=''
+    if [[ -n "$state_file" ]]; then
+        state="$(airplanes_read_state "$state_file" state 2>/dev/null || true)"
+        reason="$(airplanes_read_state "$state_file" reason 2>/dev/null || true)"
+    fi
     jq -nc \
         --arg name "$name" \
         --arg load_state "${load_state:-}" \
@@ -385,13 +418,17 @@ build_service_json() {
         --arg sub_state "${sub_state:-}" \
         --argjson restart_count_total "$nrestarts" \
         --arg version "${version:-}" \
+        --arg state "${state:-}" \
+        --arg reason "${reason:-}" \
         '{name: $name,
           load_state: $load_state,
           unit_file_state: $unit_file_state,
           active_state: $active_state,
           sub_state: $sub_state,
           restart_count_total: $restart_count_total,
-          version: $version}
+          version: $version,
+          state: $state,
+          reason: $reason}
          | with_entries(select(.value != null and .value != ""))'
 }
 
@@ -605,22 +642,23 @@ main() {
         collect_network || true
 
         local svc_feed svc_mlat svc_readsb svc_dump978 svc_978
+        # airplanes-feed has no user-disable predicate today, so its state
+        # file would always say enabled/ok — no value in plumbing it.
+        # readsb has no state file at all.
         svc_feed="$(build_service_json airplanes-feed)"
-        svc_mlat="$(build_service_json airplanes-mlat)"
+        svc_mlat="$(build_service_json airplanes-mlat "$(root_path /run/airplanes-mlat/state)")"
         svc_readsb="$(build_service_json readsb)"
-        svc_dump978="$(build_service_json dump978-fa)"
+        svc_dump978="$(build_service_json dump978-fa "$(root_path /run/dump978-fa/state)")"
         # airplanes-978 is the readsb UAT instance — only relevant when
         # the user has actually configured UAT. Without this gate, every
-        # non-UAT feeder would report a "stopped" airplanes-978 unit
-        # because the image ships the unit file even when UAT is off
-        # (the unit self-disables at runtime). Gating here keeps the
-        # dashboard quiet for the common no-978-dongle case until the
-        # collector grows a per-service `configured` field.
+        # non-UAT feeder would report an idle airplanes-978 unit and add
+        # noise to the dashboard. Globally most users don't have a 978
+        # dongle so the chip stays hidden until they wire one up.
         local uat_input
         uat_input="$(feed_env_get UAT_INPUT 2>/dev/null || true)"
         svc_978='null'
         if [[ -n "$uat_input" ]]; then
-            svc_978="$(build_service_json airplanes-978)"
+            svc_978="$(build_service_json airplanes-978 "$(root_path /run/airplanes-978/state)")"
         fi
 
         local pi_health_json

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -762,3 +762,142 @@ SH
     run jq '.system.cpu.temperature_celsius // empty' "$BODY_LOG"
     [ -z "$output" ]
 }
+
+# ---- daemon-published state/reason on service entries ----
+#
+# Helper: write a schema_version=1 state file at a rooted path.
+_write_state_file() {
+    local path="$1" state="$2" reason="$3"
+    local rooted="$ROOT_DIR$path"
+    mkdir -p "$(dirname "$rooted")"
+    {
+        printf 'schema_version=1\n'
+        printf 'state=%s\n' "$state"
+        printf 'reason=%s\n' "$reason"
+    } > "$rooted"
+}
+
+@test "POST body service entry carries state=enabled,reason=ok from state file" {
+    _write_state_file /run/airplanes-mlat/state enabled ok
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services[] | select(.name=="airplanes-mlat") | .state' "$BODY_LOG"
+    [ "$output" = 'enabled' ]
+    run jq -er '.services[] | select(.name=="airplanes-mlat") | .reason' "$BODY_LOG"
+    [ "$output" = 'ok' ]
+}
+
+@test "POST body service entry carries state=disabled,reason=mlat_enabled_false" {
+    _write_state_file /run/airplanes-mlat/state disabled mlat_enabled_false
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services[] | select(.name=="airplanes-mlat") | .state' "$BODY_LOG"
+    [ "$output" = 'disabled' ]
+    run jq -er '.services[] | select(.name=="airplanes-mlat") | .reason' "$BODY_LOG"
+    [ "$output" = 'mlat_enabled_false' ]
+}
+
+@test "POST body service entry carries disabled,no_hardware for dump978-fa" {
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+    "show airplanes-feed "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-mlat "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show dump978-fa "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    *) ;;
+esac
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+    _write_state_file /run/dump978-fa/state disabled no_hardware
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services[] | select(.name=="dump978-fa") | .state' "$BODY_LOG"
+    [ "$output" = 'disabled' ]
+    run jq -er '.services[] | select(.name=="dump978-fa") | .reason' "$BODY_LOG"
+    [ "$output" = 'no_hardware' ]
+}
+
+@test "POST body omits state/reason when state file is missing" {
+    # No state file → fields absent. Server falls back to systemd-only.
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .reason // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}
+
+@test "POST body omits state/reason when schema_version is wrong" {
+    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    mkdir -p "$(dirname "$rooted")"
+    {
+        printf 'schema_version=2\n'
+        printf 'state=disabled\n'
+        printf 'reason=mlat_enabled_false\n'
+    } > "$rooted"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}
+
+@test "POST body omits state/reason on corrupt state file (no schema_version)" {
+    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    mkdir -p "$(dirname "$rooted")"
+    {
+        printf 'state=disabled\n'
+        printf 'reason=mlat_enabled_false\n'
+    } > "$rooted"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}
+
+@test "POST body airplanes-feed has no state/reason (not plumbed)" {
+    # airplanes-feed has no user-disable predicate today; the script doesn't
+    # pass a state file path for it. Pinning this so a future PR doesn't
+    # silently start plumbing it without a deliberate decision.
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-feed") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}
+
+@test "POST body airplanes-978 carries state=enabled,reason=peer_no_hardware" {
+    # When UAT is configured and the local dump978-fa peer is idle (no SDR),
+    # airplanes-978 publishes enabled/peer_no_hardware. The dashboard
+    # classifies that as the actionable "978 peer unreachable" chip.
+    printf 'REPORT_STATUS=true\nUAT_INPUT=driver=0bda:2838,serial=978\n' \
+        > "$ROOT_DIR/etc/airplanes/feed.env"
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+    "show airplanes-feed "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-mlat "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-978 "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    *) ;;
+esac
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+    _write_state_file /run/airplanes-978/state enabled peer_no_hardware
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services[] | select(.name=="airplanes-978") | .state' "$BODY_LOG"
+    [ "$output" = 'enabled' ]
+    run jq -er '.services[] | select(.name=="airplanes-978") | .reason' "$BODY_LOG"
+    [ "$output" = 'peer_no_hardware' ]
+}
+
+@test "build_service_json uses rooted /run path (AIRPLANES_DIAGNOSTICS_ROOT honoured)" {
+    # Regression guard against a future refactor that hardcodes /run/... —
+    # the test seam roots everything under $ROOT_DIR, and the script must
+    # route the state file path through root_path() so the seam works.
+    _write_state_file /run/airplanes-mlat/state disabled geo_not_configured
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services[] | select(.name=="airplanes-mlat") | .reason' "$BODY_LOG"
+    [ "$output" = 'geo_not_configured' ]
+}

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -901,3 +901,54 @@ SH
     run jq -er '.services[] | select(.name=="airplanes-mlat") | .reason' "$BODY_LOG"
     [ "$output" = 'geo_not_configured' ]
 }
+
+@test "POST body omits state/reason when state file has state but no reason" {
+    # Schema-valid but orphan: only `state=` present. The publisher must
+    # refuse to send half a pair — that would let the dashboard see
+    # ``state=disabled`` with no reason and fall through to the catchall.
+    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    mkdir -p "$(dirname "$rooted")"
+    {
+        printf 'schema_version=1\n'
+        printf 'state=disabled\n'
+    } > "$rooted"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .reason // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}
+
+@test "POST body omits state/reason when state file has reason but no state" {
+    # Mirror of the above: orphan reason. All-or-nothing publish keeps the
+    # server free of partial pairs even on schema-valid-but-corrupt files.
+    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    mkdir -p "$(dirname "$rooted")"
+    {
+        printf 'schema_version=1\n'
+        printf 'reason=mlat_enabled_false\n'
+    } > "$rooted"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .reason // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}
+
+@test "POST body omits state/reason when state file value contains CR" {
+    # state-writer.sh promises no CR in values; a CR in the on-disk file
+    # is a corruption signal and must invalidate the whole record.
+    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    mkdir -p "$(dirname "$rooted")"
+    {
+        printf 'schema_version=1\n'
+        printf 'state=disabled\r\n'
+        printf 'reason=mlat_enabled_false\n'
+    } > "$rooted"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
+    [ -z "$output" ]
+}


### PR DESCRIPTION
`build_service_json` in `airplanes-diagnostics.sh` now reads the daemon-published `/run/<service>/state` file via `scripts/lib/state-reader.sh` and attaches the `state` and `reason` tokens to each service entry in the diagnostics POST. This lets the dashboard distinguish a user-disabled service (mute as "Not configured") from a runtime hardware-missing one (surface as actionable "SDR missing" / "978 peer unreachable") without re-deriving either predicate on the server.

Plumbed for `airplanes-mlat`, `dump978-fa`, and `airplanes-978`. `airplanes-feed` is left without a state file path because it has no user-disable predicate today; `readsb` has no daemon state file. State-file read failure is silent — entries simply omit the two fields and the server falls back to systemd-only classification, same fail-soft posture as the rest of the script.

The `airplanes-978` early-null gate on `UAT_INPUT` is unchanged so the chip stays hidden globally for the non-UAT majority.
