### PR TITLE
Pick up remote config seconds after claiming, not on the next timer tick

### DIFF
--- a/scripts/apl-feed/backup.sh
+++ b/scripts/apl-feed/backup.sh
@@ -283,6 +283,12 @@ config_restore() {
     rm -f "$(secret_pending_path)"
     echo "Restored feeder config for Feeder ID $BACKUP_UUID"
 
+    # Claim secret is on disk — nudge config-sync so a remote-config-enabled
+    # feeder picks up its server-side configuration within seconds instead of
+    # the unit's ~60s timer tick. Nudge-only (restore doesn't manage the claim
+    # retry timer); the service self-gates on the opt-in.
+    nudge_config_sync_if_present
+
     if [[ "$existing_uuid" != "$BACKUP_UUID" ]]; then
         if ! restart_feeder_services; then
             echo "Saved, but service restart failed — daemons may still advertise the old Feeder ID until you restart them manually." >&2

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -119,11 +119,12 @@ claim_register() {
                     chmod 640 "$pending"
                     mv "$pending" "$final"
                 fi
-                # The secret is on disk; stop the timer before any later
-                # failure (write_version_file errno, echo EPIPE, etc.)
-                # could abort under `set -e` and leave the retry timer
-                # firing indefinitely against a now-claimed feeder.
-                stop_claim_timer_if_present
+                # The secret is on disk; run the claim-landed side effects
+                # (stop the retry timer, nudge config-sync) before any later
+                # failure (write_version_file errno, echo EPIPE, etc.) could
+                # abort under `set -e` and leave the retry timer firing
+                # indefinitely against a now-claimed feeder.
+                claim_secret_landed_side_effects
                 write_version_file "$version"
                 echo "SUCCESS ($status, version $version)"
                 echo "Secret persisted to $final"
@@ -503,15 +504,16 @@ claim_set() {
         # and the file mode (0600). Don't drop the version file — the
         # local secret bytes haven't functionally changed.
         write_secret_file "$final" "$secret"
-        stop_claim_timer_if_present
+        claim_secret_landed_side_effects
         echo "Local claim secret already matches — no change."
         return 0
     fi
 
     write_secret_file "$final" "$secret"
-    # Secret is on disk; stop the timer before any later step (rm,
-    # echo EPIPE) could abort under `set -e`.
-    stop_claim_timer_if_present
+    # Secret is on disk; run the claim-landed side effects (stop the retry
+    # timer, nudge config-sync) before any later step (rm, echo EPIPE) could
+    # abort under `set -e`.
+    claim_secret_landed_side_effects
 
     # Local secret no longer matches whatever the version file claimed.
     # Drop the version file so `claim show` / `backup` can't pair a

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -532,6 +532,40 @@ stop_claim_timer_if_present() {
     systemctl --no-block stop airplanes-claim.timer 2>/dev/null || true
 }
 
+# Nudge airplanes-config-sync.service so a just-claimed feeder syncs its
+# remote configuration within seconds instead of waiting for the unit's
+# ~60s timer tick. Mirrors stop_claim_timer_if_present's guards:
+# host-root-only (so a chroot / build-mode run doesn't poke the host's
+# systemd) and systemctl-present. The service self-gates — it skips when
+# the claim secret is absent (ConditionPathExists) and exits silently
+# unless REMOTE_CONFIG_ENABLED is opted in — so an unconditional nudge on
+# every secret-landed path is safe and idempotent.
+#
+# APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE is the test-only override (separate
+# from APL_FEED_TEST_TIMER_STOP_FORCE so a test can exercise one helper
+# without implicitly forcing the other). Production callers must never set
+# it.
+nudge_config_sync_if_present() {
+    if [[ "$ROOT" != "/" && -z "${APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE:-}" ]]; then
+        return 0
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 0
+    fi
+    systemctl --no-block start airplanes-config-sync.service 2>/dev/null || true
+}
+
+# Run the systemd side effects for "a claim secret just landed on disk":
+# stop the now-pointless claim retry timer, then nudge the config syncer.
+# Grouping the two keeps every secret-write success path consistent — a
+# future path can't silently pick up one side effect and miss the other.
+# Both self-gate, so calling this on a re-confirm or an already-claimed
+# feeder is a harmless no-op.
+claim_secret_landed_side_effects() {
+    stop_claim_timer_if_present
+    nudge_config_sync_if_present
+}
+
 parse_common_option() {
     case "${1:-}" in
         --root)

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -573,10 +573,12 @@ EOF
 
 @test "claim set never restarts feeder daemons (no daemon consumes the secret)" {
     # The claim secret is consumed only by apl-feed itself, not by
-    # airplanes-feed or airplanes-mlat. Saving it must not bounce a
-    # working feeder. The only permitted systemctl call is the post-write
-    # stop of airplanes-claim.timer (see test_claim_timer_stop.bats);
-    # this assertion pins that NOTHING ELSE is touched.
+    # airplanes-feed or airplanes-mlat. Saving it must not bounce a working
+    # feeder. The only permitted systemctl calls are the post-write
+    # claim-landed side effects — stop airplanes-claim.timer and nudge
+    # airplanes-config-sync.service (see test_claim_timer_stop.bats and
+    # test_config_sync_nudge.bats); this assertion pins that NOTHING ELSE
+    # (no daemon restart or reload) is touched.
     COMMAND_LOG="$(mktemp)"
     cat > "$STUB_BIN_DIR/systemctl" <<'STUB'
 #!/usr/bin/env bash
@@ -584,16 +586,17 @@ EOF
 exit 0
 STUB
     chmod +x "$STUB_BIN_DIR/systemctl"
-    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1
+    export COMMAND_LOG APL_FEED_TEST_TIMER_STOP_FORCE=1 APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE=1
 
     run env "$SCRIPT" claim set --root "$ROOT_DIR" <<<"ABCDEFGHIJKLMNOP"
 
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "Restarted" ]]
-    # Every recorded systemctl invocation must be the timer-stop. No
-    # restart, no reload, no apl-feed daemon touched.
+    # Every recorded systemctl invocation must be one of the two claim-landed
+    # side effects. No restart, no reload, no apl-feed daemon touched.
     while IFS= read -r line; do
-        [[ "$line" == "systemctl --no-block stop airplanes-claim.timer" ]] \
+        [[ "$line" == "systemctl --no-block stop airplanes-claim.timer" \
+            || "$line" == "systemctl --no-block start airplanes-config-sync.service" ]] \
             || { echo "unexpected systemctl call: $line" >&2; false; }
     done < "$COMMAND_LOG"
     rm -f "$COMMAND_LOG"

--- a/test/test_claim_register.bats
+++ b/test/test_claim_register.bats
@@ -396,12 +396,14 @@ mock_url() {
     grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
 }
 
-@test "201 success: timer stop sees secret on disk and no .pending (ordering)" {
-    # Pins the ordering invariant: stop_claim_timer_if_present must run
+@test "201 success: claim-landed side effects see secret on disk and no .pending (ordering)" {
+    # Pins the ordering invariant: the claim-landed side effects
+    # (stop_claim_timer_if_present + nudge_config_sync_if_present) must run
     # AFTER the mv "$pending" "$final" promotion, not before. A future
-    # refactor that moved the call earlier could stop the timer while
-    # the secret hasn't been persisted, breaking recovery if the script
-    # then aborts. The stub captures fs state at call time.
+    # refactor that moved the call earlier could stop the timer / nudge the
+    # syncer while the secret hasn't been persisted, breaking recovery if the
+    # script then aborts. The stub captures fs state at call time.
+    export APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE=1
     cat > "$STUB_BIN_DIR/systemctl" <<STUB
 #!/usr/bin/env bash
 final_present=missing
@@ -416,19 +418,30 @@ STUB
     start_mock_server
     run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
     [ "$status" -eq 0 ]
-    # When the helper was invoked, final must exist and pending must be gone.
-    grep -F -- 'final=present pending=missing' "$COMMAND_LOG"
-    # And the argv must be the timer-stop, not something else (defence
-    # against a refactor that calls systemctl elsewhere on the success path).
+    # Both side effects must observe the secret on disk with no leftover pending.
+    [ "$(grep -c -F -- 'final=present pending=missing' "$COMMAND_LOG")" = "2" ]
+    # Both expected argv shapes are present (defence against a refactor that
+    # calls systemctl elsewhere on the success path).
     grep -F -- 'argv=--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+    grep -F -- 'argv=--no-block start airplanes-config-sync.service' "$COMMAND_LOG"
+    # Timer stop precedes the config-sync nudge.
+    local stop_line start_line
+    stop_line="$(grep -n -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    start_line="$(grep -n -F -- 'start airplanes-config-sync.service' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    [ "$stop_line" -lt "$start_line" ]
 }
 
-@test "400 bad request does NOT stop the timer (secret not on disk)" {
+@test "400 bad request runs no claim-landed side effects (secret not on disk)" {
+    # Failure path: the secret is never written, so neither the timer-stop
+    # nor the config-sync nudge may fire. Force the nudge guard on to prove
+    # the gate is the success branch, not the ROOT check.
+    export APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE=1
     write_contract_response secret invalid_claim_secret
     start_mock_server
     run "$SCRIPT" claim register --root "$ROOT_DIR" --website-url "$(mock_url)"
     [ "$status" -eq 1 ]
     ! grep -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG"
+    ! grep -F -- 'start airplanes-config-sync.service' "$COMMAND_LOG"
 }
 
 @test "409 rotation_rejected does NOT stop the timer" {

--- a/test/test_config_sync_nudge.bats
+++ b/test/test_config_sync_nudge.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+#
+# Unit tests for nudge_config_sync_if_present and the
+# claim_secret_landed_side_effects grouping helper, both defined in
+# scripts/apl-feed/common.sh. Source-based so the helpers run in the
+# test's own shell — that lets us override the `command` builtin to fake
+# out `command -v systemctl` lookups (a PATH stub can hide our stubbed
+# systemctl but can't make the real /usr/bin/systemctl disappear from the
+# rest of PATH).
+#
+# Integration coverage (the nudge fires at the right time inside
+# claim_register / claim_set / restore and stays silent on failure paths)
+# lives in test_claim_register.bats and test_apl_feed_cli.bats.
+
+setup() {
+    COMMON_LIB="$BATS_TEST_DIRNAME/../scripts/apl-feed/common.sh"
+    STUB_DIR="$(mktemp -d)"
+    COMMAND_LOG="$(mktemp)"
+
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+
+    OLD_PATH="$PATH"
+    PATH="$STUB_DIR:$PATH"
+    export PATH COMMAND_LOG
+
+    # shellcheck source=/dev/null
+    source "$COMMON_LIB"
+}
+
+teardown() {
+    PATH="$OLD_PATH"
+    rm -rf "$STUB_DIR"
+    rm -f "$COMMAND_LOG"
+}
+
+# Hide systemctl from `command -v` so the no-systemctl branch is reachable
+# even on CI runners and dev boxes where /usr/bin/systemctl is preinstalled.
+_hide_systemctl_from_command_v() {
+    command() {
+        if [[ "$1" = "-v" && "$2" = "systemctl" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+}
+
+@test "nudge_config_sync_if_present invokes systemctl --no-block start on ROOT=/" {
+    ROOT="/"
+    run nudge_config_sync_if_present
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block start airplanes-config-sync.service' "$COMMAND_LOG"
+}
+
+@test "nudge_config_sync_if_present skips silently when ROOT != / without the force env" {
+    ROOT="/tmp/somerootfs"
+    unset APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE
+    run nudge_config_sync_if_present
+    [ "$status" -eq 0 ]
+    [ ! -s "$COMMAND_LOG" ]
+}
+
+@test "nudge_config_sync_if_present runs anyway when APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE=1" {
+    # Test seam used by the integration bats files so they can keep using
+    # --root for filesystem fixtures while still exercising the helper.
+    ROOT="/tmp/somerootfs"
+    APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE=1
+    run nudge_config_sync_if_present
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block start airplanes-config-sync.service' "$COMMAND_LOG"
+}
+
+@test "nudge_config_sync_if_present is silent with no systemctl in PATH" {
+    # Manual installs on non-systemd hosts (or chroots) shouldn't error.
+    _hide_systemctl_from_command_v
+    ROOT="/"
+    run nudge_config_sync_if_present
+    [ "$status" -eq 0 ]
+    [ ! -s "$COMMAND_LOG" ]
+}
+
+@test "nudge_config_sync_if_present exits 0 even when systemctl exits non-zero" {
+    # A host without the unit yet (or a transient systemd hiccup) returns
+    # non-zero from `systemctl start`. The trailing `|| true` must absorb it
+    # so the calling claim path still ends at `return 0`.
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'systemctl'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$COMMAND_LOG"
+exit 1
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    ROOT="/"
+    run nudge_config_sync_if_present
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block start airplanes-config-sync.service' "$COMMAND_LOG"
+}
+
+@test "nudge_config_sync_if_present passes the documented argv (pinned)" {
+    # Pin the exact argv: --no-block (returns immediately; the oneshot does a
+    # network round-trip), start (run it now rather than wait for the timer),
+    # airplanes-config-sync.service (the unit the image side ships).
+    ROOT="/"
+    run nudge_config_sync_if_present
+    [ "$status" -eq 0 ]
+    local logged; logged="$(cat "$COMMAND_LOG")"
+    [ "$logged" = "systemctl --no-block start airplanes-config-sync.service" ]
+}
+
+@test "claim_secret_landed_side_effects stops the timer then nudges config-sync, in order" {
+    ROOT="/"
+    run claim_secret_landed_side_effects
+    [ "$status" -eq 0 ]
+    grep -F -- '--no-block stop airplanes-claim.timer' "$COMMAND_LOG"
+    grep -F -- '--no-block start airplanes-config-sync.service' "$COMMAND_LOG"
+    # Timer stop is logged before the config-sync nudge.
+    local stop_line start_line
+    stop_line="$(grep -n -F -- 'stop airplanes-claim.timer' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    start_line="$(grep -n -F -- 'start airplanes-config-sync.service' "$COMMAND_LOG" | head -1 | cut -d: -f1)"
+    [ "$stop_line" -lt "$start_line" ]
+}
+
+@test "claim_secret_landed_side_effects honours both ROOT != / guards (silent)" {
+    # On a chroot / build-mode run (ROOT != /) with neither force env set,
+    # both side effects must stay silent so we never poke the host's systemd.
+    ROOT="/tmp/somerootfs"
+    unset APL_FEED_TEST_TIMER_STOP_FORCE
+    unset APL_FEED_TEST_CONFIG_SYNC_NUDGE_FORCE
+    run claim_secret_landed_side_effects
+    [ "$status" -eq 0 ]
+    [ ! -s "$COMMAND_LOG" ]
+}


### PR DESCRIPTION
When a feeder is claimed — or its identity is restored from a backup — apl-feed now triggers the config-sync service immediately instead of letting it wait for its periodic (~60s) tick. A feeder that has remote configuration enabled picks up its server-side settings within seconds of being claimed.

The trigger reuses the existing claim-secret-landed path and self-gates: it only starts the config-sync unit, which itself does nothing unless the feeder is claimed and has opted into remote configuration.