### PR TITLE
Leave MLAT name empty in build-mode default config

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -68,16 +68,22 @@ detect_receiver_input() {
     fi
 }
 
-# Derive MLAT_USER from the sanitized user-supplied feeder name. Empty
-# input falls back to DEFAULT_MLAT_NAME. This function does not set
+# Derive MLAT_USER from the sanitized user-supplied feeder name. A
+# supplied name is used verbatim. Empty input falls back to
+# DEFAULT_MLAT_NAME — except in build mode, where it is left empty so a
+# generic baked image defers to airplanes-mlat's per-device
+# "Anonymous-<short-id>" runtime fallback instead of freezing one shared
+# literal name into every flashed card. This function does not set
 # MLAT_ENABLED — that's the caller's job (set explicitly from
 # AIRPLANES_MLAT_ENABLED in non-interactive mode, defaulted to "true"
 # in the interactive flow).
 derive_mlat_keys() {
-    if [[ -z "$NOSPACENAME" ]]; then
-        MLAT_USER="$DEFAULT_MLAT_NAME"
-    else
+    if [[ -n "$NOSPACENAME" ]]; then
         MLAT_USER="$NOSPACENAME"
+    elif airplanes_is_build_mode 2>/dev/null; then
+        MLAT_USER=""
+    else
+        MLAT_USER="$DEFAULT_MLAT_NAME"
     fi
 }
 
@@ -200,7 +206,8 @@ configure_noninteractive() {
     [[ "$missing" == "0" ]] || exit 1
 
     # MLAT_USER is optional. Empty / unset falls back to DEFAULT_MLAT_NAME
-    # via derive_mlat_keys (which write_feed_env calls).
+    # via derive_mlat_keys (which write_feed_env calls) — except in build
+    # mode, where it stays empty for the daemon's per-device fallback.
     ADSBFIUSERNAME="${AIRPLANES_MLAT_USER:-}"
     NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
 

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -227,6 +227,37 @@ run_configure_env() {
     grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
 }
 
+@test "configure.sh build mode leaves an unset MLAT_USER empty (daemon fallback)" {
+    # Mirrors the image build invocation: build mode, MLAT off, geo
+    # placeholders, no name supplied. The baked default must NOT freeze
+    # "Anonymous" into the image — empty MLAT_USER lets airplanes-mlat pick
+    # a per-device "Anonymous-<short-id>" at runtime instead.
+    run_configure_env \
+        AIRPLANES_BUILD_MODE=1 \
+        AIRPLANES_MLAT_ENABLED="false" \
+        AIRPLANES_LATITUDE="0" \
+        AIRPLANES_LONGITUDE="0" \
+        AIRPLANES_ALTITUDE=""
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER=""' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'GEO_CONFIGURED=false' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'ALTITUDE=""' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh build mode still honors an explicit MLAT_USER" {
+    run_configure_env \
+        AIRPLANES_BUILD_MODE=1 \
+        AIRPLANES_MLAT_USER="ci-feeder" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="ci-feeder"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
 @test "configure.sh AIRPLANES_MLAT_ENABLED=false preserves the supplied name" {
     run_configure_env \
         AIRPLANES_MLAT_USER="alice" \


### PR DESCRIPTION
When configure.sh runs in build mode — used to generate the default feed.env baked into a flashable image — an unset MLAT name now stays empty instead of defaulting to "Anonymous". An empty name lets the mlat-client daemon pick its per-device `Anonymous-<short-id>` at runtime, so a generic image no longer freezes one shared name into every card.

Interactive and scripted installs are unchanged: a blank name there still falls back to "Anonymous".