### PR TITLE
fix(claim): stop airplanes-claim.timer after a successful claim write

### DIFF
--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -118,6 +118,11 @@ claim_register() {
                     chmod 640 "$pending"
                     mv "$pending" "$final"
                 fi
+                # The secret is on disk; stop the timer before any later
+                # failure (write_version_file errno, echo EPIPE, etc.)
+                # could abort under `set -e` and leave the retry timer
+                # firing indefinitely against a now-claimed feeder.
+                stop_claim_timer_if_present
                 write_version_file "$version"
                 echo "SUCCESS ($status, version $version)"
                 echo "Secret persisted to $final"
@@ -394,9 +399,15 @@ claim_rotate() {
 claim_set() {
     # Save a claim secret minted by the website (e.g. the same-IP claim
     # legacy bootstrap, the owner-side Reset secret flow, or a support
-    # reset) and restart feeder services so the new value takes effect
-    # immediately. The secret is read from stdin (TTY prompts; pipes work
+    # reset). The secret is read from stdin (TTY prompts; pipes work
     # too) so the value never lands in argv or shell history.
+    #
+    # No feeder-daemon restart: neither airplanes-feed nor airplanes-mlat
+    # reads the claim secret — only apl-feed itself does, and the next
+    # CLI invocation picks up the file change immediately. The only
+    # systemd touch is stopping the image-side airplanes-claim.timer
+    # post-write so the now-claimed feeder stops accumulating condition-
+    # skip noise in the service journal.
     #
     # Refuses to overwrite an existing different secret unless --force is
     # passed; a no-op when the supplied secret already matches the local
@@ -468,7 +479,7 @@ claim_set() {
 
     echo "Feeder ID: $uuid"
     if (( DRY_RUN )); then
-        echo "(dry-run; would save secret + restart feeder services)"
+        echo "(dry-run; would save secret to $final)"
         return 0
     fi
 
@@ -481,14 +492,17 @@ claim_set() {
         # Same canonical value already on disk. Re-write to normalize byte
         # contents (lowercase / hyphenated raw input gets canonicalized)
         # and the file mode (0600). Don't drop the version file — the
-        # local secret bytes haven't functionally changed. Don't restart
-        # services either: nothing observable changed.
+        # local secret bytes haven't functionally changed.
         write_secret_file "$final" "$secret"
+        stop_claim_timer_if_present
         echo "Local claim secret already matches — no change."
         return 0
     fi
 
     write_secret_file "$final" "$secret"
+    # Secret is on disk; stop the timer before any later step (rm,
+    # echo EPIPE) could abort under `set -e`.
+    stop_claim_timer_if_present
 
     # Local secret no longer matches whatever the version file claimed.
     # Drop the version file so `claim show` / `backup` can't pair a
@@ -497,12 +511,10 @@ claim_set() {
     rm -f "$version_path"
 
     echo "Claim secret saved."
-    # No daemon restart: neither airplanes-feed nor airplanes-mlat reads
-    # the claim secret. Only this CLI does, and the next CLI invocation
-    # picks up the file change immediately. The website's hash is already
-    # the new value (this command is run AFTER the website mints the
-    # secret), so the next outbound `status` or `rotate` from the feeder
-    # authenticates fine.
+    # The website's hash is already the new value (this command is run
+    # AFTER the website mints the secret), so the next outbound `status`
+    # or `rotate` from the feeder authenticates fine. No daemon restart
+    # — neither airplanes-feed nor airplanes-mlat reads this file.
     echo "Done. The feeder will use the new secret on its next contact with the website."
 }
 

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -510,6 +510,34 @@ restart_feeder_services() {
     return $rc
 }
 
+# Stop the image-side airplanes-claim.timer after a successful claim write
+# (claim register / claim set). The timer drives retry of unclaimed feeders;
+# once the secret is on disk it has nothing to do, and every subsequent
+# 5-min fire logs `Condition check resulted in ... skipped` against the
+# service unit — which the webconfig "Claim activity" panel surfaces as
+# noise. The timer's WantedBy=timers.target keeps it re-armable on next
+# reboot if the secret is ever deleted (factory reset, manual reclaim).
+#
+# Defensive on every leg: silently no-ops on hosts without systemctl,
+# hosts without the timer unit (legacy non-image installs), and non-root
+# --root invocations (mirrors restart_feeder_services — stopping the
+# host's timer when operating on a different rootfs is wrong).
+#
+# APL_FEED_TEST_TIMER_STOP_FORCE is a test-only override so bats
+# integration tests can exercise the helper while using --root to scope
+# filesystem fixtures. The TEST prefix is deliberate so a stray export
+# in a production shell is visible at a glance; production callers must
+# never set this.
+stop_claim_timer_if_present() {
+    if [[ "$ROOT" != "/" && -z "${APL_FEED_TEST_TIMER_STOP_FORCE:-}" ]]; then
+        return 0
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 0
+    fi
+    systemctl --no-block stop airplanes-claim.timer 2>/dev/null || true
+}
+
 parse_common_option() {
     case "${1:-}" in
         --root)

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -570,22 +570,32 @@ EOF
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")" = "7" ]
 }
 
-@test "claim set never invokes systemctl (no daemon consumes the secret)" {
+@test "claim set never restarts feeder daemons (no daemon consumes the secret)" {
     # The claim secret is consumed only by apl-feed itself, not by
     # airplanes-feed or airplanes-mlat. Saving it must not bounce a
-    # working feeder. Use a sentinel stub that fails the test if invoked.
+    # working feeder. The only permitted systemctl call is the post-write
+    # stop of airplanes-claim.timer (see test_claim_timer_stop.bats);
+    # this assertion pins that NOTHING ELSE is touched.
+    COMMAND_LOG="$(mktemp)"
     cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
 #!/usr/bin/env bash
-echo "systemctl invoked with: $*" >&2
-exit 99
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
 STUB
     chmod +x "$STUB_BIN_DIR/systemctl"
+    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
 
     run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
 
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "systemctl invoked" ]]
     [[ ! "$output" =~ "Restarted" ]]
+    # Every recorded systemctl invocation must be the timer-stop. No
+    # restart, no reload, no apl-feed daemon touched.
+    while IFS= read -r line; do
+        [[ "$line" == "systemctl --no-block stop airplanes-claim.timer" ]] \
+            || { echo "unexpected systemctl call: $line" >&2; false; }
+    done < "$COMMAND_LOG"
+    rm -f "$COMMAND_LOG"
 }
 
 @test "claim set is idempotent when supplied secret already matches local" {
@@ -655,6 +665,93 @@ STUB
     [[ "$output" =~ "dry-run" ]]
     [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
     [ ! -f "$restart_log" ]
+}
+
+
+# --- claim set: post-write timer stop -------------------------------------
+#
+# Coordinated with the image-side airplanes-claim.timer. Once claim set
+# lands the secret on disk, the timer has nothing left to do, and every
+# subsequent fire pollutes the service journal with condition-skip lines
+# that the webconfig Claim activity panel surfaces.
+
+@test "claim set new-secret write stops airplanes-claim.timer" {
+    COMMAND_LOG="$(mktemp)"
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+    rm -f "$COMMAND_LOG"
+}
+
+@test "claim set same-canonical-value (idempotent) still stops the timer" {
+    # The re-normalize path also writes the file (to fix mode / casing), so
+    # we want the timer-stop here too — keeps the helper invariant simple:
+    # any successful secret write triggers the stop.
+    echo "abcd-efgh-ijkl-mnop" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 644 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    COMMAND_LOG="$(mktemp)"
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCD-EFGH-IJKL-MNOP"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "already matches" ]]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+    rm -f "$COMMAND_LOG"
+}
+
+@test "claim set --dry-run does NOT stop the timer (no secret was written)" {
+    COMMAND_LOG="$(mktemp)"
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" --dry-run <<<"ABCDEFGHIJKLMNOP"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dry-run" ]]
+    [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+    rm -f "$COMMAND_LOG"
+}
+
+@test "claim set refuse-without-force does NOT stop the timer (nothing written)" {
+    echo "OLDSECRETXYZ1234" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    COMMAND_LOG="$(mktemp)"
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
+
+    run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"NEWSECRETXYZ5678"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "different claim secret" ]]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+    rm -f "$COMMAND_LOG"
 }
 
 @test "id set writes a new UUID and restarts both daemons feed-first" {

--- a/test/test_claim_register.bats
+++ b/test/test_claim_register.bats
@@ -17,12 +17,27 @@ setup() {
     # header on line 1 and the request body on line 2. Tests grep this
     # to assert v2 wire shape (DEV-427).
     MOCK_REQ_FILE="$(mktemp)"
+
+    # Stub systemctl so the post-success stop_claim_timer_if_present call
+    # can be observed via COMMAND_LOG. APL_FEED_TEST_TIMER_STOP_FORCE bypasses
+    # the helper's ROOT != "/" guard so the integration tests (which all
+    # pass --root "$ROOT_DIR") still exercise the systemctl path.
+    STUB_BIN_DIR="$(mktemp -d)"
+    COMMAND_LOG="$(mktemp)"
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    PATH="$STUB_BIN_DIR:$PATH"
+    export PATH COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
 }
 
 teardown() {
     stop_mock_server || true
-    rm -rf "$ROOT_DIR"
-    rm -f "$MOCK_RESP_FILE" "$MOCK_PORT_FILE" "$MOCK_PID_FILE" "$MOCK_REQ_FILE"
+    rm -rf "$ROOT_DIR" "$STUB_BIN_DIR"
+    rm -f "$MOCK_RESP_FILE" "$MOCK_PORT_FILE" "$MOCK_PID_FILE" "$MOCK_REQ_FILE" "$COMMAND_LOG"
 }
 
 # Inline mock HTTP server. Reads its (status, body) response from
@@ -327,4 +342,168 @@ mock_url() {
     [ -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ]
     [ ! -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending" ]
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "RESUMEPENDING123" ]
+}
+
+
+# --- Post-success timer-stop ----------------------------------------------
+#
+# Once `claim register` succeeds, the image-side airplanes-claim.timer has
+# nothing left to do. Stopping it post-success keeps the timer's 5-min
+# OnUnitActiveSec from logging "Condition check resulted in ... skipped"
+# against airplanes-claim.service on every fire — which the webconfig
+# Claim activity panel surfaces as noise.
+#
+# Critical invariants:
+#   1. Timer stop is invoked exactly when the secret file lands on disk
+#      (200 / 201).
+#   2. Timer stop is NOT invoked on any failure path. This is load-bearing
+#      because the unit's SuccessExitStatus=75 lets a transient curl
+#      failure (rc 6/7/28 → exit 75 from claim_register) exit "successfully"
+#      from systemd's perspective — but the secret was NEVER written, so
+#      we must not stop the retry timer.
+
+@test "201 success stops airplanes-claim.timer" {
+    write_contract_response secret create_success
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "200 NOOP_REPLAY success stops airplanes-claim.timer" {
+    write_contract_response secret noop_replay
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "200 NOOP_REPLAY with pre-existing final secret also stops the timer" {
+    # The `[[ -f \"\$final\" ]]` branch in claim_register reuses the
+    # existing secret instead of writing pending → final. The timer
+    # still needs stopping (it was either already stopped, in which
+    # case the helper is a no-op, or someone re-armed it and we
+    # re-stop). Without this test the new behavior could regress to
+    # only-on-mv-path and existing-final feeders would keep retrying.
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    echo "PRESERVEDSECRET1" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    write_contract_response secret noop_replay
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SUCCESS" ]]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "201 success: timer stop sees secret on disk and no .pending (ordering)" {
+    # Pins the ordering invariant: stop_claim_timer_if_present must run
+    # AFTER the mv "$pending" "$final" promotion, not before. A future
+    # refactor that moved the call earlier could stop the timer while
+    # the secret hasn't been persisted, breaking recovery if the script
+    # then aborts. The stub captures fs state at call time.
+    cat > "$STUB_BIN_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+final_present=missing
+pending_present=missing
+[ -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret" ] && final_present=present
+[ -f "$ROOT_DIR/etc/airplanes/feeder-claim-secret.pending" ] && pending_present=present
+printf 'final=%s pending=%s argv=%s\n' "\$final_present" "\$pending_present" "\$*" >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    write_contract_response secret create_success
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    # When the helper was invoked, final must exist and pending must be gone.
+    grep -F -- 'final=present pending=missing' "$COMMAND_LOG"
+    # And the argv must be the timer-stop, not something else (defence
+    # against a refactor that calls systemctl elsewhere on the success path).
+    grep -F -- 'argv=--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "400 bad request does NOT stop the timer (secret not on disk)" {
+    write_contract_response secret invalid_claim_secret
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "409 rotation_rejected does NOT stop the timer" {
+    write_contract_response secret rotation_rejected
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "423 feeder_blocked does NOT stop the timer" {
+    write_contract_response secret feeder_blocked
+    start_mock_server
+    run timeout 5 "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "409 legacy_unclaimed does NOT stop the timer" {
+    write_contract_response secret legacy_unclaimed
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 4 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "non-JSON 404 does NOT stop the timer (endpoint disabled)" {
+    write_response 404 '<html>Not Found</html>' 'text/html'
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 1 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "transient connect failure (curl rc=7) → exit 75 does NOT stop the timer" {
+    # Load-bearing: the image unit sets SuccessExitStatus=75 so a transient
+    # network failure does not park the unit in `failed`. We must NOT
+    # stop the timer on this path, or the timer's OnUnitActiveSec=5min
+    # retry loop dies and the feeder never registers. Using port 1
+    # (always refused locally) makes this deterministic — independent of
+    # the host's DNS resolver / corporate proxy behavior.
+    run timeout 5 "$SCRIPT" claim register --root "$ROOT_DIR" \
+        --website-url "http://127.0.0.1:1" \
+        --max-retry-time 1
+    [ "$status" -eq 75 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "5xx loop until deadline → exit 3 does NOT stop the timer" {
+    # Pin the deadline-exhausted path (return 3 from claim_register's
+    # while loop) separately from the curl-rc transient path. A future
+    # change that mis-routed the success branch into the 5xx case would
+    # otherwise slip past the connection-refused test.
+    write_response 503 '{"error":"backend"}'
+    start_mock_server
+    run timeout 10 "$SCRIPT" claim register --root "$ROOT_DIR" \
+        --website-url "$(mock_url)" --max-retry-time 1
+    [ "$status" -eq 3 ]
+    ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "post-success: timer stop is silent when systemctl exits non-zero" {
+    # If the timer unit doesn't exist on this host (legacy non-image
+    # install), systemctl returns non-zero. The helper's `|| true` must
+    # swallow it so the script still exits 0 from a successful registration.
+    cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 1
+STUB
+    chmod +x "$STUB_BIN_DIR/systemctl"
+    write_contract_response secret create_success
+    start_mock_server
+    run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "SUCCESS" ]]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
 }

--- a/test/test_claim_timer_stop.bats
+++ b/test/test_claim_timer_stop.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+#
+# Unit tests for stop_claim_timer_if_present, defined in
+# scripts/apl-feed/common.sh. Source-based so the helper runs in the
+# test's own shell — that lets us override the `command` builtin to
+# fake out `command -v systemctl` lookups (a PATH stub can hide our
+# stubbed systemctl but can't make the real /usr/bin/systemctl
+# disappear from the rest of PATH).
+#
+# Integration coverage (helper is invoked at the right time inside
+# claim_register / claim_set, and is silent on failure paths) lives in
+# test_claim_register.bats and test_apl_feed_cli.bats.
+
+setup() {
+    COMMON_LIB="$BATS_TEST_DIRNAME/../scripts/apl-feed/common.sh"
+    STUB_DIR="$(mktemp -d)"
+    COMMAND_LOG="$(mktemp)"
+
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+
+    OLD_PATH="$PATH"
+    PATH="$STUB_DIR:$PATH"
+    export PATH COMMAND_LOG
+
+    # shellcheck source=/dev/null
+    source "$COMMON_LIB"
+}
+
+teardown() {
+    PATH="$OLD_PATH"
+    rm -rf "$STUB_DIR"
+    rm -f "$COMMAND_LOG"
+}
+
+# Helper: hide systemctl from `command -v` so the no-systemctl branch is
+# reachable even on CI runners and dev boxes where /usr/bin/systemctl is
+# preinstalled. Mirrors the _hide_ss_from_command_v pattern in
+# test_apl_feed_status.bats.
+_hide_systemctl_from_command_v() {
+    command() {
+        if [[ "$1" = "-v" && "$2" = "systemctl" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+}
+
+@test "stop_claim_timer_if_present invokes systemctl --no-block stop on ROOT=/" {
+    ROOT="/"
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "stop_claim_timer_if_present skips silently when ROOT != /" {
+    ROOT="/tmp/somerootfs"
+    unset APL_FEED_TEST_TIMER_STOP_FORCE
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    [ ! -s "$COMMAND_LOG" ]
+}
+
+@test "stop_claim_timer_if_present runs anyway when APL_FEED_TEST_TIMER_STOP_FORCE=1" {
+    # Test seam used by the integration bats files so they can keep using
+    # --root for filesystem fixtures while still exercising the helper.
+    ROOT="/tmp/somerootfs"
+    APL_FEED_TEST_TIMER_STOP_FORCE=1
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "stop_claim_timer_if_present is silent with no systemctl in PATH" {
+    # Manual installs on non-systemd hosts (or chroots) shouldn't error.
+    _hide_systemctl_from_command_v
+    ROOT="/"
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    [ ! -s "$COMMAND_LOG" ]
+}
+
+@test "stop_claim_timer_if_present exits 0 even when systemctl exits non-zero" {
+    # Legacy hosts without airplanes-claim.timer return non-zero from
+    # `systemctl stop`. The helper's trailing `|| true` must absorb it so
+    # the calling claim_register / claim_set still ends at `return 0`.
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 1
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    ROOT="/"
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+}
+
+@test "stop_claim_timer_if_present is idempotent across repeat calls" {
+    # claim_set on an already-claimed feeder hits the timer-stop branch
+    # again; both calls must exit 0 even though the second one is a no-op
+    # at the systemd level.
+    ROOT="/"
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    # Both invocations should have hit the stub.
+    [ "$(grep -c -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG")" = "2" ]
+}
+
+@test "stop_claim_timer_if_present passes the documented argv (pinned)" {
+    # Pin the exact argv shape: --no-block (returns immediately so the
+    # service can exit), stop (not disable — we keep the timer's enable
+    # symlink so a future reclaim can re-arm it on reboot),
+    # airplanes-claim.timer (the unit name the image side ships).
+    ROOT="/"
+    run stop_claim_timer_if_present
+    [ "$status" -eq 0 ]
+    local logged; logged="$(cat "$COMMAND_LOG")"
+    [ "$logged" = "systemctl --no-block stop airplanes-claim.timer" ]
+}


### PR DESCRIPTION
The image-side `airplanes-claim.timer` retries `apl-feed claim register` every five minutes until a feeder is claimed. Once the secret lands on disk, the timer has nothing left to do — but it doesn't stop on its own, so every subsequent fire activates a service whose `ConditionPathExists=!/etc/airplanes/feeder-claim-secret` now fails. systemd logs `airplanes-claim.service - airplanes.live feeder claim registration skipped, unmet condition check ...` on every retry, which the webconfig Claim activity panel surfaces to feeder owners as endless "unmet condition" noise indistinguishable from a real error.

Stop the timer from the success path of both writers: `claim register` immediately after `mv "\$pending" "\$final"`, `claim set` immediately after `write_secret_file`. Critical: the call sits strictly after the secret is on disk and strictly inside the success branches — the `SuccessExitStatus=75` (EX_TEMPFAIL) path of the image unit must keep retrying. `WantedBy=timers.target` stays intact so a future factory reset or reclaim re-arms the timer on the next reboot.

Defensive: silent on hosts without systemctl, hosts without the timer unit (legacy non-image installs), and `--root` invocations operating on a different rootfs — same shape as the existing `restart_feeder_services` guard.