### PR TITLE
Give each apl-feed command its own contextual help

### DIFF
--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -169,7 +169,7 @@ main() {
             usage
             ;;
         *)
-            die "unknown command: $cmd"
+            usage_error usage "unknown command: $cmd"
             ;;
     esac
 }

--- a/scripts/apl-feed/apply.sh
+++ b/scripts/apl-feed/apply.sh
@@ -34,7 +34,24 @@
 #   {"status":"parse_error", "message":"..."}
 #   {"status":"usage_error", "message":"..."}
 
+usage_apply() {
+    cat <<'USAGE'
+Usage: apl-feed apply [--no-restart] [--lock-timeout SECS]
+
+Reads a JSON payload of config updates on stdin and applies them to
+feed.env via the canonical writer, emitting a JSON result. --no-restart
+suppresses the post-apply service restart; --lock-timeout caps how long to
+wait for the feed.env lock.
+USAGE
+}
+
 apl_feed_apply_cli() {
+    # Help must work without jq installed — handle it before require_jq.
+    local _arg
+    for _arg in "$@"; do
+        case "$_arg" in -h|--help) usage_apply; exit 0 ;; esac
+    done
+
     require_jq
 
     local feed_env lock_path skip_restart=0 lock_timeout=""
@@ -59,7 +76,7 @@ apl_feed_apply_cli() {
                 shift 2
                 ;;
             --json) shift ;;
-            -h|--help) usage; exit 0 ;;
+            -h|--help) usage_apply; exit 0 ;;
             *)
                 _apl_feed_apply_emit_error usage_error "unknown flag for apply: $1"
                 return 5

--- a/scripts/apl-feed/backup.sh
+++ b/scripts/apl-feed/backup.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+usage_backup() {
+    cat <<'USAGE'
+Usage: apl-feed backup <file>|-
+
+Writes a JSON backup of the feeder's claim secret and Feeder ID to <file>
+(mode 0600), or to stdout when the path is '-'. Refuses to overwrite an
+existing file.
+USAGE
+}
+
+usage_restore() {
+    cat <<'USAGE'
+Usage:
+  apl-feed restore <file>
+  apl-feed restore --check <file>
+  apl-feed restore --uuid <uuid> [--check]
+
+Restores the claim secret and Feeder ID from a backup <file>, or with
+--uuid takes the Feeder ID from the flag and reads a fresh secret from
+stdin (the website-restore path) in one atomic two-file commit, then
+restarts both daemons. --check validates the source without writing;
+--force overwrites differing local state.
+USAGE
+}
+
 read_backup_file() {
     local infile="$1"
     BACKUP_SCHEMA="$(jq -r '.schema_version // empty' < "$infile")"
@@ -26,7 +51,9 @@ config_backup() {
             --force)
                 die "unknown flag for backup: --force"
                 ;;
-            --root|--website-url|--max-retry-time|-h|--help)
+            -h|--help)
+                usage_backup; exit 0 ;;
+            --root|--website-url|--max-retry-time)
                 if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
                 case "$opt_rc" in
                     1) shift ;;
@@ -46,7 +73,7 @@ config_backup() {
                 ;;
         esac
     done
-    [[ -n "$outfile" ]] || die "backup requires a file (use '-' for stdout)"
+    [[ -n "$outfile" ]] || usage_error usage_backup "backup requires a file (use '-' for stdout)"
     local stdout_mode=0
     if [[ "$outfile" == "-" ]]; then
         stdout_mode=1
@@ -147,7 +174,9 @@ config_restore() {
                 uuid_arg="$2"
                 shift 2
                 ;;
-            --root|--website-url|--max-retry-time|-h|--help)
+            -h|--help)
+                usage_restore; exit 0 ;;
+            --root|--website-url|--max-retry-time)
                 if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
                 case "$opt_rc" in
                     1) shift ;;
@@ -172,7 +201,7 @@ config_restore() {
         die "restore: --uuid and a backup file are mutually exclusive"
     fi
     if [[ -z "$uuid_arg" && -z "$infile" ]]; then
-        die "restore requires --uuid <UUID> or a backup file"
+        usage_error usage_restore "restore requires --uuid <UUID> or a backup file"
     fi
 
     if [[ -n "$infile" ]]; then

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -21,6 +21,7 @@ claim_register() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help) usage_claim_register; exit 0 ;;
             --dry-run)
                 DRY_RUN=1
                 shift
