### PR TITLE
fix(claim): clarify ambiguous "Version:" line in CLI output

### DIFF
--- a/scripts/apl-feed/backup.sh
+++ b/scripts/apl-feed/backup.sh
@@ -210,7 +210,7 @@ config_restore() {
             echo "Created: $BACKUP_CREATED_AT"
         fi
         if [[ -n "$BACKUP_VERSION" ]]; then
-            echo "Version: $BACKUP_VERSION"
+            echo "Secret version: $BACKUP_VERSION"
         fi
         echo "Claim secret: present"
         return 0

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -220,7 +220,7 @@ claim_show() {
     echo "Claim secret: $(display_secret "$secret")"
     echo "Claim page: $(claim_page_url)"
     if version="$(read_version_file 2>/dev/null)"; then
-        echo "Version: $version"
+        echo "Secret version: $version"
     fi
 }
 


### PR DESCRIPTION
The `Version:` line printed by `apl-feed claim show` and `apl-feed restore --check` is the claim-secret rotation version, but the bare label collides with feed software, image, schema, and API versioning concepts. A user landing on the output cannot tell which "version" is being shown.

Rename it to `Secret version:` so the value visually bonds to the `Claim secret:` line above it and matches how the same field is named in `apl-feed status --json` (`.claim.version`) and the backup JSON (`.claim.version`).
