### PR TITLE
revert(mlat): drop 30187 RESULTS4 + outbound listener

### DIFF
--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -73,23 +73,10 @@ FEED_BIN="${AIRPLANES_FEED_BIN:-$DEFAULT_FEED_BIN}"
 # daemon. The image branch keeps its leaner FEED_NET_OPTIONS override
 # and adds FEED_IMAGE_OPTIONS for the baked-decoder case.
 TARGET="${TARGET:-"--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"}"
-# --forward-mlat is required for MLAT frames received on --net-bi-port 30187
-# to actually leave via the upstream beast_reduce_plus_out connector. readsb
-# gates Beast output on (!is_mlat || forward_mlat); the flag defaults off.
-# Without it, mlat-client delivers Beast results that the feeder silently
-# drops on the floor instead of forwarding to the aggregator.
-NET_OPTIONS="${NET_OPTIONS:-"--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --forward-mlat"}"
+NET_OPTIONS="${NET_OPTIONS:-"--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bo-port 0 --net-ri-port 0"}"
 
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
-    # --net-bi-port 30187 is the listener mlat-client (airplanes-mlat.sh)
-    # connects to with --results beast,connect,127.0.0.1:30187 so MLAT planes
-    # reach the aggregator via this feeder. Loopback-bound to match the
-    # decoder side. --forward-mlat is required so the received MLAT frames
-    # actually leave via the upstream beast_reduce_plus_out connector
-    # (readsb gates Beast output on (!is_mlat || forward_mlat) — default off).
-    # An operator-set FEED_NET_OPTIONS replaces this default whole (same
-    # convention as NET_OPTIONS / TARGET / JSON_OPTIONS).
-    FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-"--net-ro-interval 0.2 --net-bind-address 127.0.0.1 --net-bi-port 30187 --forward-mlat"}"
+    FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-"--net-ro-interval 0.2"}"
     FEED_IMAGE_OPTIONS="${FEED_IMAGE_OPTIONS:-"--db-file=none --max-range 450"}"
 else
     FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-$NET_OPTIONS}"

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -138,11 +138,16 @@ INPUT_TYPE="${INPUT_TYPE:-dump1090}"
 # RESULTS* slots are set on disk. Legacy single-line feed.env may carry
 # a combined `RESULTS="--results ... --results ..."` and we must not
 # duplicate outputs by stacking individual defaults on top.
+#
+# These are receive-side endpoints — mlat-client delivers computed MLAT
+# positions here for local display only (tar1090/graphs1090 read from
+# 30104; the listen ports are for downstream consumers that poll
+# mlat-client directly). Upstream contribution flows via mlat-client's
+# own --server connection to MLATSERVER, not through any of these.
 if [[ ! -v RESULTS && ! -v RESULTS1 && ! -v RESULTS2 && ! -v RESULTS3 && ! -v RESULTS4 ]]; then
     RESULTS="--results beast,connect,127.0.0.1:30104"
     RESULTS2="--results basestation,listen,31015"
     RESULTS3="--results beast,listen,30157"
-    RESULTS4="--results beast,connect,127.0.0.1:30187"
 fi
 
 UUID_FILE="--uuid-file $FEEDER_ID_FILE"

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -115,14 +115,16 @@ SH
     grep -q -- '--max-range 450' "$arg_log"
     grep -q -- '--modeac' "$arg_log"
     grep -q -- "--uuid-file=$root/etc/airplanes/feeder-id" "$arg_log"
-    # MLAT-feedback listener — mlat-client routes --results beast,connect,
-    # 127.0.0.1:30187 here so this feeder forwards MLAT to the aggregator.
-    # Bound to loopback only. --forward-mlat is required because readsb
-    # gates Beast output on (!is_mlat || forward_mlat) — without it, MLAT
-    # frames received on 30187 would be dropped instead of forwarded.
-    grep -q -- '--net-bi-port 30187' "$arg_log"
-    grep -q -- '--net-bind-address 127.0.0.1' "$arg_log"
-    grep -q -- '--forward-mlat' "$arg_log"
+    # Image-mode feeder is a pure outbound forwarder — no Beast input
+    # listener, no MLAT handling on this binary. MLAT contribution flows
+    # via mlat-client's --server connection to MLATSERVER, not through any
+    # Beast feedback into this process.
+    if grep -q -- '--net-bi-port' "$arg_log"; then
+        return 1
+    fi
+    if grep -q -- '--forward-mlat' "$arg_log"; then
+        return 1
+    fi
     # --write-json was the output sink for the bundled tar1090 installer; nothing
     # consumes /run/airplanes-feed anymore. Match the bare flag only — guard
     # against accidental reintroduction without flagging --write-json-every or
@@ -1173,12 +1175,13 @@ SH
     grep -q -- "feed_bin=$root/usr/bin/airplanes-feeder" "$root/run/airplanes-feed/state"
 }
 