@@ -202,6 +203,7 @@ claim_register() {
 claim_show() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_claim_show; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -227,6 +229,7 @@ claim_show() {
 claim_rotate_abort() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_claim_rotate; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -263,6 +266,10 @@ claim_rotate_abort() {
 }
 
 claim_rotate() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage_claim_rotate
+        exit 0
+    fi
     if [[ "${1:-}" == "--abort" ]]; then
         shift
         claim_rotate_abort "$@"
@@ -271,6 +278,7 @@ claim_rotate() {
 
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_claim_rotate; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -415,6 +423,7 @@ claim_set() {
     local opt_rc force=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help) usage_claim_set; exit 0 ;;
             --force)
                 # shellcheck disable=SC2034  # tracked locally; not exported
                 force=1
@@ -519,16 +528,76 @@ claim_set() {
 }
 
 
+usage_claim() {
+    cat <<'USAGE'
+Usage: apl-feed claim <subcommand> [options]
+
+Subcommands:
+  register    Generate and register the claim secret with airplanes.live
+  show        Print the local claim secret and the claim page URL
+  rotate      Rotate the claim secret (--abort cancels a pending rotation)
+  set         Save a claim secret minted by the website (reads stdin)
+
+Run 'apl-feed claim <subcommand> --help' for details.
+USAGE
+}
+
+usage_claim_register() {
+    cat <<'USAGE'
+Usage: apl-feed claim register
+
+Generates a claim secret (when none exists yet) and registers it with
+airplanes.live, then prints the secret and the claim page URL. Safe to
+re-run: an already-registered feeder re-confirms its existing secret.
+USAGE
+}
+
+usage_claim_show() {
+    cat <<'USAGE'
+Usage: apl-feed claim show
+
+Prints the locally stored claim secret, its version (when known), and the
+claim page URL. Does not contact the website.
+USAGE
+}
+
+usage_claim_rotate() {
+    cat <<'USAGE'
+Usage:
+  apl-feed claim rotate
+  apl-feed claim rotate --abort
+
+Rotates the claim secret with airplanes.live, replacing the local secret
+on success. --abort cancels a pending (interrupted) rotation, keeping the
+current secret as long as the server still accepts it.
+USAGE
+}
+
+usage_claim_set() {
+    cat <<'USAGE'
+Usage: apl-feed claim set [--force]
+
+Reads a claim secret from stdin (or prompts on a TTY) and saves it
+locally. The feeder uses the new secret on its next contact with the
+website — no daemon restart, since neither airplanes-feed nor
+airplanes-mlat consumes the claim secret. --force overwrites a different
+secret already saved on this feeder.
+USAGE
+}
+
 dispatch_claim() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "claim requires a subcommand"
+    [[ -n "$sub" ]] || usage_error usage_claim
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_claim
+        return 0
+    fi
     shift || true
     case "$sub" in
         register) claim_register "$@" ;;
         show) claim_show "$@" ;;
         rotate) claim_rotate "$@" ;;
         set) claim_set "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown claim subcommand: $sub" ;;
