### PR TITLE
fix(feed): bind 30187 to loopback by default; migrate legacy MLAT path

### DIFF
--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -72,13 +72,22 @@ FEED_BIN="${AIRPLANES_FEED_BIN:-$DEFAULT_FEED_BIN}"
 # in feed.env after configure.sh slimming) still produce a working
 # daemon. The image branch keeps its leaner FEED_NET_OPTIONS override
 # and adds FEED_IMAGE_OPTIONS for the baked-decoder case.
+#
+# --net-bind-address 127.0.0.1 binds --net-bi-port 30187 (the mlat-client
+# feedback listener) to loopback. Co-located airplanes-mlat reaches it via
+# 127.0.0.1, so the standard one-Pi topology is unaffected. To accept
+# Beast/MLAT injection from another host (rare cross-host topology),
+# override NET_OPTIONS in /etc/airplanes/feed.env to swap the bind to
+# 0.0.0.0 — the override replaces the default whole, same convention as
+# TARGET / JSON_OPTIONS / INPUT.
+#
+# --forward-mlat is required for MLAT frames received on --net-bi-port
+# 30187 to actually leave via the upstream beast_reduce_plus_out
+# connector. readsb gates Beast output on (!is_mlat || forward_mlat); the
+# flag defaults off. Without it, mlat-client delivers Beast results that
+# the feeder silently drops on the floor instead of forwarding upstream.
 TARGET="${TARGET:-"--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"}"
-# --forward-mlat is required for MLAT frames received on --net-bi-port 30187
-# to actually leave via the upstream beast_reduce_plus_out connector. readsb
-# gates Beast output on (!is_mlat || forward_mlat); the flag defaults off.
-# Without it, mlat-client delivers Beast results that the feeder silently
-# drops on the floor instead of forwarding to the aggregator.
-NET_OPTIONS="${NET_OPTIONS:-"--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --forward-mlat"}"
+NET_OPTIONS="${NET_OPTIONS:-"--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bind-address 127.0.0.1 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --forward-mlat"}"
 
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
     # --net-bi-port 30187 is the listener mlat-client (airplanes-mlat.sh)

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -107,6 +107,89 @@ migrate_net_options_beast_reduce_plus() {
     sed -i -e 's/beast_reduce_out,/beast_reduce_plus_out,/g' "$feed_env" || true
 }
 
