### PR TITLE
Return 75 (EX_TEMPFAIL) from claim register on transient curl failures

### DIFF
--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -87,12 +87,21 @@ claim_register() {
         case "$curl_rc" in
             0) ;;
             6|7|28)
+                # Transient network conditions (DNS not yet resolvable, no
+                # route, connect timeout). Exit 75 (EX_TEMPFAIL) so the
+                # caller's systemd unit can map it via SuccessExitStatus=
+                # and the timer's OnUnitActiveSec= re-arms cleanly off a
+                # dead-not-failed unit. Exit 2 stays reserved for argv /
+                # config errors that retry can't fix.
                 echo "ERROR: curl rc=$curl_rc (DNS/connect/timeout) - network unreachable" >&2
-                return 2
+                return 75
                 ;;
             *)
+                # Other curl failures (SSL handshake, recv error, etc.) are
+                # also retry-worthy from the timer's perspective, so use 75
+                # rather than 2.
                 echo "ERROR: curl rc=$curl_rc - $WEBSITE_URL/api/feeders/secret unreachable" >&2
-                return 2
+                return 75
                 ;;
         esac
 

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -91,17 +91,18 @@ claim_register() {
                 # route, connect timeout). Exit 75 (EX_TEMPFAIL) so the
                 # caller's systemd unit can map it via SuccessExitStatus=
                 # and the timer's OnUnitActiveSec= re-arms cleanly off a
-                # dead-not-failed unit. Exit 2 stays reserved for argv /
-                # config errors that retry can't fix.
+                # dead-not-failed unit.
                 echo "ERROR: curl rc=$curl_rc (DNS/connect/timeout) - network unreachable" >&2
                 return 75
                 ;;
             *)
-                # Other curl failures (SSL handshake, recv error, etc.) are
-                # also retry-worthy from the timer's perspective, so use 75
-                # rather than 2.
+                # Catch-all for non-transient curl failures (rc=3 malformed
+                # URL, rc=51/60 SSL cert verify, rc=58 missing client cert,
+                # rc=1 unsupported protocol, ...). These are config errors
+                # that retry can't fix; keep exit 2 so the unit ends in
+                # `failed` and stays visible in `systemctl --failed`.
                 echo "ERROR: curl rc=$curl_rc - $WEBSITE_URL/api/feeders/secret unreachable" >&2
-                return 75
+                return 2
                 ;;
         esac
 

--- a/test/test_claim_register.bats
+++ b/test/test_claim_register.bats
@@ -257,11 +257,14 @@ mock_url() {
     [ "$status" -eq 1 ]
 }
 
-@test "network unreachable (RFC 2606 .invalid) exits 2" {
+@test "network unreachable (RFC 2606 .invalid) exits 75 (EX_TEMPFAIL)" {
+    # 75 (EX_TEMPFAIL) instead of 2 so a systemd unit with
+    # SuccessExitStatus=75 stays out of `failed` state and its timer
+    # re-arms cleanly. Exit 2 stays reserved for argv / config errors.
     run "$SCRIPT" claim register --root "$ROOT_DIR" \
         --website-url "http://nonexistent-host-deliberately-broken.invalid" \
         --max-retry-time 5
-    [ "$status" -eq 2 ]
+    [ "$status" -eq 75 ]
 }
 
 
@@ -290,8 +293,8 @@ mock_url() {
     run timeout 4 "$SCRIPT" claim register --root "$ROOT_DIR" \
         --website-url "http://127.0.0.1:1" \
         --max-retry-time 1
-    # Either curl-rc network-error (exit 2) or rate-limit-cap (exit 3).
-    [ "$status" -eq 2 ] || [ "$status" -eq 3 ]
+    # Either curl-rc network-error (exit 75 EX_TEMPFAIL) or rate-limit-cap (exit 3).
+    [ "$status" -eq 75 ] || [ "$status" -eq 3 ]
     # The pending file must exist because we wrote it pre-POST.
     [ -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending" ]
     # Final must NOT exist (POST didn't succeed).


### PR DESCRIPTION
`apl-feed claim register` now returns 75 (`EX_TEMPFAIL` per `sysexits.h`) on curl rc 6/7/28 (DNS / connect / timeout) instead of overloading 2. Exit 2 stays reserved for argv / config errors that a retry can't fix.

The motivating bug: when the unit on the image ran at first boot before DNS was resolvable, it exited 2, systemd parked it in `failed` state, and the timer's `OnUnitActiveSec=5min` didn't re-arm cleanly — observed gap was ~50 minutes instead of 5. Paired with `SuccessExitStatus=75` on the systemd unit (airplanes-live/image), the unit ends in `dead` instead of `failed` and the timer fires again on schedule.

Other curl failures (SSL, recv error, etc.) also return 75 since they're retry-worthy from the timer's perspective. The other `return 2` paths in `claim.sh` (rotation flow's transient handling) are intentionally untouched — that's an interactive flow, not timer-triggered, where the exit code goes straight to a human.

Addresses #96.