+        *) usage_error usage_claim "unknown claim subcommand: $sub" ;;
     esac
 }

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -91,61 +91,55 @@ new_tmp_file() {
 
 usage() {
     cat <<'USAGE'
-Usage:
-  apl-feed status [--json]
-  apl-feed claim register
-  apl-feed claim show
-  apl-feed claim rotate
-  apl-feed claim rotate --abort
-  apl-feed claim set [--force]
-  apl-feed id set [--force]
-  apl-feed mlat enable
-  apl-feed mlat disable
-  apl-feed mlat setup
-  apl-feed mlat user <name>
-  apl-feed mlat user --clear
-  apl-feed mlat geo <lat> <lon> <alt>
-  apl-feed mlat private enable
-  apl-feed mlat private disable
-  apl-feed 978 enable [--serial SERIAL] [--gain GAIN]
-  apl-feed 978 disable
-  apl-feed 978 setup
-  apl-feed 978 status
-  apl-feed diagnostics enable
-  apl-feed diagnostics disable
-  apl-feed apply [--no-restart] [--lock-timeout SECS]
-  apl-feed schema
-  apl-feed config sync [--dry-run] [--no-restart]
-  apl-feed import legacy-config [--no-restart] <path>
-  apl-feed backup <file>|-
-  apl-feed restore <file>
-  apl-feed restore --check <file>
-  apl-feed restore --uuid <uuid> [--check]
+apl-feed — airplanes.live feeder control
+
+Usage: apl-feed <command> [subcommand] [options]
+
+Commands:
+  status        Show feeder status
+  claim         Manage the claim secret (register/show/rotate/set)
+  id            Manage the Feeder ID (set)
+  mlat          Configure MLAT (enable/disable/setup/user/geo/private)
+  978           Configure 978 MHz UAT (enable/disable/setup/status)
+  diagnostics   Enable or disable diagnostics push (enable/disable)
+  config        Remote config sync (sync/enable/disable)
+  import        Import configuration (legacy-config)
+  apply         Apply config keys from a JSON payload on stdin
+  schema        Print the feed.env config schema as JSON
+  backup        Write a config backup (claim secret + Feeder ID)
+  restore       Restore from a backup file or the website
 
 Options:
-  --force             For restore / claim set / id set: overwrite differing
-                      local state.
-  --check             For restore: validate the source without writing.
-  -h, --help          Show this message.
+  -h, --help    Show this message.
 
-`apl-feed claim set` reads a claim secret from stdin (or prompts when run
-on a TTY) and saves it locally. The feeder will use the new secret on its
-next contact with the website. No daemon restart — neither airplanes-feed
-nor airplanes-mlat consumes the claim secret.
-
-`apl-feed id set` reads a Feeder ID (UUID) from stdin and saves it
-locally. Both airplanes-feed and airplanes-mlat consume the UUID, so this
-command restarts both services after writing.
-
-`apl-feed restore --uuid <uuid>` is the website-restore path. It writes
-both the supplied UUID and a fresh secret read from stdin in one atomic
-two-file commit, then restarts both daemons.
+Run 'apl-feed <command> --help' for details on a command.
 USAGE
 }
 
 die() {
     echo "ERROR: $*" >&2
     exit 1
+}
+
+# Usage-error exit path. Prints an optional "ERROR: <message>" line, then
+# the relevant command's help, both to stderr, and exits 2 — the
+# argparse / bash-builtin / coreutils convention for "invoked wrong",
+# kept distinct from die()'s exit 1 for runtime / precondition failures.
+# The usage function is named (not called directly) so callers can refer
+# to a usage_* defined in a later-sourced module; declare -F guards a
+# mistyped or not-yet-sourced name by falling back to the top-level index.
+usage_error() {
+    local usage_fn="$1"
+    shift || true
+    if [[ $# -gt 0 && -n "$1" ]]; then
+        echo "ERROR: $*" >&2
+    fi
+    if declare -F "$usage_fn" >/dev/null 2>&1; then
+        "$usage_fn" >&2
+    else
+        usage >&2
+    fi
+    exit 2
 }
 
 root_path() {

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -633,7 +633,7 @@ apl_feed_config_sync() {
                 shift
                 ;;
             -h|--help)
-                usage
+                usage_config_sync
                 exit 0
                 ;;
             *)
@@ -848,6 +848,7 @@ _config_toggle_emit_result() {
 apl_feed_config_enable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_config_enable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -863,6 +864,7 @@ apl_feed_config_enable() {
 apl_feed_config_disable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_config_disable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -875,15 +877,60 @@ apl_feed_config_disable() {
     _config_toggle_emit_result "REMOTE_CONFIG_ENABLED set to false (remote config sync disabled; the timer stays armed but the sync CLI exits silently each tick)"
 }
 
+usage_config() {
+    cat <<'USAGE'
+Usage: apl-feed config <subcommand> [options]
+
+Subcommands:
+  sync [--dry-run] [--no-restart]   Run a one-shot remote config sync
+  enable                            Enable remote config sync (opt-in)
+  disable                           Disable remote config sync
+
+Run 'apl-feed config <subcommand> --help' for details.
+USAGE
+}
+
+usage_config_sync() {
+    cat <<'USAGE'
+Usage: apl-feed config sync [--dry-run] [--no-restart]
+
+Pushes the local feed.env snapshot to airplanes.live and applies the
+server's merged response. Requires REMOTE_CONFIG_ENABLED=true (see
+'apl-feed config enable'). --dry-run prints the outgoing payload without
+contacting the server; --no-restart suppresses the post-apply restart.
+USAGE
+}
+
+usage_config_enable() {
+    cat <<'USAGE'
+Usage: apl-feed config enable
+
+Opts this feeder into remote config sync (sets REMOTE_CONFIG_ENABLED=true).
+The next sync tick within ~60s contacts the website.
+USAGE
+}
+
+usage_config_disable() {
+    cat <<'USAGE'
+Usage: apl-feed config disable
+
+Opts this feeder out of remote config sync (sets REMOTE_CONFIG_ENABLED=
+false). The timer stays armed but the sync exits silently each tick.
+USAGE
+}
+
 dispatch_config() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "config requires a subcommand (enable|disable|sync)"
+    [[ -n "$sub" ]] || usage_error usage_config
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_config
+        return 0
+    fi
     shift || true
     case "$sub" in
         enable)  apl_feed_config_enable  "$@" ;;
         disable) apl_feed_config_disable "$@" ;;
         sync)    apl_feed_config_sync    "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown config subcommand: $sub" ;;
+        *) usage_error usage_config "unknown config subcommand: $sub" ;;
     esac
 }

--- a/scripts/apl-feed/diagnostics.sh
+++ b/scripts/apl-feed/diagnostics.sh
@@ -70,6 +70,7 @@ _diagnostics_apply() {
 apl_feed_diagnostics_enable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_diagnostics_enable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -85,6 +86,7 @@ apl_feed_diagnostics_enable() {
 apl_feed_diagnostics_disable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_diagnostics_disable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -97,14 +99,47 @@ apl_feed_diagnostics_disable() {
     _diagnostics_emit_result "REPORT_STATUS set to false (diagnostics push disabled; the next tick within ~10 min sends one final muted signal to airplanes.live, then the collector exits silently)"
 }
 
+usage_diagnostics() {
+    cat <<'USAGE'
+Usage: apl-feed diagnostics <subcommand>
+
+Subcommands:
+  enable     Enable diagnostics push to airplanes.live
+  disable    Disable diagnostics push
+
+Run 'apl-feed diagnostics <subcommand> --help' for details.
+USAGE
+}
+
+usage_diagnostics_enable() {
+    cat <<'USAGE'
+Usage: apl-feed diagnostics enable
+
+Enables the diagnostics push (sets REPORT_STATUS=true). The next timer
+tick within ~10 min sends the first report.
+USAGE
+}
+
+usage_diagnostics_disable() {
+    cat <<'USAGE'
+Usage: apl-feed diagnostics disable
+
+Disables the diagnostics push (sets REPORT_STATUS=false). One final muted
+signal is sent on the next tick, then the collector exits silently.
+USAGE
+}
+
 dispatch_diagnostics() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "diagnostics requires a subcommand (enable|disable)"
+    [[ -n "$sub" ]] || usage_error usage_diagnostics
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_diagnostics
+        return 0
+    fi
     shift || true
     case "$sub" in
         enable)  apl_feed_diagnostics_enable  "$@" ;;
         disable) apl_feed_diagnostics_disable "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown diagnostics subcommand: $sub" ;;
