### PR TITLE
Tag journal lines with host=, downgrade feeder_unclaimed to info

### DIFF
--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -66,7 +66,7 @@ ROOT="${AIRPLANES_DIAGNOSTICS_ROOT:-/}"
 
 log() {
     local level="$1"; shift
-    printf '%s level=%s %s\n' "$SCRIPT_NAME" "$level" "$*" >&2
+    printf '%s level=%s %s host=%s\n' "$SCRIPT_NAME" "$level" "$*" "$WEBSITE_HOST" >&2
 }
 
 # parse_report_status RAW
@@ -810,7 +810,18 @@ main() {
         4*)
             local body_err
             body_err="$(parse_field_from "$response_file" '.error')"
-            log warn "status=client_error http=$status mode=$mode error=${body_err:-unknown}"
+            # feeder_unclaimed is the expected pre-claim state on a fresh
+            # feeder until someone redeems the claim secret on the website.
+            # Logging it at level=warn every ~10 min causes alarm fatigue
+            # and hides legitimate warnings under journalctl priority
+            # filtering. Promote to a named status so operators can grep
+            # status=unclaimed; keep error=feeder_unclaimed for any consumer
+            # already counting that field.
+            if [[ "${body_err:-}" == "feeder_unclaimed" ]]; then
+                log info "status=unclaimed http=$status mode=$mode error=feeder_unclaimed"
+            else
+                log warn "status=client_error http=$status mode=$mode error=${body_err:-unknown}"
+            fi
             ;;
         5*)
             log warn "status=server_error http=$status mode=$mode"

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -39,13 +39,27 @@ _resolve_website_url() {
 # a glance which backend a request hit (production vs FEED_HOST-overridden
 # staging). Re-derived from parse_common_option's --website-url branch so CLI
 # overrides propagate before any log call.
+#
+# Order is path-then-userinfo, not the other way around: a path with an
+# embedded `@` (e.g. https://airplanes.live/api/user@example) would otherwise
+# get mis-tagged as host=example. We also greedy-strip userinfo (##*@) so a
+# pathological double-@ in userinfo lands on the canonical separator.
+#
+# The result is then validated against a hostname charset (alnum, hyphen,
+# dot, colon). If the source URL contains anything outside that set (CRLF,
+# spaces, `=` from a deliberate ` level=error` smuggle), WEBSITE_HOST is
+# set to `invalid` rather than risking a journal-line injection.
 _set_website_host() {
     local s="${WEBSITE_URL#*://}"
-    s="${s#*@}"          # strip optional userinfo
-    s="${s%%/*}"         # strip path
-    s="${s%%\?*}"        # strip query
-    s="${s%%#*}"         # strip fragment
-    WEBSITE_HOST="$s"
+    s="${s%%/*}"          # strip path
+    s="${s%%\?*}"         # strip query
+    s="${s%%#*}"          # strip fragment
+    s="${s##*@}"          # strip userinfo (greedy: pick last @)
+    if [[ "$s" =~ ^[A-Za-z0-9.:-]+$ ]]; then
+        WEBSITE_HOST="$s"
+    else
+        WEBSITE_HOST="invalid"
+    fi
 }
 
 # shellcheck disable=SC2034  # WEBSITE_URL/WEBSITE_HOST/MAX_RETRY_TIME/DRY_RUN/FORCE are read by sibling modules sourced from apl-feed.sh

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -33,8 +33,26 @@ _resolve_website_url() {
     printf 'https://airplanes.live'
 }
 
-# shellcheck disable=SC2034  # WEBSITE_URL/MAX_RETRY_TIME/DRY_RUN/FORCE are read by sibling modules sourced from apl-feed.sh
+# Derive WEBSITE_HOST (host[:port], no scheme/userinfo/path/query/fragment)
+# from WEBSITE_URL. Used as a `host=` tag in structured journal lines emitted
+# by airplanes-diagnostics.sh and apl-feed/config.sh so operators can tell at
+# a glance which backend a request hit (production vs FEED_HOST-overridden
+# staging). Re-derived from parse_common_option's --website-url branch so CLI
+# overrides propagate before any log call.
+_set_website_host() {
+    local s="${WEBSITE_URL#*://}"
+    s="${s#*@}"          # strip optional userinfo
+    s="${s%%/*}"         # strip path
+    s="${s%%\?*}"        # strip query
+    s="${s%%#*}"         # strip fragment
+    WEBSITE_HOST="$s"
+}
+
+# shellcheck disable=SC2034  # WEBSITE_URL/WEBSITE_HOST/MAX_RETRY_TIME/DRY_RUN/FORCE are read by sibling modules sourced from apl-feed.sh
 WEBSITE_URL="$(_resolve_website_url)"
+# shellcheck disable=SC2034
+WEBSITE_HOST=""
+_set_website_host
 # shellcheck disable=SC2034
 MAX_RETRY_TIME="${APL_FEED_MAX_RETRY_TIME:-60}"
 # shellcheck disable=SC2034
@@ -489,6 +507,7 @@ parse_common_option() {
             [[ $# -ge 2 ]] || die "--website-url requires URL"
             # shellcheck disable=SC2034  # consumed by http.sh/claim.sh after parse
             WEBSITE_URL="$2"
+            _set_website_host
             return 2
             ;;
         --max-retry-time)

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -62,7 +62,7 @@ CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-/var/lib/ai
 _config_sync_log() {
     local level="$1"
     shift
-    printf 'apl-feed-config-sync level=%s %s\n' "$level" "$*" >&2
+    printf 'apl-feed-config-sync level=%s %s host=%s\n' "$level" "$*" "$WEBSITE_HOST" >&2
 }
 
 # True if feed.env has a (non-comment) line matching `^[[:space:]]*KEY=`.

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -174,7 +174,7 @@ run_script() {
         AIRPLANES_DIAGNOSTICS_ROOT="$ROOT_DIR" \
         AIRPLANES_DIAGNOSTICS_LAST_SUCCESS="$LAST_SUCCESS" \
         AIRPLANES_DIAGNOSTICS_INTENT_ACK_FILE="$INTENT_ACK" \
-        APL_FEED_WEBSITE_URL='http://127.0.0.1:0' \
+        APL_FEED_WEBSITE_URL="${APL_FEED_WEBSITE_URL:-http://127.0.0.1:0}" \
         COMMAND_LOG="$COMMAND_LOG" \
         BODY_LOG="$BODY_LOG" \
         HEADER_LOG="$HEADER_LOG" \
@@ -726,7 +726,35 @@ SH
     [ "$status" -eq 0 ]
     [[ "$output" == *"status=client_error"* ]]
     [[ "$output" == *"http=400"* ]]
+    [[ "$output" == *"level=warn"* ]]
     [ ! -f "$LAST_SUCCESS" ]
+}
+
+@test "HTTP 403 feeder_unclaimed downgrades to level=info status=unclaimed" {
+    CURL_STATUS=403 CURL_RESPONSE='{"error":"feeder_unclaimed"}' run_script
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"level=info"* ]]
+    [[ "$output" == *"status=unclaimed"* ]]
+    [[ "$output" == *"http=403"* ]]
+    [[ "$output" == *"error=feeder_unclaimed"* ]]
+    [[ "$output" != *"status=client_error"* ]]
+    [[ "$output" != *"level=warn"* ]]
+    [ ! -f "$LAST_SUCCESS" ]
+}
+
+@test "HTTP 403 with non-feeder_unclaimed body stays at level=warn status=client_error" {
+    CURL_STATUS=403 CURL_RESPONSE='{"error":"signature_invalid"}' run_script
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"level=warn"* ]]
+    [[ "$output" == *"status=client_error"* ]]
+    [[ "$output" == *"error=signature_invalid"* ]]
+    [[ "$output" != *"status=unclaimed"* ]]
+}
+
+@test "log line carries host= tag from WEBSITE_URL" {
+    APL_FEED_WEBSITE_URL='http://feed.airplanes.test:8080/v1' run_script
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"host=feed.airplanes.test:8080"* ]]
 }
 
 @test "HTTP 5xx logs server_error and exits 0" {

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -749,3 +749,62 @@ STUB
     [ "$status" -eq 0 ]
     [ "$output" = "https://airplanes.live" ]
 }
