### PR TITLE
Fix config-sync first-boot namespace failure on a fresh feeder

### DIFF
--- a/scripts/airplanes-config-sync.service
+++ b/scripts/airplanes-config-sync.service
@@ -13,4 +13,13 @@ NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
-ReadWritePaths=/var/lib/airplanes /etc/airplanes /run
+# Own state directory for the success-mtime sentinel. systemd creates a
+# StateDirectory= before it sets up the mount namespace and adds it to the
+# writable set automatically, so the unit no longer depends on
+# airplanes-diagnostics' StateDirectory having created /var/lib/airplanes
+# first. The first config-sync.timer tick used to fail namespace setup
+# ("/var/lib/airplanes: No such file or directory") when it fired before
+# diagnostics ever ran.
+StateDirectory=airplanes-config-sync
+StateDirectoryMode=0755
+ReadWritePaths=/etc/airplanes /run

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -54,8 +54,12 @@ _config_sync_parse_opt_in() {
     esac
 }
 
-# Sentinel mtime path. Overridable for tests + chroot smokes.
-CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-/var/lib/airplanes/config-sync-last-success}"
+# Sentinel mtime path. Overridable for tests + chroot smokes. Defaults to the
+# unit's own StateDirectory (airplanes-config-sync.service:StateDirectory=),
+# which systemd exports as $STATE_DIRECTORY at runtime so the path tracks the
+# unit without drift; the literal fallback covers manual / chroot invocations
+# where the unit env isn't present.
+CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-${STATE_DIRECTORY:-/var/lib/airplanes-config-sync}/config-sync-last-success}"
 
 # Structured logger. Mirrors airplanes-diagnostics.sh's `log` so the two
 # timers produce a uniform journal stream.

--- a/test/test_apl_feed_config_sync.bats
+++ b/test/test_apl_feed_config_sync.bats
@@ -69,7 +69,7 @@ STUB
         > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
     chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
 
-    AIRPLANES_CONFIG_SYNC_LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes/config-sync-last-success"
+    AIRPLANES_CONFIG_SYNC_LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes-config-sync/config-sync-last-success"
     export AIRPLANES_CONFIG_SYNC_LAST_SUCCESS
 }
 
@@ -716,4 +716,18 @@ EOF
     grep -F 'LATITUDE="47.0"' "$ROOT_DIR/etc/airplanes/feed.env"
     grep -F 'LONGITUDE="8.0"' "$ROOT_DIR/etc/airplanes/feed.env"
     echo "$SYNC_ERR" | grep -F 'reason=position_group_skipped_by_lww'
+}
+
+@test "airplanes-config-sync.service owns its StateDirectory, not the shared /var/lib/airplanes" {
+    # Regression guard for the first-boot race: the unit must provision its own
+    # StateDirectory (created by systemd before the mount namespace) instead of
+    # depending on airplanes-diagnostics having created /var/lib/airplanes. A
+    # ReadWritePaths= bind to a not-yet-existent /var/lib/airplanes fails
+    # namespace setup (status=226/NAMESPACE) when config-sync.timer fires first.
+    local unit="$REPO_ROOT/scripts/airplanes-config-sync.service"
+    run grep -qE '^StateDirectory=airplanes-config-sync$' "$unit"
+    [ "$status" -eq 0 ]
+    run grep -E '^ReadWritePaths=' "$unit"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"/var/lib/airplanes"* ]]
 }

--- a/test/test_install_uninstall_symmetry.bats
+++ b/test/test_install_uninstall_symmetry.bats
@@ -136,6 +136,12 @@ stage_install_footprint() {
     mkdir -p "$ROOT_DIR/var/lib/airplanes"
     : > "$ROOT_DIR/var/lib/airplanes/diagnostics-last-success"
 
+    # Config-sync state directory — its own StateDirectory=airplanes-config-sync
+    # (separate from diagnostics so the two oneshots never re-chown a shared
+    # dir). uninstall.sh wipes it too.
+    mkdir -p "$ROOT_DIR/var/lib/airplanes-config-sync"
+    : > "$ROOT_DIR/var/lib/airplanes-config-sync/config-sync-last-success"
+
     # CLI wrapper at /usr/local/bin — installed by update.sh:545.
     mkdir -p "$ROOT_DIR/usr/local/bin"
     : > "$ROOT_DIR/usr/local/bin/apl-feed"
@@ -174,6 +180,14 @@ run_uninstall() {
 
     [ "$status" -eq 0 ]
     [ ! -e "$ROOT_DIR/var/lib/airplanes" ]
+}
+
+@test "after install footprint, uninstall removes /var/lib/airplanes-config-sync state dir" {
+    stage_install_footprint
+    run_uninstall
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes-config-sync" ]
 }
 
 @test "after install footprint, uninstall wipes IPATH and leaves only the legacy UUID symlink" {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -72,10 +72,11 @@ systemctl daemon-reload || true
 # below handles everything inside it.
 rm -f "$LOCAL_BIN_APL_FEED"
 rm -f "$IMAGE_INSTALL_MARKER"
-# State directory for the diagnostics oneshot (last-success timestamp file).
-# Created by systemd's StateDirectory=airplanes on first fire of the unit;
-# nothing in it is user-supplied, so remove wholesale.
+# State directories for the diagnostics and config-sync oneshots (last-success
+# timestamp files). Created by systemd's StateDirectory= on first fire of each
+# unit; nothing in them is user-supplied, so remove wholesale.
 rm -rf "$(airplanes_path /var/lib/airplanes)"
+rm -rf "$(airplanes_path /var/lib/airplanes-config-sync)"
 
 # Preserve the legacy fallback in memory before wiping IPATH so the canonical
 # feeder-id can be materialized from it if no canonical copy exists. The


### PR DESCRIPTION
On a freshly-flashed feeder, `airplanes-config-sync.service` could fail once at first boot with a mount-namespace error. Its `ReadWritePaths=` listed `/var/lib/airplanes`, but that directory only comes into existence as a side effect of `airplanes-diagnostics.service`'s `StateDirectory=`. When the config-sync timer fired before diagnostics had ever run, the bind target was missing and the unit failed to start with `status=226/NAMESPACE`. It recovered on the next tick once the directory existed, so the only symptom was an alarming boot-journal error and a transient failed unit.

config-sync now declares its own `StateDirectory=airplanes-config-sync` — which systemd creates before setting up the mount namespace — and writes its success sentinel there. It no longer depends on another unit having created the shared directory first.