+        *) usage_error usage_diagnostics "unknown diagnostics subcommand: $sub" ;;
     esac
 }

--- a/scripts/apl-feed/id.sh
+++ b/scripts/apl-feed/id.sh
@@ -20,6 +20,7 @@ id_set() {
     local opt_rc force=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help) usage_id_set; exit 0 ;;
             --force)
                 # shellcheck disable=SC2034  # tracked locally; not exported
                 force=1
@@ -117,13 +118,38 @@ id_set() {
 }
 
 
+usage_id() {
+    cat <<'USAGE'
+Usage: apl-feed id <subcommand> [options]
+
+Subcommands:
+  set    Save a Feeder ID (UUID) supplied by the website (reads stdin)
+
+Run 'apl-feed id <subcommand> --help' for details.
+USAGE
+}
+
+usage_id_set() {
+    cat <<'USAGE'
+Usage: apl-feed id set [--force]
+
+Reads a Feeder ID (UUID) from stdin (or prompts on a TTY) and saves it
+locally. Both airplanes-feed and airplanes-mlat consume the UUID, so this
+command restarts both services after writing. --force overwrites a
+different Feeder ID already saved on this feeder.
+USAGE
+}
+
 dispatch_id() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "id requires a subcommand"
+    [[ -n "$sub" ]] || usage_error usage_id
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_id
+        return 0
+    fi
     shift || true
     case "$sub" in
         set) id_set "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown id subcommand: $sub" ;;
+        *) usage_error usage_id "unknown id subcommand: $sub" ;;
     esac
 }

--- a/scripts/apl-feed/import.sh
+++ b/scripts/apl-feed/import.sh
@@ -75,7 +75,7 @@ apl_feed_import_legacy_config() {
     local no_restart=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            -h|--help) usage; return 0 ;;
+            -h|--help) usage_import_legacy_config; exit 0 ;;
             --no-restart)
                 no_restart=1
                 shift
@@ -337,13 +337,37 @@ apl_feed_import_legacy_config() {
     esac
 }
 
+usage_import() {
+    cat <<'USAGE'
+Usage: apl-feed import <subcommand> [options]
+
+Subcommands:
+  legacy-config [--no-restart] <path>   Import a legacy airplanes-config.txt
+
+Run 'apl-feed import <subcommand> --help' for details.
+USAGE
+}
+
+usage_import_legacy_config() {
+    cat <<'USAGE'
+Usage: apl-feed import legacy-config [--no-restart] <path>
+
+Translates a legacy /boot/airplanes-config.txt-shaped file into the
+canonical feed.env schema and writes it to /etc/airplanes/feed.env.
+--no-restart suppresses the post-write service restart.
+USAGE
+}
+
 dispatch_import() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "import requires a subcommand (legacy-config)"
+    [[ -n "$sub" ]] || usage_error usage_import
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_import
+        return 0
+    fi
     shift || true
     case "$sub" in
         legacy-config) apl_feed_import_legacy_config "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown import subcommand: $sub" ;;
+        *) usage_error usage_import "unknown import subcommand: $sub" ;;
     esac
 }

--- a/scripts/apl-feed/mlat.sh
+++ b/scripts/apl-feed/mlat.sh
@@ -100,6 +100,7 @@ _mlat_require_geo() {
 apl_feed_mlat_disable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_mlat_disable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -115,6 +116,7 @@ apl_feed_mlat_disable() {
 apl_feed_mlat_enable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_mlat_enable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -141,6 +143,7 @@ apl_feed_mlat_enable() {
 apl_feed_mlat_private_enable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_mlat_private_enable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -156,6 +159,7 @@ apl_feed_mlat_private_enable() {
 apl_feed_mlat_private_disable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_mlat_private_disable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -172,6 +176,7 @@ apl_feed_mlat_user() {
     local clear=0 name="" name_set=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help) usage_mlat_user; exit 0 ;;
             --clear)
                 clear=1
                 shift ;;
@@ -214,7 +219,9 @@ apl_feed_mlat_geo() {
         case "$1" in
             -[0-9]*|-.[0-9]*)
                 positional+=("$1"); shift ;;
-            --|-h|--help|--root|--website-url|--max-retry-time)
+            -h|--help)
+                usage_mlat_geo; exit 0 ;;
+            --|--root|--website-url|--max-retry-time)
                 local opt_rc
                 if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
                 case "$opt_rc" in