+
+# --- _set_website_host ---
+#
+# WEBSITE_HOST is the bare host[:port] tag used by structured journal lines
+# in airplanes-diagnostics and apl-feed-config-sync. The parser must strip
+# scheme, userinfo, path, query, and fragment, while keeping any explicit
+# port — non-default ports are operationally useful in the journal.
+
+@test "_set_website_host: strips scheme only on plain host" {
+    WEBSITE_URL="https://airplanes.live"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+}
+
+@test "_set_website_host: preserves host:port" {
+    WEBSITE_URL="http://localhost:8080"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "localhost:8080" ]
+}
+
+@test "_set_website_host: strips path" {
+    WEBSITE_URL="https://airplanes.live/api/foo"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+}
+
+@test "_set_website_host: strips query string" {
+    WEBSITE_URL="https://airplanes.live?x=1"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+}
+
+@test "_set_website_host: strips fragment" {
+    WEBSITE_URL="https://airplanes.live#section"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+}
+
+@test "_set_website_host: strips userinfo (credential leak prevention)" {
+    WEBSITE_URL="https://user:pass@airplanes.live"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+}
+
+@test "_set_website_host: userinfo + port + path + query combined" {
+    WEBSITE_URL="https://u:p@host.example:9000/path?q=1"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "host.example:9000" ]
+}
+
+@test "_set_website_host: re-derives after --website-url reassignment" {
+    WEBSITE_URL="https://airplanes.live"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+    # Simulate parse_common_option's --website-url branch.
+    WEBSITE_URL="http://staging.example:8443/v2"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "staging.example:8443" ]
+}

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -799,12 +799,38 @@ STUB
     [ "$WEBSITE_HOST" = "host.example:9000" ]
 }
 
