### PR TITLE
Require airplanes-uuid compat symlink only on the legacy contract

### DIFF
--- a/test/image-boot.sh
+++ b/test/image-boot.sh
@@ -784,8 +784,20 @@ assert_image_contracts() {
         assert_file /etc/airplanes/feed.env
     fi
     assert_valid_uuid_file /etc/airplanes/feeder-id
-    assert_symlink_target /usr/local/share/airplanes/airplanes-uuid '../../../../etc/airplanes/feeder-id'
+    # The /usr/local/share/airplanes/airplanes-uuid -> feeder-id compat symlink
+    # is required only on the legacy contract. create-uuid.sh lays it down on
+    # any install path that runs update.sh; the overlay-managed new image
+    # instead generates the canonical /etc/airplanes/feeder-id inline at first
+    # boot and deliberately does NOT ship the legacy symlink (the image's own
+    # overlay smoke asserts its absence). We assert presence only on legacy
+    # rather than asserting absence on new, because a hypothetical non-overlay
+    # new install would still run update.sh and create the symlink — the
+    # invariant that actually holds is "required on legacy", not "forbidden on
+    # new". apl-feed resolves feeder-id from the canonical path first
+    # (common.sh's resolver), so the symlink is a back-compat shim, not a
+    # functional dependency on the new contract.
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
+        assert_symlink_target /usr/local/share/airplanes/airplanes-uuid '../../../../etc/airplanes/feeder-id'
         assert_exec /usr/bin/airplanes-feeder
     else
         assert_exec /usr/local/share/airplanes/feed-airplanes


### PR DESCRIPTION
The boot-smoke harness required `/usr/local/share/airplanes/airplanes-uuid` to be a symlink to `feeder-id` on every contract. That symlink is created by `create-uuid.sh` on installs that run `update.sh`. The overlay-managed image generates the canonical `/etc/airplanes/feeder-id` inline at first boot and deliberately omits the legacy symlink — the image's own overlay smoke asserts its absence on that contract. The harness assertion was only passing because the boot smoke used to run `update.sh`; now that the overlay guard correctly stops it, the new-contract boot smoke fails on a back-compat shim it never ships.

Scope the assertion to the legacy contract. `apl-feed` resolves the feeder ID from the canonical path first and only falls back to the legacy paths, so the symlink isn't a functional dependency on the new contract. The check asserts presence on legacy rather than absence on new, since a non-overlay install that still runs `update.sh` would legitimately create it — the invariant that holds is "required on legacy", not "forbidden on new".