@@ -257,6 +264,7 @@ apl_feed_mlat_geo() {
 apl_feed_mlat_setup() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_mlat_setup; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -410,21 +418,123 @@ apl_feed_mlat_setup() {
     _mlat_emit_result "feed.env updated; MLAT enabled."
 }
 
+usage_mlat() {
+    cat <<'USAGE'
+Usage: apl-feed mlat <subcommand> [options]
+
+Subcommands:
+  enable                    Enable MLAT (requires a configured location)
+  disable                   Disable MLAT
+  setup                     Interactive MLAT configuration
+  user <name>               Set the MLAT feeder name (--clear to remove)
+  geo <lat> <lon> <alt>     Set the antenna location
+  private <enable|disable>  Hide or show the feed name on the public map
+
+Run 'apl-feed mlat <subcommand> --help' for details.
+USAGE
+}
+
+usage_mlat_private() {
+    cat <<'USAGE'
+Usage: apl-feed mlat private <subcommand>
+
+Subcommands:
+  enable     Hide the feed name on the public MLAT map
+  disable    Show the feed name on the public MLAT map
+
+Run 'apl-feed mlat private <subcommand> --help' for details.
+USAGE
+}
+
+usage_mlat_enable() {
+    cat <<'USAGE'
+Usage: apl-feed mlat enable
+
+Enables MLAT (multilateration). Requires a configured antenna location
+(set it with 'apl-feed mlat geo' or 'apl-feed mlat setup' first) and
+restarts the MLAT service.
+USAGE
+}
+
+usage_mlat_disable() {
+    cat <<'USAGE'
+Usage: apl-feed mlat disable
+
+Disables MLAT. The daemon stays enabled at the systemd level but sleeps
+while disabled.
+USAGE
+}
+
+usage_mlat_setup() {
+    cat <<'USAGE'
+Usage: apl-feed mlat setup
+
+Interactive prompt for the antenna location, MLAT name, and privacy, then
+enables MLAT. Requires a TTY; for non-interactive use run
+'apl-feed mlat geo', then optionally 'apl-feed mlat user', then
+'apl-feed mlat enable'.
+USAGE
+}
+
+usage_mlat_user() {
+    cat <<'USAGE'
+Usage:
+  apl-feed mlat user <name>
+  apl-feed mlat user --clear
+
+Sets the MLAT feeder name (1-64 chars from [A-Za-z0-9_-]). --clear removes
+it so the daemon falls back to Anonymous-<short-feeder-id>.
+USAGE
+}
+
+usage_mlat_geo() {
+    cat <<'USAGE'
+Usage: apl-feed mlat geo <lat> <lon> <alt>
+
+Sets the antenna location. <lat>/<lon> are decimal degrees; <alt> accepts
+a metric or imperial suffix (e.g. 120m, 400ft) or bare metres. The (0,0)
+placeholder is treated as "location not configured".
+USAGE
+}
+
+usage_mlat_private_enable() {
+    cat <<'USAGE'
+Usage: apl-feed mlat private enable
+
+Hides the feed name on the public MLAT map (sets MLAT_PRIVATE=true).
+USAGE
+}
+
+usage_mlat_private_disable() {
+    cat <<'USAGE'
+Usage: apl-feed mlat private disable
+
+Shows the feed name on the public MLAT map (sets MLAT_PRIVATE=false).
+USAGE
+}
+
 dispatch_mlat_private() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "mlat private requires a subcommand (enable|disable)"
+    [[ -n "$sub" ]] || usage_error usage_mlat_private
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_mlat_private
+        return 0
+    fi
     shift || true
     case "$sub" in
         enable)  apl_feed_mlat_private_enable  "$@" ;;
         disable) apl_feed_mlat_private_disable "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown mlat private subcommand: $sub" ;;
+        *) usage_error usage_mlat_private "unknown mlat private subcommand: $sub" ;;
     esac
 }
 
 dispatch_mlat() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "mlat requires a subcommand (enable|disable|setup|user|geo|private)"
+    [[ -n "$sub" ]] || usage_error usage_mlat
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_mlat
+        return 0
+    fi
     shift || true
     case "$sub" in
         enable)  apl_feed_mlat_enable  "$@" ;;
@@ -433,8 +543,7 @@ dispatch_mlat() {
         user)    apl_feed_mlat_user    "$@" ;;
         geo)     apl_feed_mlat_geo     "$@" ;;
         private) dispatch_mlat_private "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown mlat subcommand: $sub" ;;
+        *) usage_error usage_mlat "unknown mlat subcommand: $sub" ;;
     esac
 }
 

--- a/scripts/apl-feed/schema.sh
+++ b/scripts/apl-feed/schema.sh
@@ -9,7 +9,22 @@
 # update. Stable JSON shape — the version field is for future-incompat
 # evolution.
 
+usage_schema() {
+    cat <<'USAGE'
+Usage: apl-feed schema
+
+Prints the canonical feed.env schema (writable and readable keys) as a
+single line of JSON. Used by webconfig to filter responses and build forms.
+USAGE
+}
+
 apl_feed_schema_cli() {
+    # Help must work without jq installed — handle it before require_jq.
+    local _arg
+    for _arg in "$@"; do
+        case "$_arg" in -h|--help) usage_schema; exit 0 ;; esac
+    done
+
     require_jq
 
     while (( $# > 0 )); do
@@ -21,7 +36,7 @@ apl_feed_schema_cli() {
         esac
         case "$1" in
             --json) shift ;;
-            -h|--help) usage; exit 0 ;;
+            -h|--help) usage_schema; exit 0 ;;
             *) die "unknown flag for schema: $1" ;;
         esac
     done

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -691,11 +691,22 @@ diagnostics_status_line() {
     fi
 }
 
+usage_status() {
+    cat <<'USAGE'
+Usage: apl-feed status [--json]
+
+Runs the feeder health checks (receiver input, feed/MLAT services, ADS-B
+uplink, website claim/reception, diagnostics) and prints a summary.
+--json emits a machine-readable report instead of the human summary.
+USAGE
+}
+
 feed_status() {
     local opt_rc
     STATUS_OUTPUT_JSON=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help) usage_status; exit 0 ;;
             --json)
                 STATUS_OUTPUT_JSON=1
                 shift

