### PR TITLE
Let apl-feed backup write to stdout via '-'

### DIFF
--- a/scripts/apl-feed/backup.sh
+++ b/scripts/apl-feed/backup.sh
@@ -46,8 +46,13 @@ config_backup() {
                 ;;
         esac
     done
-    [[ -n "$outfile" ]] || die "backup requires a file"
-    [[ ! -e "$outfile" ]] || die "$outfile already exists"
+    [[ -n "$outfile" ]] || die "backup requires a file (use '-' for stdout)"
+    local stdout_mode=0
+    if [[ "$outfile" == "-" ]]; then
+        stdout_mode=1
+    else
+        [[ ! -e "$outfile" ]] || die "$outfile already exists"
+    fi
     require_jq
 
     local uuid secret version tmp created_at
@@ -57,6 +62,28 @@ config_backup() {
     created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     if version_read="$(read_version_file 2>/dev/null)"; then
         version="$version_read"
+    fi
+
+    if (( stdout_mode )); then
+        # Pipe-friendly mode for callers that consume the JSON directly
+        # (e.g. the on-device webconfig's export wrapper). No tempfile,
+        # no permissions to manage, no trailing confirmation message —
+        # stdout is reserved for the JSON payload.
+        if [[ "$version" == "null" ]]; then
+            jq -n \
+                --arg created_at "$created_at" \
+                --arg feeder_uuid "$uuid" \
+                --arg secret "$secret" \
+                '{schema_version:1, created_at:$created_at, feeder_uuid:$feeder_uuid, claim:{secret:$secret, version:null}}'
+        else
+            jq -n \
+                --arg created_at "$created_at" \
+                --arg feeder_uuid "$uuid" \
+                --arg secret "$secret" \
+                --argjson version "$version" \
+                '{schema_version:1, created_at:$created_at, feeder_uuid:$feeder_uuid, claim:{secret:$secret, version:$version}}'
+        fi
+        return 0
     fi
 
     tmp="${outfile}.$$"

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -117,7 +117,7 @@ Usage:
   apl-feed schema
   apl-feed config sync [--dry-run] [--no-restart]
   apl-feed import legacy-config [--no-restart] <path>
-  apl-feed backup <file>
+  apl-feed backup <file>|-
   apl-feed restore <file>
   apl-feed restore --check <file>
   apl-feed restore --uuid <uuid> [--check]

--- a/test/test_apl_feed_backup.bats
+++ b/test/test_apl_feed_backup.bats
@@ -195,6 +195,40 @@ write_backup() {
     [[ "$created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
 }
 
+@test "config_backup: '-' writes JSON to stdout, no file created" {
+    run config_backup -
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    [ ! -e "$ROOT_DIR/-" ]
+    [ "$(printf '%s' "$output" | jq -r '.schema_version')" = '1' ]
+    [ "$(printf '%s' "$output" | jq -r '.feeder_uuid')" = "$UUID" ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.secret')" = "$SECRET" ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.version')" = 'null' ]
+}
+
+@test "config_backup: '-' includes integer version when version file present" {
+    printf '7\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+    run config_backup -
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.version')" = '7' ]
+}
+
+@test "config_backup: '-' emits no confirmation line on stdout" {
+    run config_backup -
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Backed up feeder config"* ]]
+}
+
+@test "config_backup: '-' is not blocked by a pre-existing file literally named '-'" {
+    : > "$ROOT_DIR/-"
+    cd "$ROOT_DIR"
+    run config_backup -
+    [ "$status" -eq 0 ]
+    # The literal '-' file we created earlier stays empty — stdout-mode
+    # never touches the filesystem.
+    [ ! -s "$ROOT_DIR/-" ]
+}
+
 @test "config_backup: missing UUID file dies" {
     rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
     run bash -c "


### PR DESCRIPTION
`apl-feed backup -` now writes the backup JSON straight to stdout instead of requiring a writable file path. Same schema as the file form, no confirmation message mixed in, and no umask/tempfile/rename dance to manage. Useful when a caller wants to consume the payload directly without staging a file on disk first.

The existing `apl-feed backup <path>` form keeps its prior behavior — the change is purely additive.