-@test "_set_website_host: re-derives after --website-url reassignment" {
+@test "_set_website_host: re-derives via parse_common_option --website-url" {
     WEBSITE_URL="https://airplanes.live"
     _set_website_host
     [ "$WEBSITE_HOST" = "airplanes.live" ]
-    # Simulate parse_common_option's --website-url branch.
-    WEBSITE_URL="http://staging.example:8443/v2"
-    _set_website_host
+    # Drive the real parser so the production code path is covered.
+    # Return code 2 is parse_common_option's "consumed 2 args" signal, not
+    # an error — || true keeps `set -e` from aborting the bats run.
+    parse_common_option --website-url "http://staging.example:8443/v2" || true
+    [ "$WEBSITE_URL" = "http://staging.example:8443/v2" ]
     [ "$WEBSITE_HOST" = "staging.example:8443" ]
+}
+
+@test "_set_website_host: @ in path does not capture suffix as host" {
+    WEBSITE_URL="https://airplanes.live/api/user@example"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "airplanes.live" ]
+}
+
+@test "_set_website_host: log-injection attempt becomes invalid" {
+    WEBSITE_URL="https://good.example level=error injected=1"
+    _set_website_host
+    [ "$WEBSITE_HOST" = "invalid" ]
+}
+
+@test "_set_website_host: embedded newline becomes invalid" {
+    WEBSITE_URL=$'https://good.example\nfake-line'
+    _set_website_host
+    [ "$WEBSITE_HOST" = "invalid" ]
+}
+
+@test "_set_website_host: empty / default produces invalid (defensive)" {
+    WEBSITE_URL=""
+    _set_website_host
+    [ "$WEBSITE_HOST" = "invalid" ]
 }

--- a/test/test_apl_feed_config_sync.bats
+++ b/test/test_apl_feed_config_sync.bats
@@ -254,6 +254,17 @@ EOF
     fi
 }
 
+@test "log line carries host= tag from WEBSITE_URL" {
+    seed_feed_env
+    set_canned 200 '{"schema_version":1,"server_time":"2026-05-14T12:00:00Z","owned":false}'
+    # apl-feed.sh runs in a subshell — must export so common.sh picks it up.
+    export APL_FEED_WEBSITE_URL='http://feed.airplanes.test:8080/v1'
+    run_sync
+    unset APL_FEED_WEBSITE_URL
+    [ "$SYNC_RC" -eq 0 ]
+    [[ "$SYNC_ERR" == *"host=feed.airplanes.test:8080"* ]]
+}
+
 @test "200 applied response runs apl_feed_apply with server tuples" {
     seed_feed_env
     seed_feed_meta MLAT_USER "2026-05-10T00:00:00Z"


### PR DESCRIPTION
Two journal-observability tweaks to the structured log stream from `airplanes-diagnostics` and `apl-feed-config-sync`.

Every line now carries a trailing `host=<host[:port]>` field derived from `WEBSITE_URL` (scheme, userinfo, path, query, fragment all stripped). When the feeder is pointed at a non-prod backend via `FEED_HOST` or `--website-url`, operators can tell from the journal which server actually got the request — until now the structured line never said.

The pre-claim `feeder_unclaimed` 403 from `/api/feeders/diagnostics` now logs at `level=info` with a new `status=unclaimed` instead of `level=warn status=client_error`. That state is expected for minutes-to-days on a freshly-flashed feeder waiting for someone to redeem the claim secret on the website; logging it as a warning every ~10 min created alarm fatigue and hid real warnings under journalctl priority filtering. The `error=feeder_unclaimed` field is kept so any consumer counting it keeps working.