--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -124,6 +124,7 @@ apl_feed_uat_enable() {
     local serial_set=0 gain_set=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -h|--help) usage_uat_enable; exit 0 ;;
             --serial)
                 [[ $# -ge 2 ]] || die "--serial requires VALUE"
                 serial="$2"; serial_set=1; shift 2 ;;
@@ -159,6 +160,7 @@ apl_feed_uat_enable() {
 apl_feed_uat_disable() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_uat_disable; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -174,6 +176,7 @@ apl_feed_uat_disable() {
 apl_feed_uat_setup() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_uat_setup; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -223,6 +226,7 @@ apl_feed_uat_setup() {
 apl_feed_uat_status() {
     local opt_rc
     while [[ $# -gt 0 ]]; do
+        case "$1" in -h|--help) usage_uat_status; exit 0 ;; esac
         if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
         case "$opt_rc" in
             1) shift ;;
@@ -260,16 +264,71 @@ apl_feed_uat_status() {
     done
 }
 
+usage_uat() {
+    cat <<'USAGE'
+Usage: apl-feed 978 <subcommand> [options]
+
+Subcommands:
+  enable [--serial S] [--gain G]   Enable 978 MHz UAT reception
+  disable                          Disable 978 UAT
+  setup                            Interactive 978 configuration
+  status                           Show 978 UAT configuration and services
+
+Run 'apl-feed 978 <subcommand> --help' for details.
+USAGE
+}
+
+usage_uat_enable() {
+    cat <<'USAGE'
+Usage: apl-feed 978 enable [--serial SERIAL] [--gain GAIN]
+
+Enables 978 MHz UAT reception (points UAT_INPUT at the local dump978-fa
+endpoint). --serial pins the 978 SDR's EEPROM serial; --gain pins the
+dump978 gain. Omitting either leaves any stored value unchanged; the
+dump978 wrapper applies its built-in defaults when the value is unset.
+USAGE
+}
+
+usage_uat_disable() {
+    cat <<'USAGE'
+Usage: apl-feed 978 disable
+
+Disables 978 UAT reception by clearing UAT_INPUT.
+USAGE
+}
+
+usage_uat_setup() {
+    cat <<'USAGE'
+Usage: apl-feed 978 setup
+
+Interactive prompt for the 978 SDR serial and gain, then enables 978.
+Requires a TTY; for non-interactive use run
+'apl-feed 978 enable [--serial S] [--gain G]'.
+USAGE
+}
+
+usage_uat_status() {
+    cat <<'USAGE'
+Usage: apl-feed 978 status
+
+Shows whether 978 UAT is enabled, the configured SDR serial and gain, and
+the state of the dump978-fa / airplanes-978 services.
+USAGE
+}
+
 dispatch_uat() {
     local sub="${1:-}"
-    [[ -n "$sub" ]] || die "978 requires a subcommand (enable|disable|setup|status)"
+    [[ -n "$sub" ]] || usage_error usage_uat
+    if [[ "$sub" == "-h" || "$sub" == "--help" ]]; then
+        usage_uat
+        return 0
+    fi
     shift || true
     case "$sub" in
         enable)  apl_feed_uat_enable  "$@" ;;
         disable) apl_feed_uat_disable "$@" ;;
         setup)   apl_feed_uat_setup   "$@" ;;
         status)  apl_feed_uat_status  "$@" ;;
-        -h|--help) usage ;;
-        *) die "unknown 978 subcommand: $sub" ;;
+        *) usage_error usage_uat "unknown 978 subcommand: $sub" ;;
     esac
 }

--- a/test/test_apl_feed_config.bats
+++ b/test/test_apl_feed_config.bats
@@ -189,10 +189,10 @@ EOF
     grep -Eq "^REMOTE_CONFIG_ENABLED=\"?false\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
-@test "dispatch_config with no subcommand fails with actionable message" {
+@test "dispatch_config with no subcommand shows help (exit 2)" {
     run dispatch_config
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"config requires a subcommand"* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"apl-feed config <subcommand>"* ]]
     [[ "$output" == *"enable"* ]]
     [[ "$output" == *"disable"* ]]
     [[ "$output" == *"sync"* ]]

--- a/test/test_apl_feed_diagnostics.bats
+++ b/test/test_apl_feed_diagnostics.bats
@@ -181,10 +181,10 @@ EOF
     grep -Eq "^REPORT_STATUS=\"?false\"?$" "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
-@test "dispatch_diagnostics with no subcommand fails with actionable message" {
+@test "dispatch_diagnostics with no subcommand shows help (exit 2)" {
     run dispatch_diagnostics
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"diagnostics requires a subcommand"* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"apl-feed diagnostics <subcommand>"* ]]
     [[ "$output" == *"enable"* ]]
     [[ "$output" == *"disable"* ]]
 }

