### PR TITLE
Omit dump978-fa from diagnostics when UAT is not configured

### DIFF
--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -669,16 +669,18 @@ main() {
         svc_feed="$(build_service_json airplanes-feed)"
         svc_mlat="$(build_service_json airplanes-mlat "$(root_path /run/airplanes-mlat/state)")"
         svc_readsb="$(build_service_json readsb)"
-        svc_dump978="$(build_service_json dump978-fa "$(root_path /run/dump978-fa/state)")"
-        # airplanes-978 is the readsb UAT instance — only relevant when
-        # the user has actually configured UAT. Without this gate, every
-        # non-UAT feeder would report an idle airplanes-978 unit and add
-        # noise to the dashboard. Globally most users don't have a 978
-        # dongle so the chip stays hidden until they wire one up.
+        # dump978-fa and airplanes-978 are both UAT-only — relevant only
+        # when the user has actually configured UAT. Without this gate,
+        # any feeder with the dump978-fa unit installed would report an
+        # idle service and add a stale warning chip to the dashboard.
+        # Most feeders don't have a 978 dongle, so the chips stay hidden
+        # until the user wires one up.
         local uat_input
         uat_input="$(feed_env_get UAT_INPUT 2>/dev/null || true)"
+        svc_dump978='null'
         svc_978='null'
         if [[ -n "$uat_input" ]]; then
+            svc_dump978="$(build_service_json dump978-fa "$(root_path /run/dump978-fa/state)")"
             svc_978="$(build_service_json airplanes-978 "$(root_path /run/airplanes-978/state)")"
         fi
 

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -858,6 +858,8 @@ _write_state_file() {
 }
 
 @test "POST body service entry carries disabled,no_hardware for dump978-fa" {
+    printf 'REPORT_STATUS=true\nUAT_INPUT=127.0.0.1:30978\n' \
+        > "$ROOT_DIR/etc/airplanes/feed.env"
     cat > "$STUB_DIR/systemctl" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
@@ -876,6 +878,30 @@ SH
     [ "$output" = 'disabled' ]
     run jq -er '.services[] | select(.name=="dump978-fa") | .reason' "$BODY_LOG"
     [ "$output" = 'no_hardware' ]
+}
+
+@test "POST body omits dump978-fa when UAT_INPUT is empty" {
+    # Default feed.env has REPORT_STATUS=true and no UAT_INPUT. The
+    # dump978-fa unit is installed and would otherwise show as
+    # inactive/dead in the payload, surfacing a stale warning chip on
+    # a feeder that never opted in to UAT.
+    cat > "$STUB_DIR/systemctl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+    "show airplanes-feed "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    "show airplanes-mlat "*) printf 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nSubState=running\nNRestarts=0\n' ;;
+    # The collector must not even probe dump978-fa when UAT is off —
+    # if it does, this stub would emit it and the assertion below fails.
+    "show dump978-fa "*) printf 'LoadState=loaded\nUnitFileState=disabled\nActiveState=inactive\nSubState=dead\nNRestarts=0\n' ;;
+    *) ;;
+esac
+exit 0
+SH
+    chmod +x "$STUB_DIR/systemctl"
+    run_script
+    [ "$status" -eq 0 ]
+    run jq -er '.services | map(select(.name=="dump978-fa")) | length' "$BODY_LOG"
+    [ "$output" = '0' ]
 }
 
 @test "POST body omits state/reason when state file is missing" {


### PR DESCRIPTION
The diagnostics payload already gated `airplanes-978` on `UAT_INPUT` but emitted `dump978-fa` unconditionally. Any feeder with the dump978-fa unit installed (legacy images carry the FlightAware unit; new images install it too) and no 978 dongle configured was reporting an inactive service, which surfaced as a stale warning chip on the feeder dashboard.

Apply the same UAT_INPUT gate to dump978-fa so both 978-related services are reported iff the user has actually opted in to UAT.