### PR TITLE
Fix DNS race at boot: wait for network-online.target in feed and mlat units

### DIFF
--- a/scripts/airplanes-feed.service
+++ b/scripts/airplanes-feed.service
@@ -1,8 +1,8 @@
 
 [Unit]
 Description=airplanes-feed
-Wants=network.target
-After=network.target airplanes-first-run.service
+Wants=network-online.target
+After=network-online.target airplanes-first-run.service
 
 [Service]
 User=airplanes-feed

--- a/scripts/airplanes-mlat.service
+++ b/scripts/airplanes-mlat.service
@@ -1,8 +1,8 @@
 
 [Unit]
 Description=airplanes-mlat
-Wants=network.target
-After=network.target airplanes-first-run.service
+Wants=network-online.target
+After=network-online.target airplanes-first-run.service
 
 [Service]
 User=airplanes-feed


### PR DESCRIPTION
Both `airplanes-feed` and `airplanes-mlat` make outbound connections to `feed.airplanes.live` and need DNS to be reachable before they start. `network.target` only signals that the networking subsystem is initialised — it does not wait for a resolver. The result at boot is a burst of "Temporary failure in name resolution" log entries before the daemon self-recovers.

Switching to `network-online.target` matches what `airplanes-claim`, `airplanes-config-sync`, and `airplanes-diagnostics` already declare. On this image NetworkManager-wait-online is already pulled into boot by the claim service, so there is no added boot delay.