--- a/test/test_apl_feed_help.bats
+++ b/test/test_apl_feed_help.bats
@@ -1,0 +1,274 @@
+#!/usr/bin/env bats
+
+# Contextual --help and usage-error behavior for the apl-feed CLI.
+#
+# Contract:
+#   - `apl-feed` / `apl-feed -h`             -> concise index, stdout, exit 0
+#   - `apl-feed <group>` (no subcommand)     -> group help, stderr, exit 2
+#   - `apl-feed <group> --help`              -> group help, stdout, exit 0
+#   - `apl-feed <group> <bogus>`             -> ERROR + group help, stderr, exit 2
+#   - `apl-feed <…> --help` on any leaf      -> that leaf's help, stdout, exit 0
+#   - unknown top-level command              -> ERROR + index, stderr, exit 2
+# Usage errors exit 2 (distinct from die()'s exit 1).
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/apl-feed.sh"
+}
+
+# --- top-level index ------------------------------------------------------
+
+@test "apl-feed (no args): concise index on stdout, exit 0" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Commands:'* ]]
+    [[ "$output" == *"Run 'apl-feed <command> --help'"* ]]
+    [[ "$output" == *'claim'* ]]
+    [[ "$output" == *'mlat'* ]]
+}
+
+@test "apl-feed -h / --help: concise index, exit 0" {
+    run "$SCRIPT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Commands:'* ]]
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Commands:'* ]]
+}
+
+@test "apl-feed -h prints to stdout (not stderr)" {
+    run bash -c "'$SCRIPT' -h 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Commands:'* ]]
+}
+
+@test "unknown top-level command: ERROR + index on stderr, exit 2" {
+    run "$SCRIPT" frobnitz
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'unknown command: frobnitz'* ]]
+    [[ "$output" == *'Commands:'* ]]
+}
+
+@test "unknown top-level command writes nothing to stdout" {
+    run bash -c "'$SCRIPT' frobnitz 2>/dev/null"
+    [ "$status" -eq 2 ]
+    [ -z "$output" ]
+}
+
+# --- group: bare (exit 2) + --help (exit 0) -------------------------------
+
+@test "claim: bare shows group help on stderr, exit 2" {
+    run "$SCRIPT" claim
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed claim <subcommand>'* ]]
+    [[ "$output" == *'register'* ]]
+}
+
+@test "claim: bare writes nothing to stdout" {
+    run bash -c "'$SCRIPT' claim 2>/dev/null"
+    [ "$status" -eq 2 ]
+    [ -z "$output" ]
+}
+
+@test "claim --help: group help on stdout, exit 0" {
+    run bash -c "'$SCRIPT' claim --help 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed claim <subcommand>'* ]]
+}
+
+@test "claim <bogus>: ERROR + group help, exit 2" {
+    run "$SCRIPT" claim bogus
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'unknown claim subcommand: bogus'* ]]
+    [[ "$output" == *'register'* ]]
+}
+
+@test "id: bare exit 2, --help exit 0" {
+    run "$SCRIPT" id
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed id <subcommand>'* ]]
+    run "$SCRIPT" id --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed id <subcommand>'* ]]
+}
+
+@test "mlat: bare exit 2, --help exit 0" {
+    run "$SCRIPT" mlat
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed mlat <subcommand>'* ]]
+    run "$SCRIPT" mlat --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed mlat <subcommand>'* ]]
+    [[ "$output" == *'private'* ]]
+}
+
+@test "mlat private: bare exit 2, --help exit 0" {
+    run "$SCRIPT" mlat private
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed mlat private <subcommand>'* ]]
+    run "$SCRIPT" mlat private --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed mlat private <subcommand>'* ]]
+}
+
+@test "978: bare exit 2, --help exit 0" {
+    run "$SCRIPT" 978
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed 978 <subcommand>'* ]]
+    run "$SCRIPT" 978 --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed 978 <subcommand>'* ]]
+}
+
+@test "diagnostics: bare exit 2, --help exit 0" {
+    run "$SCRIPT" diagnostics
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed diagnostics <subcommand>'* ]]
+    run "$SCRIPT" diagnostics --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed diagnostics <subcommand>'* ]]
+}
+
+@test "config: bare exit 2, --help exit 0" {
+    run "$SCRIPT" config
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed config <subcommand>'* ]]
+    run "$SCRIPT" config --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed config <subcommand>'* ]]
+}
+
+@test "import: bare exit 2, --help exit 0" {
+    run "$SCRIPT" import
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed import <subcommand>'* ]]
+    run "$SCRIPT" import --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed import <subcommand>'* ]]
+}
+
+# --- per-leaf --help (stdout, exit 0) -------------------------------------
+
+@test "claim register --help: leaf-specific help" {
+    run "$SCRIPT" claim register --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed claim register'* ]]
+}
+
+@test "claim set --help: mentions stdin + --force" {
+    run "$SCRIPT" claim set --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed claim set'* ]]
+    [[ "$output" == *'--force'* ]]
+}
+
+@test "claim rotate --help: mentions --abort" {
+    run "$SCRIPT" claim rotate --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed claim rotate'* ]]
+    [[ "$output" == *'--abort'* ]]
+}
+
+@test "id set --help: leaf help" {
+    run "$SCRIPT" id set --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed id set'* ]]
+}
+
+@test "mlat geo --help: geo-specific help" {
+    run "$SCRIPT" mlat geo --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed mlat geo <lat> <lon> <alt>'* ]]
+}
+
+@test "mlat user --help: user-specific help" {
+    run "$SCRIPT" mlat user --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed mlat user'* ]]
+    [[ "$output" == *'--clear'* ]]
+}
+
+@test "mlat private enable --help: leaf help" {
+    run "$SCRIPT" mlat private enable --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed mlat private enable'* ]]
+}
+
+@test "978 enable --help: mentions --serial/--gain" {
+    run "$SCRIPT" 978 enable --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed 978 enable'* ]]
+    [[ "$output" == *'--serial'* ]]
+}
+
+@test "config sync --help: sync-specific help" {
+    run "$SCRIPT" config sync --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed config sync'* ]]
+    [[ "$output" == *'--dry-run'* ]]
+}
+
+@test "import legacy-config --help: leaf help" {
+    run "$SCRIPT" import legacy-config --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed import legacy-config'* ]]
+}
+
+@test "status --help: status help" {
+    run "$SCRIPT" status --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed status'* ]]
+    [[ "$output" == *'--json'* ]]
+}
+
+@test "backup -h: backup help" {
+    run "$SCRIPT" backup -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed backup'* ]]
+}
+
+@test "restore -h: restore help mentions --uuid" {
+    run "$SCRIPT" restore -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed restore'* ]]
+    [[ "$output" == *'--uuid'* ]]
+}
+
+# --- backup/restore missing operand -> usage error (exit 2) ---------------
+
+@test "backup with no file: usage error, exit 2" {
+    run "$SCRIPT" backup
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed backup'* ]]
+}
+
+@test "restore with no source: usage error, exit 2" {
+    run "$SCRIPT" restore
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed restore'* ]]
+}
+
+# --- help must not require jq --------------------------------------------
+
+@test "apply --help works with jq absent from PATH" {
+    local stub
+    stub="$(mktemp -d)"
+    ln -s /usr/bin/* "$stub"/ 2>/dev/null || true
+    ln -s /bin/* "$stub"/ 2>/dev/null || true
+    rm -f "$stub/jq"
+    run env PATH="$stub" "$SCRIPT" apply --help
+    rm -rf "$stub"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed apply'* ]]
+}
+
+@test "schema --help works with jq absent from PATH" {
+    local stub
+    stub="$(mktemp -d)"
+    ln -s /usr/bin/* "$stub"/ 2>/dev/null || true
+    ln -s /bin/* "$stub"/ 2>/dev/null || true
+    rm -f "$stub/jq"
+    run env PATH="$stub" "$SCRIPT" schema --help
+    rm -rf "$stub"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed schema'* ]]
+}

--- a/test/test_apl_feed_id.bats
+++ b/test/test_apl_feed_id.bats
@@ -50,15 +50,15 @@ teardown() {
 
 # --- dispatch_id ---
 
-@test "dispatch_id: missing subcommand dies" {
+@test "dispatch_id: missing subcommand shows id help (exit 2)" {
     run bash -c "
         set -euo pipefail
         source '$LIB_DIR/common.sh'
         source '$LIB_DIR/id.sh'
         dispatch_id
     "
-    [ "$status" -ne 0 ]
-    [[ "$output" == *'id requires a subcommand'* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed id <subcommand>'* ]]
 }
 
 @test "dispatch_id: unknown subcommand dies" {

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -121,15 +121,15 @@ EOF
 
 # --- dispatch_mlat ---
 
-@test "dispatch_mlat: missing subcommand dies" {
+@test "dispatch_mlat: missing subcommand shows mlat help (exit 2)" {
     run bash -c "
         set -euo pipefail
         source '$LIB_DIR/common.sh'
         source '$LIB_DIR/mlat.sh'
         dispatch_mlat
     "
-    [ "$status" -ne 0 ]
-    [[ "$output" == *'mlat requires a subcommand'* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed mlat <subcommand>'* ]]
 }
 
 @test "dispatch_mlat: unknown subcommand dies" {
@@ -273,15 +273,15 @@ EOF
 
 # --- mlat private subcommand ---
 
-@test "dispatch_mlat private: missing subcommand dies" {
+@test "dispatch_mlat private: missing subcommand shows help (exit 2)" {
     run bash -c "
         set -euo pipefail
         source '$LIB_DIR/common.sh'
         source '$LIB_DIR/mlat.sh'
         dispatch_mlat private
     "
-    [ "$status" -ne 0 ]
-    [[ "$output" == *'mlat private requires a subcommand'* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed mlat private <subcommand>'* ]]
 }
 
 @test "dispatch_mlat private: unknown subcommand dies" {

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -113,10 +113,10 @@ EOF
 
 # --- dispatch_uat ---
 
-@test "dispatch_uat: missing subcommand dies" {
+@test "dispatch_uat: missing subcommand shows 978 help (exit 2)" {
     run dispatch_uat
-    [ "$status" -ne 0 ]
-    [[ "$output" == *'978 requires a subcommand'* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'apl-feed 978 <subcommand>'* ]]
 }
 
 @test "dispatch_uat: unknown subcommand dies" {


### PR DESCRIPTION
Running `apl-feed` with no arguments now prints a concise list of commands instead of the entire command tree, and every command and subcommand has its own `--help`. Running a command group without a subcommand (for example `apl-feed claim`) now prints that command's help instead of a terse "requires a subcommand" error.

Usage errors — a missing or unknown subcommand, an unknown command, or a missing required argument — print the relevant help to stderr and exit 2, while `--help` prints to stdout and exits 0.