+# Append --forward-mlat and ensure --net-bi-port includes 30187 in any
+# persisted legacy NET_OPTIONS in feed.env. The new airplanes-feed/mlat
+# wrappers route mlat-client RESULTS to 127.0.0.1:30187 and expect
+# --forward-mlat so readsb propagates MLAT frames through the upstream
+# beast_reduce_plus_out connector (readsb gates Beast output on
+# (!is_mlat || forward_mlat); default off). Legacy NET_OPTIONS predates
+# both knobs — the combined binary used to forward MLAT received on
+# 30104 inline — so an unmigrated legacy install silently stops
+# contributing MLAT after the wrapper update.
+#
+# Idempotent: no-op when both knobs are already present. Multi-line
+# backslash-continued NET_OPTIONS values (the legacy /etc/default/
+# airplanes shape) are normalized to single-line as a side effect of the
+# rewrite; that's necessary because the substring edits target a single
+# logical NET_OPTIONS= line.
+#
+# --net-bind-address is intentionally NOT touched. Legacy posture binds
+# all NET_OPTIONS listeners to 0.0.0.0 and operators may rely on that
+# for multi-host topologies (a separate decoder host pushing Beast in,
+# downstream consumers pulling Beast out). Tightening here would be a
+# silent breaking change. Fresh manual installs get loopback via the
+# wrapper default; migrated installs keep their pre-existing posture,
+# with 30187 inheriting the same unbound state as 30004/30104.
+#
+# Backup at $feed_env.pre-mlat-forwarding is written exactly once and
+# never overwritten so subsequent runs can't corrupt the original.
+migrate_net_options_mlat_forwarding() {
+    local feed_env="$1"
+    [[ -f "$feed_env" ]] || return 0
+    # No persisted NET_OPTIONS → wrapper default fires, which already
+    # includes both knobs (and loopback bind for fresh installs). Skip.
+    if ! grep -qE '^NET_OPTIONS=' "$feed_env"; then
+        return 0
+    fi
+
+    local has_forward_mlat=0 has_30187=0 has_bi_port=0
+    grep -q -- '--forward-mlat' "$feed_env" && has_forward_mlat=1
+    # \b30187\b is a whole-number match so 30187 isn't found inside
+    # 301870, 130187, etc. — defensive against pathological port lists.
+    if grep -qE -- '--net-bi-port[[:space:]]+[0-9,]*\b30187\b' "$feed_env"; then
+        has_30187=1
+        has_bi_port=1
+    elif grep -qE -- '--net-bi-port[[:space:]]+[0-9,]+' "$feed_env"; then
+        has_bi_port=1
+    fi
+
+    if [[ "$has_forward_mlat" == "1" && "$has_30187" == "1" ]]; then
+        return 0
+    fi
+
+    local backup="${feed_env}.pre-mlat-forwarding"
+    if [[ ! -f "$backup" ]]; then
+        cp -fp "$feed_env" "$backup"
+    fi
+
+    # Normalize multi-line backslash-continued NET_OPTIONS to single-line
+    # so the substring edits below work uniformly. The leading ^NET_OPTIONS=
+    # anchor scopes this to NET_OPTIONS only, leaving other backslash-
+    # continued values (if any) untouched. Loop via :a / ba until the
+    # collected line no longer ends with a continuation.
+    sed -i -e ':a' \
+        -e '/^NET_OPTIONS=/ { /\\[[:space:]]*$/ { N; s/\\[[:space:]]*\n[[:space:]]*/ /; ba } }' \
+        "$feed_env" || true
+
+    # Apply substring edits to the (now single-line) NET_OPTIONS value.
+    if [[ "$has_30187" == "0" ]]; then
+        if [[ "$has_bi_port" == "1" ]]; then
+            # Extend the existing comma-separated port list.
+            sed -i -E '/^NET_OPTIONS=/ s/(--net-bi-port[[:space:]]+[0-9,]+)/\1,30187/' "$feed_env" || true
+        else
+            # No --net-bi-port flag at all — append it inside the quoted
+            # NET_OPTIONS value. Matches NET_OPTIONS="...". Single-quoted
+            # or unquoted exotic forms are skipped (operator hand-edits
+            # beyond the legacy double-quoted convention apply manually).
+            sed -i -E '/^NET_OPTIONS=/ s/"([^"]*)"/"\1 --net-bi-port 30187"/' "$feed_env" || true
+        fi
+    fi
+
+    if [[ "$has_forward_mlat" == "0" ]]; then
+        sed -i -E '/^NET_OPTIONS=/ s/"([^"]*)"/"\1 --forward-mlat"/' "$feed_env" || true
+    fi
+}
+
 # Rewrite the legacy TARGET fallback host
 # feed.airplanes.live,64004 → feed2.airplanes.live,64004.
 migrate_target_fallback_host() {
@@ -453,6 +536,7 @@ run_config_file_migrations() {
         fi
     fi
     migrate_net_options_beast_reduce_plus "$feed_env"
+    migrate_net_options_mlat_forwarding "$feed_env"
     migrate_target_fallback_host "$feed_env"
     migrate_strip_uuid_file_arg "$feed_env"
     migrate_user_to_mlat_split "$feed_env"

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -136,25 +136,69 @@ migrate_net_options_beast_reduce_plus() {
 migrate_net_options_mlat_forwarding() {
     local feed_env="$1"
     [[ -f "$feed_env" ]] || return 0
+
+    # Normalize multi-line backslash-continued NET_OPTIONS to single-line
+    # FIRST so subsequent extraction sees the whole value. Anchor on
+    # ^NET_OPTIONS= so other backslash-continued values elsewhere in
+    # feed.env stay untouched. Loop via :a / ba until the collected line
+    # no longer ends with a continuation. Done unconditionally before the
+    # extract step below — an unnormalized multi-line value would be
+    # parsed as a truncated string and silently mishandled.
+    sed -i -e ':a' \
+        -e '/^NET_OPTIONS=/ { /\\[[:space:]]*$/ { N; s/\\[[:space:]]*\n[[:space:]]*/ /; ba } }' \
+        "$feed_env" || true
+
     # No persisted NET_OPTIONS → wrapper default fires, which already
     # includes both knobs (and loopback bind for fresh installs). Skip.
     if ! grep -qE '^NET_OPTIONS=' "$feed_env"; then
         return 0
     fi
 
-    local has_forward_mlat=0 has_30187=0 has_bi_port=0
-    grep -q -- '--forward-mlat' "$feed_env" && has_forward_mlat=1
-    # \b30187\b is a whole-number match so 30187 isn't found inside
-    # 301870, 130187, etc. — defensive against pathological port lists.
-    if grep -qE -- '--net-bi-port[[:space:]]+[0-9,]*\b30187\b' "$feed_env"; then
-        has_30187=1
-        has_bi_port=1
-    elif grep -qE -- '--net-bi-port[[:space:]]+[0-9,]+' "$feed_env"; then
-        has_bi_port=1
+    # Extract the ACTIVE NET_OPTIONS value (last occurrence wins, mirroring
+    # bash's source-order semantics). Checking the extracted value — not
+    # the whole file — keeps commented examples, stale lines, or other
+    # variables containing --forward-mlat / --net-bi-port 30187 from
+    # tricking the idempotency check into a silent no-op.
+    local current_value
+    current_value="$(_extract_env_value "$feed_env" NET_OPTIONS)"
+
+    local need_forward_mlat=0 need_30187_action="" existing_list=""
+    if [[ "$current_value" != *--forward-mlat* ]]; then
+        need_forward_mlat=1
+    fi
+    # Match --net-bi-port followed by a comma-separated port list. The
+    # ,30187, sentinel boundary check ensures 30187 inside 130187 or
+    # 301870 is not mistaken for our port — by padding the list with
+    # leading and trailing commas before comparing.
+    local port_list_re='--net-bi-port[[:space:]]+([0-9,]+)'
+    if [[ "$current_value" =~ $port_list_re ]]; then
+        existing_list="${BASH_REMATCH[1]}"
+        if [[ ",${existing_list}," == *,30187,* ]]; then
+            : # 30187 already present in the active value
+        else
+            need_30187_action="extend"
+        fi
+    else
+        need_30187_action="add"
     fi
 
-    if [[ "$has_forward_mlat" == "1" && "$has_30187" == "1" ]]; then
+    if [[ "$need_forward_mlat" == "0" && -z "$need_30187_action" ]]; then
         return 0
+    fi
+
+    # Build the new value in-memory so we don't rely on sed silently
+    # no-op'ing when the active line's quoting doesn't match a regex.
+    local new_value="$current_value"
+    case "$need_30187_action" in
+        extend)
+            new_value="${new_value/--net-bi-port ${existing_list}/--net-bi-port ${existing_list},30187}"
+            ;;
+        add)
+            new_value="$new_value --net-bi-port 30187"
+            ;;
+    esac
+    if [[ "$need_forward_mlat" == "1" ]]; then
+        new_value="$new_value --forward-mlat"
     fi
 
     local backup="${feed_env}.pre-mlat-forwarding"
@@ -162,32 +206,21 @@ migrate_net_options_mlat_forwarding() {
         cp -fp "$feed_env" "$backup"
     fi
 
-    # Normalize multi-line backslash-continued NET_OPTIONS to single-line
-    # so the substring edits below work uniformly. The leading ^NET_OPTIONS=
-    # anchor scopes this to NET_OPTIONS only, leaving other backslash-
-    # continued values (if any) untouched. Loop via :a / ba until the
-    # collected line no longer ends with a continuation.
-    sed -i -e ':a' \
-        -e '/^NET_OPTIONS=/ { /\\[[:space:]]*$/ { N; s/\\[[:space:]]*\n[[:space:]]*/ /; ba } }' \
-        "$feed_env" || true
-
-    # Apply substring edits to the (now single-line) NET_OPTIONS value.
-    if [[ "$has_30187" == "0" ]]; then
-        if [[ "$has_bi_port" == "1" ]]; then
-            # Extend the existing comma-separated port list.
-            sed -i -E '/^NET_OPTIONS=/ s/(--net-bi-port[[:space:]]+[0-9,]+)/\1,30187/' "$feed_env" || true
-        else
-            # No --net-bi-port flag at all — append it inside the quoted
-            # NET_OPTIONS value. Matches NET_OPTIONS="...". Single-quoted
-            # or unquoted exotic forms are skipped (operator hand-edits
-            # beyond the legacy double-quoted convention apply manually).
-            sed -i -E '/^NET_OPTIONS=/ s/"([^"]*)"/"\1 --net-bi-port 30187"/' "$feed_env" || true
-        fi
-    fi
-
-    if [[ "$has_forward_mlat" == "0" ]]; then
-        sed -i -E '/^NET_OPTIONS=/ s/"([^"]*)"/"\1 --forward-mlat"/' "$feed_env" || true
-    fi
+    # Atomic rewrite: strip all NET_OPTIONS= lines and append the new
+    # value as a double-quoted KEY=VALUE pair. Metachar-escape pattern
+    # mirrors migrate_user_to_mlat_split so unusual operator-supplied
+    # content survives sourcing without command/parameter expansion.
+    local tmp escaped
+    tmp="$(mktemp "${feed_env}.XXXXXX")"
+    grep -vE '^NET_OPTIONS=' "$feed_env" > "$tmp" || true
+    escaped="${new_value//\\/\\\\}"
+    escaped="${escaped//\$/\\\$}"
+    escaped="${escaped//\`/\\\`}"
+    escaped="${escaped//\"/\\\"}"
+    printf 'NET_OPTIONS="%s"\n' "$escaped" >> "$tmp"
+    chmod --reference="$feed_env" "$tmp" 2>/dev/null || true
+    chown --reference="$feed_env" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$feed_env"
 }
 
 # Rewrite the legacy TARGET fallback host

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -1303,3 +1303,91 @@ SH
         return 1
     fi
 }
+
+# ---------------------------------------------------------------------------
+# airplanes-feed.sh — non-image branch (manual install + legacy bridge)
+# ---------------------------------------------------------------------------
+# The image-mode tests above pin the IMAGE_INSTALL=1 path (where the image
+# baked-in airplanes-feeder binary exists). These tests cover the else
+# branch (IMAGE_INSTALL=0): manual installs via curl install.sh on bare
+# Debian/Ubuntu/Pi OS, and legacy-image installs migrated to feed/dev via
+# the airplanes-update bridge. Both share the combined feed-airplanes
+# binary and read NET_OPTIONS from feed.env (or fall back to the wrapper
+# default).
+
+# Fixture helper: set up a non-image rootfs with the operator-data keys
+# airplanes-feed.sh needs. Does NOT create /usr/bin/airplanes-feeder so
+# IMAGE_INSTALL stays 0. Caller installs a stub binary at AIRPLANES_FEED_BIN.
+write_non_image_config() {
+    local root="$1"
+    mkdir -p "$root/etc/airplanes"
+    cat > "$root/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+LONGITUDE="13.40"
+ALTITUDE="35"
+MLAT_USER="non-image-feeder"
+MLAT_ENABLED=true
+MLAT_PRIVATE=false
+EOF
+}
+
+@test "airplanes-feed.sh non-image: wrapper default opens loopback-bound 30187 with --forward-mlat" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/non-image-args.log"
+    local stub_bin="$ROOT_DIR/feed-airplanes-stub"
+    write_non_image_config "$root"
+    cat > "$stub_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        AIRPLANES_FEED_BIN="$stub_bin" \
+        bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # MLAT-feedback listener bound to loopback. Reason this PR exists:
+    # prior to the bind-tightening, 30187 listened on 0.0.0.0 in the
+    # non-image default and any LAN host could inject MLAT-tagged Beast
+    # frames attributed to this feeder upstream (now that --forward-mlat
+    # is on).
+    grep -q -- '--net-bi-port 30187' "$arg_log"
+    grep -q -- '--net-bind-address 127.0.0.1' "$arg_log"
+    grep -q -- '--forward-mlat' "$arg_log"
+}
+
+@test "airplanes-feed.sh non-image: operator-set NET_OPTIONS passes through verbatim (no bind-address injection)" {
+    # Escape-hatch contract: an operator override of NET_OPTIONS in
+    # feed.env replaces the wrapper's default whole. The wrapper MUST NOT
+    # silently inject --net-bind-address 127.0.0.1 into operator-supplied
+    # values. This preserves multi-host topologies — an operator pushing
+    # Beast/MLAT from another host on the LAN to this feeder's 30187 can
+    # opt back into 0.0.0.0 binding by overriding NET_OPTIONS.
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/non-image-override-args.log"
+    local stub_bin="$ROOT_DIR/feed-airplanes-override-stub"
+    write_non_image_config "$root"
+    cat >> "$root/etc/airplanes/feed.env" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30187 --forward-mlat --net-bind-address 0.0.0.0"
+EOF
+    cat > "$stub_bin" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$stub_bin"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        AIRPLANES_FEED_BIN="$stub_bin" \
+        bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Operator's explicit bind survives.
+    grep -q -- '--net-bind-address 0.0.0.0' "$arg_log"
+    # The loopback default does NOT appear — wrapper used the override whole.
+    if grep -q -- '--net-bind-address 127.0.0.1' "$arg_log"; then
+        return 1
+    fi
+}

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -850,3 +850,169 @@ EOF
     [ "$(jq -r '.fields.MLAT_USER.edited_by' "$META")" = "legacy" ]
 }
 
