### PR TITLE
Require installed update.sh only on the legacy contract

### DIFF
--- a/test/image-boot.sh
+++ b/test/image-boot.sh
@@ -799,11 +799,17 @@ assert_image_contracts() {
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
         assert_symlink_target /usr/local/share/airplanes/airplanes-uuid '../../../../etc/airplanes/feeder-id'
         assert_exec /usr/bin/airplanes-feeder
+        # update.sh installs itself to IPATH on any install path that runs it.
+        # The overlay-managed new image deliberately does NOT ship update.sh:
+        # overlay-managed feeders update via the runtime-overlay orchestrator,
+        # and update.sh refuses to run there anyway (overlay guard, EX_CONFIG).
+        # It is neither staged into the overlay tree nor a managed_paths entry.
+        # Required only on the legacy contract.
+        assert_file /usr/local/share/airplanes/update.sh
     else
         assert_exec /usr/local/share/airplanes/feed-airplanes
     fi
     assert_exec /usr/local/bin/apl-feed
-    assert_file /usr/local/share/airplanes/update.sh
     assert_file /usr/local/share/airplanes/airplanes-feed.sh
     assert_file /usr/local/share/airplanes/airplanes-mlat.sh
     assert_file /usr/local/share/airplanes/apl-feed/common.sh


### PR DESCRIPTION
The boot-smoke harness required an installed `/usr/local/share/airplanes/update.sh` on every image contract. `update.sh` self-installs to that path on any install that runs it, so the assertion only passed on the new contract because the smoke used to run `update.sh` itself. The overlay-managed image deliberately omits `update.sh` — it's neither staged into the overlay tree nor a managed-paths entry, overlay feeders update via the runtime-overlay orchestrator, and `update.sh` refuses to run on an overlay-managed root anyway. With the overlay guard correctly stopping that invocation, the new-contract boot smoke fails on a file the image never ships.

Scope the assertion to the legacy contract, alongside the other legacy-only install artifacts. A full pass over `assert_image_contracts` against the overlay image's managed paths and staging confirms this is the last assertion that was only satisfied by `update.sh` running during the smoke; every other path is overlay-symlinked, image-baked, or generated at first boot.
