### PR TITLE
Give the diagnostics service its own state directory

### DIFF
--- a/scripts/airplanes-diagnostics.service
+++ b/scripts/airplanes-diagnostics.service
@@ -6,7 +6,7 @@ After=network-online.target airplanes-feed.service
 [Service]
 Type=oneshot
 User=airplanes-feed
-StateDirectory=airplanes
+StateDirectory=airplanes-diagnostics
 # 0755 so `apl-feed status` run as a non-airplanes-feed-group user can
 # stat the last-success sentinel inside this dir. The file is non-secret
 # (mtime only), and the only thing inside is the `touch`-created marker.
@@ -20,4 +20,3 @@ NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
-ReadWritePaths=/var/lib/airplanes

--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -18,8 +18,8 @@ SCRIPT_NAME="airplanes-diagnostics"
 EXIT_OK=0
 EXIT_BAD_CONFIG=64
 
-LAST_SUCCESS_FILE="${AIRPLANES_DIAGNOSTICS_LAST_SUCCESS:-/var/lib/airplanes/diagnostics-last-success}"
-INTENT_ACK_FILE="${AIRPLANES_DIAGNOSTICS_INTENT_ACK_FILE:-/var/lib/airplanes/diagnostics-intent-acked}"
+LAST_SUCCESS_FILE="${AIRPLANES_DIAGNOSTICS_LAST_SUCCESS:-${STATE_DIRECTORY:-/var/lib/airplanes-diagnostics}/diagnostics-last-success}"
+INTENT_ACK_FILE="${AIRPLANES_DIAGNOSTICS_INTENT_ACK_FILE:-${STATE_DIRECTORY:-/var/lib/airplanes-diagnostics}/diagnostics-intent-acked}"
 INSTALL_DIR="${AIRPLANES_DIAGNOSTICS_INSTALL_DIR:-}"
 
 _resolve_install_dir() {

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -608,12 +608,12 @@ claim_registration_status_line() {
 # diagnostics_status_line — render the airplanes-diagnostics push state.
 # Reads the REPORT_STATUS toggle from feed.env, then consults the systemd
 # unit (if a bad config caused an exit-64 failure on the last run) and
-# the mtime of /var/lib/airplanes/diagnostics-last-success.
+# the mtime of /var/lib/airplanes-diagnostics/diagnostics-last-success.
 diagnostics_status_line() {
     local label="Diagnostics push"
     local unit="airplanes-diagnostics.service"
     local last_success_file
-    last_success_file="$(root_path /var/lib/airplanes/diagnostics-last-success)"
+    last_success_file="$(root_path /var/lib/airplanes-diagnostics/diagnostics-last-success)"
 
     local raw lower
     raw="$(feed_env_get REPORT_STATUS 2>/dev/null || true)"

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -158,9 +158,9 @@ OSR
     chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
     printf 'REPORT_STATUS=true\n' > "$ROOT_DIR/etc/airplanes/feed.env"
 
-    LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes/diagnostics-last-success"
+    LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-last-success"
     mkdir -p "$(dirname "$LAST_SUCCESS")"
-    INTENT_ACK="$ROOT_DIR/var/lib/airplanes/diagnostics-intent-acked"
+    INTENT_ACK="$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-intent-acked"
 }
 
 teardown() {

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -5,13 +5,13 @@ setup() {
     CONTRACT="$BATS_TEST_DIRNAME/contracts/feeder-api-v1.json"
     ROOT_DIR="$(mktemp -d)"
     mkdir -p "$ROOT_DIR/usr/local/share/airplanes" "$ROOT_DIR/etc/airplanes" \
-             "$ROOT_DIR/var/lib/airplanes"
+             "$ROOT_DIR/var/lib/airplanes-diagnostics"
     echo "11111111-2222-3333-4444-555555555555" > "$ROOT_DIR/etc/airplanes/feeder-id"
     # Stage a fresh diagnostics-push timestamp so diagnostics_status_line
     # reads "ok" rather than the default "no successful push observed yet"
     # warn (the default-healthy fixture state assumes the timer has fired
     # at least once).
-    touch "$ROOT_DIR/var/lib/airplanes/diagnostics-last-success"
+    touch "$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-last-success"
     MOCK_PORT_FILE="$(mktemp)"
     MOCK_PID_FILE="$(mktemp)"
     # Mock servers append one "PATH<TAB>AUTH<TAB>BODY" line per POST here,

--- a/test/test_install_uninstall_symmetry.bats
+++ b/test/test_install_uninstall_symmetry.bats
@@ -130,11 +130,11 @@ stage_install_footprint() {
         : > "$ROOT_DIR/lib/systemd/system/airplanes-diagnostics.timer"
     fi
 
-    # Diagnostics state directory — systemd's StateDirectory=airplanes
-    # creates /var/lib/airplanes owned by the diagnostics user on first
-    # timer fire. uninstall.sh wipes the whole directory.
-    mkdir -p "$ROOT_DIR/var/lib/airplanes"
-    : > "$ROOT_DIR/var/lib/airplanes/diagnostics-last-success"
+    # Diagnostics state directory — systemd's StateDirectory=airplanes-diagnostics
+    # creates /var/lib/airplanes-diagnostics owned by the diagnostics user on
+    # first timer fire. uninstall.sh wipes the whole directory.
+    mkdir -p "$ROOT_DIR/var/lib/airplanes-diagnostics"
+    : > "$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-last-success"
 
     # Config-sync state directory — its own StateDirectory=airplanes-config-sync
     # (separate from diagnostics so the two oneshots never re-chown a shared
@@ -174,12 +174,12 @@ run_uninstall() {
     [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-diagnostics.timer" ]
 }
 
-@test "after install footprint, uninstall removes /var/lib/airplanes diagnostics state dir" {
+@test "after install footprint, uninstall removes /var/lib/airplanes-diagnostics state dir" {
     stage_install_footprint
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ ! -e "$ROOT_DIR/var/lib/airplanes" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes-diagnostics" ]
 }
 
 @test "after install footprint, uninstall removes /var/lib/airplanes-config-sync state dir" {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -75,7 +75,7 @@ rm -f "$IMAGE_INSTALL_MARKER"
 # State directories for the diagnostics and config-sync oneshots (last-success
 # timestamp files). Created by systemd's StateDirectory= on first fire of each
 # unit; nothing in them is user-supplied, so remove wholesale.
-rm -rf "$(airplanes_path /var/lib/airplanes)"
+rm -rf "$(airplanes_path /var/lib/airplanes-diagnostics)"
 rm -rf "$(airplanes_path /var/lib/airplanes-config-sync)"
 
 # Preserve the legacy fallback in memory before wiping IPATH so the canonical


### PR DESCRIPTION
Each airplanes feeder service that keeps state now owns its own directory: the daemons use `/run/<service>`, and the oneshots use `/var/lib/<service>`. `airplanes-diagnostics` was the last feed service still writing to the shared `/var/lib/airplanes`; it now uses its own `/var/lib/airplanes-diagnostics`, matching `airplanes-config-sync`.

Internal cleanup, no behavior change — the same files (the last-success and intent-ack markers), just under a per-service state directory, so on-device state is easy to locate and `uninstall.sh` removes it with the rest. (The shared `/var/lib/airplanes` path is still used independently by the image's first-boot markers, which create it themselves; uninstall no longer touches it.)