+# ---------------------------------------------------------------------------
+# migrate_net_options_mlat_forwarding
+# ---------------------------------------------------------------------------
+
+@test "migrate_net_options_mlat_forwarding: no feed.env → no-op" {
+    rm -f "$FEED_ENV"
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    [ ! -f "$FEED_ENV" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: feed.env without NET_OPTIONS → no-op" {
+    # Fresh manual install relies on the wrapper default (which already
+    # includes both knobs + loopback bind). Nothing to migrate.
+    cat > "$FEED_ENV" <<'EOF'
+INPUT="127.0.0.1:30005"
+LATITUDE="52.5"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    ! grep -q -- '--forward-mlat' "$FEED_ENV"
+    ! grep -q -- '--net-bi-port' "$FEED_ENV"
+    [ ! -f "${FEED_ENV}.pre-mlat-forwarding" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: legacy single-line NET_OPTIONS gets both knobs appended" {
+    # Canonical legacy /etc/default/airplanes shape after migration via cp.
+    # 30004,30104 was the legacy bi-port pair; 30187 is the new MLAT-feedback
+    # listener. --forward-mlat was never set in legacy NET_OPTIONS.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-heartbeat 60 --net-ri-port 30001 --net-ro-port 30002 --net-sbs-port 30003 --net-bi-port 30004,30104 --net-bo-port 30005"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -q -- '--net-bi-port 30004,30104,30187' "$FEED_ENV"
+    grep -q -- '--forward-mlat' "$FEED_ENV"
+    # Existing port list members preserved.
+    grep -q -- '--net-bo-port 30005' "$FEED_ENV"
+    grep -q -- '--net-ri-port 30001' "$FEED_ENV"
+    # Backup written.
+    [ -f "${FEED_ENV}.pre-mlat-forwarding" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: legacy multi-line NET_OPTIONS gets normalized + both knobs appended" {
+    # The verbatim shape from airplanes-update/boot-configs/airplanes-env.
+    # cp -fp preserves multi-line; the migration normalizes to single-line
+    # as a side effect of the rewrite.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-heartbeat 60 --net-ro-size 1200 --net-ro-interval 0.1 \
+        --net-ri-port 30001 --net-ro-port 30002 --net-sbs-port 30003 \
+        --net-bi-port 30004,30104 --net-bo-port 30005"
+INPUT="127.0.0.1:30005"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    # After migration, NET_OPTIONS is single-line.
+    [ "$(grep -c '^NET_OPTIONS=' "$FEED_ENV")" = "1" ]
+    # No backslash-continuation remains in the file (would be a sign the
+    # join didn't happen).
+    if grep -qE '\\$' "$FEED_ENV"; then
+        return 1
+    fi
+    # Knobs appended.
+    grep -q -- '--net-bi-port 30004,30104,30187' "$FEED_ENV"
+    grep -q -- '--forward-mlat' "$FEED_ENV"
+    # Other keys (INPUT) unaffected.
+    grep -q '^INPUT="127.0.0.1:30005"$' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: NET_OPTIONS already has --forward-mlat + 30187 → no-op" {
+    # Operator already hand-edited (or migration already applied). Must
+    # not duplicate the appends.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30004,30104,30187 --forward-mlat"
+EOF
+    local before
+    before="$(cat "$FEED_ENV")"
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    [ "$(cat "$FEED_ENV")" = "$before" ]
+    [ ! -f "${FEED_ENV}.pre-mlat-forwarding" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: idempotent — running twice is identical to running once" {
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30004,30104 --net-bo-port 30005"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    local after_once
+    after_once="$(cat "$FEED_ENV")"
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    [ "$(cat "$FEED_ENV")" = "$after_once" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: NET_OPTIONS without --net-bi-port at all → flag appended" {
+    # Operator may have hand-stripped --net-bi-port. Migration adds it
+    # rather than trying to be clever about preserving operator intent.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-heartbeat 60 --net-ro-port 0"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -q -- '--net-bi-port 30187' "$FEED_ENV"
+    grep -q -- '--forward-mlat' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: NET_OPTIONS has 30187 but lacks --forward-mlat → only --forward-mlat appended" {
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30187 --net-bo-port 30005"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -q -- '--forward-mlat' "$FEED_ENV"
+    # 30187 not duplicated.
+    [ "$(grep -o -- '30187' "$FEED_ENV" | wc -l)" = "1" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: NET_OPTIONS has --forward-mlat but lacks 30187 → only 30187 added to bi-port list" {
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30004,30104 --forward-mlat"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -q -- '--net-bi-port 30004,30104,30187' "$FEED_ENV"
+    # --forward-mlat not duplicated.
+    [ "$(grep -o -- '--forward-mlat' "$FEED_ENV" | wc -l)" = "1" ]
+}
+
+@test "migrate_net_options_mlat_forwarding: 30187 boundary match — port list with 130187 does not skip the migration" {
+    # Pathological port-list with 130187 must not match \b30187\b. The
+    # migration should still recognize 30187 as absent and extend.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 130187,30104"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -q -- '--net-bi-port 130187,30104,30187' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: does NOT touch --net-bind-address (preserves legacy 0.0.0.0 posture)" {
+    # Migrated installs keep their pre-existing bind posture. A legacy
+    # NET_OPTIONS without --net-bind-address stays without it after
+    # migration — only the MLAT knobs are appended.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30004,30104"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    ! grep -q -- '--net-bind-address' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: preserves an existing operator-set --net-bind-address" {
+    # If the operator set their own bind-address (loopback or other), the
+    # migration leaves it alone.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bind-address 10.0.0.5 --net-bi-port 30004,30104"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -q -- '--net-bind-address 10.0.0.5' "$FEED_ENV"
+    grep -q -- '--net-bi-port 30004,30104,30187' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: backup written once and never overwritten" {
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS="--net --net-bi-port 30004,30104"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    local first_backup_mtime
+    first_backup_mtime="$(stat -c '%Y' "${FEED_ENV}.pre-mlat-forwarding")"
+    # Mutate feed.env, run again, confirm backup unchanged.
+    sleep 1
+    printf 'NET_OPTIONS="--changed"\n' > "$FEED_ENV"
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    [ "$(stat -c '%Y' "${FEED_ENV}.pre-mlat-forwarding")" = "$first_backup_mtime" ]
+}
+

--- a/test/test_migrations.bats
+++ b/test/test_migrations.bats
@@ -1002,6 +1002,41 @@ EOF
     grep -q -- '--net-bi-port 30004,30104,30187' "$FEED_ENV"
 }
 
+@test "migrate_net_options_mlat_forwarding: commented --forward-mlat does NOT trick idempotency into skipping" {
+    # Detection must look at the ACTIVE NET_OPTIONS value, not the whole
+    # file. A pre-migration feed.env with a comment line that happens to
+    # mention --forward-mlat must still trigger the migration on the
+    # actual NET_OPTIONS line below.
+    cat > "$FEED_ENV" <<'EOF'
+# Note: --forward-mlat was historically off; we now enable it.
+NET_OPTIONS="--net --net-bi-port 30004,30104"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    # Active NET_OPTIONS now has the appends.
+    grep -qE '^NET_OPTIONS=.*--forward-mlat' "$FEED_ENV"
+    grep -qE '^NET_OPTIONS=.*30187' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: commented --net-bi-port 30187 does NOT trick idempotency into skipping" {
+    cat > "$FEED_ENV" <<'EOF'
+# Old shape: NET_OPTIONS="--net-bi-port 30187,30004,30104"
+NET_OPTIONS="--net --net-bi-port 30004,30104 --forward-mlat"
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -qE '^NET_OPTIONS=.*--net-bi-port 30004,30104,30187' "$FEED_ENV"
+}
+
+@test "migrate_net_options_mlat_forwarding: single-quoted NET_OPTIONS still gets the appends (extract-modify-rewrite)" {
+    # The extract-modify-rewrite refactor handles single-quoted shapes
+    # that the original sed-substring pass would have silently skipped.
+    # Re-emitted as double-quoted, matching the canonical schema.
+    cat > "$FEED_ENV" <<'EOF'
+NET_OPTIONS='--net --net-bi-port 30004,30104'
+EOF
+    migrate_net_options_mlat_forwarding "$FEED_ENV"
+    grep -qE '^NET_OPTIONS="--net --net-bi-port 30004,30104,30187 --forward-mlat"$' "$FEED_ENV"
+}
+
 @test "migrate_net_options_mlat_forwarding: backup written once and never overwritten" {
     cat > "$FEED_ENV" <<'EOF'
 NET_OPTIONS="--net --net-bi-port 30004,30104"


### PR DESCRIPTION
The image-mode wrapper already binds the MLAT-feedback listener (`:30187`) to `127.0.0.1`, but the non-image `NET_OPTIONS` default exposed it on `0.0.0.0`. With `--forward-mlat` enabled, any LAN host could inject MLAT-tagged Beast frames attributed to this feeder upstream. The default is now loopback-bound; operator overrides via `NET_OPTIONS` in feed.env still win.

Legacy-bridge migrations carried the legacy boot-config `NET_OPTIONS` into feed.env verbatim, which predates both `--forward-mlat` and the `30187` listener — those installs silently stopped contributing MLAT after the wrapper update. A new migration appends both knobs idempotently and normalizes multi-line legacy values to single-line. `--net-bind-address` is intentionally not touched: the legacy posture binds all listeners to `0.0.0.0` and operators may rely on that for multi-host topologies.

Advanced operators who want to accept Beast/MLAT injection from another host can override `NET_OPTIONS` in `/etc/airplanes/feed.env`:

```
NET_OPTIONS="--net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30187 --net-bo-port 0 --net-ri-port 0 --forward-mlat --net-bind-address 0.0.0.0"
```

then `sudo systemctl restart airplanes-feed`. Single-bag escape hatch, same convention as TARGET / JSON_OPTIONS / INPUT.