### PR TITLE
Fix apl-feed status crash on jq 1.6 (deployed Pi OS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,46 @@ jobs:
       - name: Run bats suite
         run: bats test/
 
+  unit-tests-jq16:
+    # Pi OS bullseye/bookworm (the deployed fleet) ships jq 1.6. CI
+    # runners default to jq 1.7+, which is more permissive about reserved
+    # keywords used as `--arg` variable names. Bugs of that shape compile
+    # cleanly under 1.7 but fail at parse time on every deployed feeder.
+    # This job runs the full bats suite against a vendored jq 1.6 so
+    # version-sensitive regressions are caught before they ship.
+    name: unit tests (jq 1.6, fleet-compat)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install bats, curl, python3 (no system jq)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats curl python3
+
+      - name: Install jq 1.6 (Pi OS fleet version)
+        run: |
+          set -euo pipefail
+          # Pinned to the jq 1.6 release asset on jqlang/jq. The SHA-256
+          # check below catches any future asset replacement; a removed
+          # asset surfaces as a curl failure.
+          sudo curl -fsSL \
+            -o /usr/local/bin/jq \
+            https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64
+          sudo chmod +x /usr/local/bin/jq
+          echo 'af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  /usr/local/bin/jq' \
+            | sha256sum -c -
+          hash -r
+          jq --version
+          test "$(jq --version)" = "jq-1.6"
+
+      - name: Run bats suite
+        run: bats test/
+
   script-install:
     name: script install (${{ matrix.image_label }}, ${{ matrix.path }})
     runs-on: ubuntu-24.04

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -68,11 +68,15 @@ status_line() {
     esac
 
     if [[ -n "$STATUS_CHECKS_FILE" ]]; then
+        # `label` is a jq 1.6 keyword (used for label/break flow), so using
+        # it as a jq variable name fails to compile on Pi OS bullseye and
+        # bookworm. jq 1.7+ accepts it. The output JSON key is still
+        # `label`; only the jq variable is renamed.
         jq -nc \
             --arg state "$state" \
-            --arg label "$label" \
+            --arg label_text "$label" \
             --arg detail "$detail" \
-            '{state:$state,label:$label,detail:$detail}' \
+            '{state:$state,label:$label_text,detail:$detail}' \
             >> "$STATUS_CHECKS_FILE"
     fi
 

--- a/test/test_jq_arg_keyword_lint.bats
+++ b/test/test_jq_arg_keyword_lint.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# Lint test: refuse `--arg` / `--argjson` invocations that use a jq reserved
+# keyword as the variable name. jq 1.6 (Pi OS bullseye/bookworm default)
+# rejects `$<keyword>` references at parse time with
+# `syntax error, unexpected <keyword>, expecting IDENT or __loc__`,
+# even though jq 1.7+ accepts the same expression. Without this guard,
+# such bugs slip through CI (which uses jq 1.7) and surface only on
+# deployed feeders.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
+@test "no --arg or --argjson uses a jq reserved keyword as variable name" {
+    # jq parser keywords (1.6 + 1.7) plus the __loc__ built-in. Sorted
+    # alphabetically. Includes `break` because jq's lexer treats it as a
+    # token alongside `label`.
+    local keywords='__loc__|and|as|break|catch|def|elif|else|end|false|foreach|if|import|include|label|module|not|null|or|reduce|then|true|try'
+
+    # Match `--arg name` or `--argjson name` where `name` is the bare
+    # keyword (optionally single- or double-quoted, since `--arg "label"
+    # "$x"` would also break jq 1.6), followed by a non-word boundary
+    # (space, newline, end-of-line) — not by `_` or letters, so
+    # `label_text` is fine and only the bare keyword is flagged.
+    local pattern="--arg(json)?[[:space:]]+[\"']?(${keywords})[\"']?([[:space:]]|\$)"
+
+    # Pass the pattern via `-e` so grep doesn't try to interpret the leading
+    # `--` as its own option terminator — otherwise grep parses `--arg…` as
+    # a flag, errors out, and `|| true` silently turns the lint into a no-op.
+    local matches
+    matches="$(
+        grep -rnE -e "$pattern" "$REPO_ROOT" \
+            --include='*.sh' \
+            --include='*.bats' \
+            --exclude-dir=.git \
+            --exclude-dir=.claude \
+            --exclude='test_jq_arg_keyword_lint.bats' \
+            || true
+    )"
+
+    if [[ -n "$matches" ]]; then
+        printf '\njq --arg/--argjson uses a reserved keyword as variable name:\n%s\n' "$matches" >&2
+        printf '\nRename the variable (e.g. label -> label_text). The JSON output key can stay the same.\n' >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
`apl-feed status` crashes on every deployed Raspberry Pi feeder with `jq: error: syntax error, unexpected label, expecting IDENT or __loc__`. The cause: jq 1.6 (Pi OS bullseye/bookworm default) treats `label` as a reserved keyword (for jq's `label $x | … | break $x` flow), so `--arg label "$value"` then `$label` is rejected at parse time. jq 1.7 (CI runner default) silently accepts it, so the bug never surfaced.

Rename the jq variable from `$label` to `$label_text`; the output JSON key stays `label`. Add a new CI job that runs the full bats suite under a vendored jq 1.6 binary (SHA-pinned) to lock in fleet compatibility for future regressions, plus a static lint that rejects `--arg <jq-keyword>` patterns at the source-tree level.