-@test "airplanes-mlat.sh: RESULTS bundle default routes to 30104 + 31015 + 30157 + 30187" {
-    # When feed.env carries no RESULTS* keys at all, the wrapper's four-
-    # destination default must fire: MLAT planes go to the local decoder
-    # (30104), basestation/beast listen ports for downstream consumers
-    # (31015, 30157), and the outbound feeder for aggregator forwarding
-    # (30187). Pins the design intent of airplanes-mlat.sh:141-146.
+@test "airplanes-mlat.sh: RESULTS bundle default routes to 30104 + 31015 + 30157" {
+    # When feed.env carries no RESULTS* keys at all, the wrapper's three-
+    # destination default fires: MLAT planes go to the local decoder
+    # (30104, for tar1090/graphs1090) and to basestation/beast listen
+    # ports for downstream consumers (31015, 30157). MLAT upstream
+    # contribution flows via mlat-client's --server connection, NOT
+    # through any RESULTS endpoint.
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
@@ -1215,15 +1218,19 @@ SH
     grep -q -- '--results beast,connect,127.0.0.1:30104' "$arg_log"
     grep -q -- '--results basestation,listen,31015' "$arg_log"
     grep -q -- '--results beast,listen,30157' "$arg_log"
-    grep -q -- '--results beast,connect,127.0.0.1:30187' "$arg_log"
+    # 30187 used to be in the default bundle but never had a deployed
+    # listener and never reached the aggregator's globe (aether ingest
+    # has no --forward-mlat). MLAT upstream contribution is mlat-client's
+    # own --server connection, not Beast feedback into airplanes-feed.
+    if grep -q -- '127.0.0.1:30187' "$arg_log"; then
+        return 1
+    fi
 }
 
-@test "airplanes-mlat.sh: operator RESULTS= override suppresses the default bundle (no silent 30187 injection)" {
+@test "airplanes-mlat.sh: operator RESULTS= override suppresses the default bundle" {
     # If feed.env sets ANY of RESULTS / RESULTS1..4, the wrapper treats the
     # operator as the authority and uses ONLY their RESULTS* keys — no
-    # silent injection of the 30187 default. Pins the explicit-override
-    # contract for advanced operators and migrated legacy installs whose
-    # RESULTS= predates the dual-delivery design.
+    # silent stacking of the default endpoints on top.
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
@@ -1259,12 +1266,8 @@ SH
 
     [ "$status" -eq 0 ]
     grep -q -- '--results beast,connect,127.0.0.1:30104' "$arg_log"
-    # No silent injection of 30187, 31015, or 30157 — the operator override
-    # is the whole story. An operator who wants the dual-delivery design
-    # must opt in by setting RESULTS4 explicitly.
-    if grep -q -- '127.0.0.1:30187' "$arg_log"; then
-        return 1
-    fi
+    # No silent injection of the default endpoints — the operator override
+    # is the whole story.
     if grep -q -- 'basestation,listen,31015' "$arg_log"; then
         return 1
     fi

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -1222,7 +1222,7 @@ SH
     # listener and never reached the aggregator's globe (aether ingest
     # has no --forward-mlat). MLAT upstream contribution is mlat-client's
     # own --server connection, not Beast feedback into airplanes-feed.
-    if grep -q -- '127.0.0.1:30187' "$arg_log"; then
+    if grep -q -- '30187' "$arg_log"; then
         return 1
     fi
 }
@@ -1268,6 +1268,61 @@ SH
     grep -q -- '--results beast,connect,127.0.0.1:30104' "$arg_log"
     # No silent injection of the default endpoints — the operator override
     # is the whole story.
+    if grep -q -- 'basestation,listen,31015' "$arg_log"; then
+        return 1
+    fi
+    if grep -q -- 'beast,listen,30157' "$arg_log"; then
+        return 1
+    fi
+}
+
+@test "airplanes-mlat.sh: operator-set RESULTS4=...30187 survives the default-bundle guard" {
+    # Drop-30187 retention: an advanced operator who explicitly carries
+    # RESULTS4=...30187 in feed.env (e.g. piping MLAT into a non-airplanes.live
+    # downstream beast consumer) must keep it. The default block is gated
+    # on ALL of RESULTS / RESULTS1..4 being unset, so an explicit RESULTS4
+    # alone suppresses the default block — and the operator's argv survives.
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    local stub_bin="$ROOT_DIR/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+INPUT="127.0.0.1:30005"
+INPUT_TYPE="dump1090"
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35"
+MLAT_USER="custom-30187"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+MLATSERVER="feed.airplanes.live:31090"
+RESULTS4="--results beast,connect,127.0.0.1:30187"
+EOF
+    cat > "$stub_bin/nc" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$stub_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Operator's explicit RESULTS4 survives.
+    grep -q -- '--results beast,connect,127.0.0.1:30187' "$arg_log"
+    # Default-bundle guard: nothing from RESULTS / RESULTS2 / RESULTS3 is
+    # silently stacked on top.
+    if grep -q -- '127.0.0.1:30104' "$arg_log"; then
+        return 1
+    fi
     if grep -q -- 'basestation,listen,31015' "$arg_log"; then
         return 1
     fi


### PR DESCRIPTION
The 30187 Beast feedback path through `airplanes-feed` never reached the public globe and never has. aether-ingest doesn't run with `--forward-mlat`, so MLAT-tagged Beast frames received from feeders on 30004 don't propagate via `beast_reduce_out` (30006) into aether-api. MLAT contribution to the globe flows entirely through mlat-client's own `--server` connection to MLATSERVER (port 31090) into mlat-server; the Beast feed from this binary carries ADS-B only.

Drop the 30187 listener and `--forward-mlat` from both image and non-image `NET_OPTIONS` defaults, and drop `RESULTS4` from the mlat-client RESULTS bundle default. Local MLAT visualisation in tar1090/graphs1090 still works via `RESULTS=...30104` into the image-shipped readsb decoder. The 2.5-year-old `Connection refused` log lines in `airplanes-mlat` journals go away because mlat-client stops trying to talk to a port nothing was listening on.