### PR TITLE
Add 'apl-feed claim status' to report account-claim state

### DIFF
--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -530,6 +530,165 @@ claim_set() {
 }
 
 
+# claim_status [--json]
+#
+# Read-only probe of the feeder's account-claim status against
+# /api/feeders/status. Distinguishes "registered with the backend" from
+# "claimed by a user account" (owner_present). Writes nothing — no
+# version-mirror update — so it runs unprivileged: the on-device webconfig
+# invokes it as the airplanes-webconfig user (the airplanes-feed group
+# grants read access to the claim secret). Emits a single result every
+# time; --json produces a stable schema-v1 object, otherwise a human line.
+claim_status() {
+    local opt_rc json=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help) usage_claim_status; exit 0 ;;
+            --json) json=1; shift; continue ;;
+        esac
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for claim status: $1" ;;
+        esac
+    done
+    require_jq
+
+    local result uuid final secret
+
+    # Local state first — these answers need no network call.
+    if ! uuid="$(read_uuid 2>/dev/null)"; then
+        _claim_status_emit no_identity "$json"
+        return 0
+    fi
+    final="$(secret_final_path)"
+    if [[ ! -f "$final" ]]; then
+        _claim_status_emit unregistered "$json"
+        return 0
+    fi
+    if [[ ! -r "$final" ]]; then
+        # Present but unreadable (permissions) — distinct from malformed.
+        # Re-registering won't fix a perms problem, so don't suggest it.
+        _claim_status_emit error "$json"
+        return 2
+    fi
+    if ! secret="$(read_secret_file "$final" 2>/dev/null)"; then
+        # Present but empty / non-canonical — a local corruption, distinct
+        # from "no secret". UI action: re-register.
+        _claim_status_emit secret_invalid "$json"
+        return 0
+    fi
+
+    claim_status_probe "$uuid" "$secret"
+    case "$CLAIM_PROBE_OUTCOME" in
+        authenticated)
+            case "$CLAIM_PROBE_OWNER_PRESENT" in
+                true)  result=claimed ;;
+                false) result=unclaimed ;;
+                # An authenticated reply always carries a boolean
+                # owner_present; anything else is a contract fault, not
+                # an "unclaimed" feeder.
+                *)     result=error ;;
+            esac
+            ;;
+        minimal)          result=secret_mismatch ;;
+        registered_false) result=server_unregistered ;;
+        blocked)          result=blocked ;;
+        rate_limited)     result=rate_limited ;;
+        unreachable)      result=unreachable ;;
+        *)                result=error ;;
+    esac
+    _claim_status_emit "$result" "$json"
+    case "$result" in
+        unreachable|error) return 2 ;;
+        *) return 0 ;;
+    esac
+}
+
+# _claim_status_emit <result> <json-flag>
+# Renders <result> as schema-v1 JSON (json=1) or a human line. Reads the
+# CLAIM_PROBE_* globals for server-derived fields; for the local-only
+# results (no_identity/unregistered/secret_invalid) those are empty, which
+# the JSON nullifies.
+_claim_status_emit() {
+    local result="$1" json="$2"
+    if (( json )); then
+        jq -nc \
+            --arg result "$result" \
+            --arg registered "${CLAIM_PROBE_REGISTERED:-}" \
+            --arg owner_present "${CLAIM_PROBE_OWNER_PRESENT:-}" \
+            --arg version "${CLAIM_PROBE_VERSION:-}" \
+            --arg reset_until "${CLAIM_PROBE_RESET_UNTIL:-}" \
+            --arg last_seen_at "${CLAIM_PROBE_LAST_SEEN_AT:-}" \
+            --arg last_seen_age "${CLAIM_PROBE_LAST_SEEN_AGE:-}" \
+            --arg retry_after "${CLAIM_PROBE_RETRY_AFTER:-}" \
+            --arg detail "${CLAIM_PROBE_DETAIL:-}" \
+            '
+            def nullempty: if . == "" then null else . end;
+            def boolish: if . == "true" then true elif . == "false" then false else null end;
+            def numberish: if . == "" then null else (tonumber? // null) end;
+            {
+              schema_version: 1,
+              result: $result,
+              registered: ($registered | boolish),
+              owner_present: ($owner_present | boolish),
+              version: ($version | numberish),
+              reset_until: ($reset_until | nullempty),
+              last_seen_at: ($last_seen_at | nullempty),
+              last_seen_age_seconds: ($last_seen_age | numberish),
+              retry_after_seconds: ($retry_after | numberish),
+              detail: ($detail | nullempty)
+            }'
+        return
+    fi
+    _claim_status_human "$result"
+}
+
+# _claim_status_human <result> — one or two readable lines per result.
+_claim_status_human() {
+    local result="$1"
+    case "$result" in
+        claimed)
+            echo "Claimed: yes — this feeder is linked to an airplanes.live account." ;;
+        unclaimed)
+            echo "Claimed: no — registered, but not yet linked to an account."
+            echo "Claim it at: $(claim_page_url)" ;;
+        secret_mismatch)
+            echo "The claim secret on this feeder did not authenticate with airplanes.live."
+            echo "Re-register: sudo apl-feed claim register" ;;
+        server_unregistered)
+            echo "airplanes.live has no record of this feeder's claim secret."
+            echo "Register: sudo apl-feed claim register" ;;
+        unregistered)
+            echo "No claim secret on this feeder yet."
+            echo "Register: sudo apl-feed claim register" ;;
+        secret_invalid)
+            echo "The local claim secret is missing or malformed."
+            echo "Re-register: sudo apl-feed claim register" ;;
+        no_identity)
+            echo "This device has no Feeder ID yet." ;;
+        blocked)
+            echo "This feeder is blocked by an administrator." ;;
+        rate_limited)
+            echo "airplanes.live is rate-limiting status checks; try again shortly." ;;
+        unreachable)
+            echo "Could not reach airplanes.live to check claim status." ;;
+        *)
+            echo "Claim status unavailable." ;;
+    esac
+}
+
+usage_claim_status() {
+    cat <<'USAGE'
+Usage: apl-feed claim status [--json]
+
+Reports whether this feeder is registered with airplanes.live and whether a
+user account has claimed it. Contacts the website read-only and writes
+nothing. --json emits a machine-readable object instead of the summary.
+USAGE
+}
+
 usage_claim() {
     cat <<'USAGE'
 Usage: apl-feed claim <subcommand> [options]
@@ -537,6 +696,7 @@ Usage: apl-feed claim <subcommand> [options]
 Subcommands:
   register    Generate and register the claim secret with airplanes.live
   show        Print the local claim secret and the claim page URL
+  status      Show registration + account-claim status (--json available)
   rotate      Rotate the claim secret (--abort cancels a pending rotation)
   set         Save a claim secret minted by the website (reads stdin)
 
@@ -598,6 +758,7 @@ dispatch_claim() {
     case "$sub" in
         register) claim_register "$@" ;;
         show) claim_show "$@" ;;
+        status) claim_status "$@" ;;
         rotate) claim_rotate "$@" ;;
         set) claim_set "$@" ;;
         *) usage_error usage_claim "unknown claim subcommand: $sub" ;;

--- a/scripts/apl-feed/http.sh
+++ b/scripts/apl-feed/http.sh
@@ -103,3 +103,130 @@ status_probe_version() {
     [[ -n "$version" && "$version" != "null" ]] || return 1
     printf '%s' "$version"
 }
+
+# claim_status_probe <uuid> <secret>
+#
+# Single source of truth for probing POST /api/feeders/status and parsing
+# its response. Both `apl-feed status` (claim_registration_status_line)
+# and `apl-feed claim status` consume the CLAIM_PROBE_* output globals, so
+# the two never drift on the wire shape. Builds a Bearer token from the
+# uuid + secret, POSTs, and classifies the reply. Always returns 0 — the
+# outcome travels in CLAIM_PROBE_OUTCOME so callers under `set -e` are not
+# aborted by a non-2xx reply. Does NOT touch the on-disk version mirror;
+# a caller that wants that side effect calls write_version_file itself.
+#
+# Outputs (reset on every call; empty when not applicable):
+#   CLAIM_PROBE_OUTCOME   unreachable|registered_false|authenticated|minimal|blocked|rate_limited|http_error
+#   CLAIM_PROBE_HTTP      numeric HTTP status ("" on transport failure)
+#   CLAIM_PROBE_REGISTERED   raw .registered ("true"/"false"/"")
+#   CLAIM_PROBE_OWNER_PRESENT raw .owner_present ("true"/"false"/"")
+#   CLAIM_PROBE_VERSION   raw .version
+#   CLAIM_PROBE_RESET_UNTIL  raw .reset_until
+#   CLAIM_PROBE_LAST_SEEN_PRESENT  "true" when the last_seen_at key exists
+#                                  (distinct from a present-but-null value)
+#   CLAIM_PROBE_LAST_SEEN_AT  raw .last_seen_at ("" when null or key absent)
+#   CLAIM_PROBE_LAST_SEEN_AGE raw .last_seen_age_seconds
+#   CLAIM_PROBE_RETRY_AFTER   raw .retry_after (429 only)
+#   CLAIM_PROBE_ERROR     raw .error (non-200 diagnostics)
+#   CLAIM_PROBE_DETAIL    short body preview (diagnostics)
+#
+# CLAIM_PROBE_* are consumed by sibling apl-feed modules (claim.sh,
+# status.sh), not within this file (SC2034 is disabled repo-wide).
+claim_status_probe() {
+    local uuid="$1" secret="$2"
+    CLAIM_PROBE_OUTCOME=''
+    CLAIM_PROBE_HTTP=''
+    CLAIM_PROBE_REGISTERED=''
+    CLAIM_PROBE_OWNER_PRESENT=''
+    CLAIM_PROBE_VERSION=''
+    CLAIM_PROBE_RESET_UNTIL=''
+    CLAIM_PROBE_LAST_SEEN_PRESENT=''
+    CLAIM_PROBE_LAST_SEEN_AT=''
+    CLAIM_PROBE_LAST_SEEN_AGE=''
+    CLAIM_PROBE_RETRY_AFTER=''
+    CLAIM_PROBE_ERROR=''
+    CLAIM_PROBE_DETAIL=''
+
+    local response_file status curl_rc body token
+    response_file="$(mktemp)"
+    # Body carries only the UUID; auth is in the Bearer header.
+    body="$(printf '{"uuid":"%s"}' "$uuid")"
+    # Honor the always-returns-0 contract: bad uuid/secret inputs would
+    # otherwise abort under set -e via the failing command substitution.
+    if ! token="$(apl_auth_token "$uuid" "$secret")"; then
+        CLAIM_PROBE_OUTCOME='error'
+        CLAIM_PROBE_DETAIL='invalid auth token inputs'
+        rm -f "$response_file"
+        return 0
+    fi
+    set +e
+    status="$(post_json_bearer "$token" '/api/feeders/status' "$body" "$response_file")"
+    curl_rc=$?
+    set -e
+    CLAIM_PROBE_HTTP="$status"
+    if [[ "$curl_rc" -ne 0 ]]; then
+        CLAIM_PROBE_OUTCOME='unreachable'
+        CLAIM_PROBE_DETAIL="curl rc=$curl_rc"
+        rm -f "$response_file"
+        return 0
+    fi
+    CLAIM_PROBE_ERROR="$(parse_field_from "$response_file" '.error')"
+    CLAIM_PROBE_DETAIL="$(body_preview "$response_file")"
+    case "$status" in
+        200)
+            # A 200 must carry a JSON object; an HTML error page or a
+            # truncated body is a contract fault, not "unregistered".
+            if ! jq -e . "$response_file" >/dev/null 2>&1; then
+                CLAIM_PROBE_OUTCOME='http_error'
+                rm -f "$response_file"
+                return 0
+            fi
+            CLAIM_PROBE_REGISTERED="$(parse_field_from "$response_file" '.registered')"
+            case "$CLAIM_PROBE_REGISTERED" in
+                true) ;;
+                false)
+                    CLAIM_PROBE_OUTCOME='registered_false'
+                    rm -f "$response_file"
+                    return 0
+                    ;;
+                *)
+                    # `registered` missing or non-boolean on a valid-JSON
+                    # 200: a contract fault, surfaced as an error rather
+                    # than a (false) claim state.
+                    CLAIM_PROBE_OUTCOME='http_error'
+                    rm -f "$response_file"
+                    return 0
+                    ;;
+            esac
+            CLAIM_PROBE_VERSION="$(parse_field_from "$response_file" '.version')"
+            CLAIM_PROBE_OWNER_PRESENT="$(parse_field_from "$response_file" '.owner_present')"
+            CLAIM_PROBE_RESET_UNTIL="$(parse_field_from "$response_file" '.reset_until')"
+            # The authenticated reply carries a version; a minimal reply
+            # (wrong/superseded local secret) is registered:true with no
+            # version — surfaced distinctly so the UI says "re-register"
+            # rather than "claimed".
+            if [[ -n "$CLAIM_PROBE_VERSION" ]]; then
+                CLAIM_PROBE_OUTCOME='authenticated'
+                CLAIM_PROBE_LAST_SEEN_PRESENT="$(json_has_key "$response_file" 'last_seen_at')"
+                if [[ "$CLAIM_PROBE_LAST_SEEN_PRESENT" == "true" ]]; then
+                    CLAIM_PROBE_LAST_SEEN_AT="$(parse_field_from "$response_file" '.last_seen_at')"
+                    CLAIM_PROBE_LAST_SEEN_AGE="$(parse_field_from "$response_file" '.last_seen_age_seconds')"
+                fi
+            else
+                CLAIM_PROBE_OUTCOME='minimal'
+            fi
+            ;;
+        423)
+            CLAIM_PROBE_OUTCOME='blocked'
+            ;;
+        429)
+            CLAIM_PROBE_OUTCOME='rate_limited'
+            CLAIM_PROBE_RETRY_AFTER="$(parse_field_from "$response_file" '.retry_after')"
+            ;;
+        *)
+            CLAIM_PROBE_OUTCOME='http_error'
+            ;;
+    esac
+    rm -f "$response_file"
+    return 0
+}

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -519,9 +519,7 @@ server_reception_status_line() {
 claim_registration_status_line() {
     require_jq
 
-    local uuid final pending secret response_file body status curl_rc token
-    local registered version owner_present reset_until error preview
-    local last_seen_present last_seen_at last_seen_age
+    local uuid final pending secret
 
     if ! uuid="$(read_uuid 2>/dev/null)"; then
         status_line fail "Feeder ID" "missing or invalid"
@@ -547,70 +545,56 @@ claim_registration_status_line() {
         status_line warn "Claim rotation" "pending rotation file exists"
     fi
 
-    response_file="$(new_tmp_file)"
-    # Body carries only the UUID; auth is in the Bearer header.
-    body="$(printf '{"uuid":"%s"}' "$uuid")"
-    token="$(apl_auth_token "$uuid" "$secret")"
-    set +e
-    status="$(post_json_bearer "$token" '/api/feeders/status' "$body" "$response_file")"
-    curl_rc=$?
-    set -e
-    if [[ "$curl_rc" -ne 0 ]]; then
-        status_line warn "Website claim" "unreachable (curl rc=$curl_rc)"
-        return
-    fi
-
-    error="$(parse_field_from "$response_file" '.error')"
-    preview="$(body_preview "$response_file")"
-    case "$status" in
-        200)
-            registered="$(parse_field_from "$response_file" '.registered')"
-            version="$(parse_field_from "$response_file" '.version')"
-            owner_present="$(parse_field_from "$response_file" '.owner_present')"
-            reset_until="$(parse_field_from "$response_file" '.reset_until')"
-            STATUS_CLAIM_REGISTERED="$registered"
-            if [[ "$registered" != "true" ]]; then
-                status_line warn "Website claim" "not registered; run sudo apl-feed claim register"
-                return
-            fi
-            if [[ -n "$version" ]]; then
-                STATUS_CLAIM_VERSION="$version"
-                STATUS_OWNER_PRESENT="$owner_present"
-                write_version_file "$version"
-                # Claim-secret version is internal bookkeeping; exposed
-                # via --json (.claim.version) and the local mirror file
-                # ($IPATH/feeder-claim-secret.version) for tooling.
-                # Omitting it from the human line keeps the output
-                # readable — a `v1`-vs-`vN` number tells operators
-                # nothing actionable.
-                if [[ "$owner_present" == "true" ]]; then
-                    status_line ok "Website claim" "registered and claimed"
-                else
-                    status_line ok "Website claim" "registered, not yet claimed"
-                fi
-                if [[ -n "$reset_until" && "$reset_until" != "null" ]]; then
-                    status_line warn "Claim reset" "locked until $reset_until"
-                fi
-                last_seen_present="$(json_has_key "$response_file" 'last_seen_at')"
-                if [[ "$last_seen_present" == "true" ]]; then
-                    last_seen_at="$(parse_field_from "$response_file" '.last_seen_at')"
-                    last_seen_age="$(parse_field_from "$response_file" '.last_seen_age_seconds')"
-                    STATUS_LAST_SEEN_AT="$last_seen_at"
-                    STATUS_LAST_SEEN_AGE_SECONDS="$last_seen_age"
-                    server_reception_status_line
-                fi
+    # Probe POST /api/feeders/status via the shared helper (http.sh) so
+    # this renderer and `apl-feed claim status` never drift on the wire
+    # shape. The helper carries its outcome in CLAIM_PROBE_*; we render
+    # from those and own the version-mirror write here.
+    claim_status_probe "$uuid" "$secret"
+    case "$CLAIM_PROBE_OUTCOME" in
+        unreachable)
+            status_line warn "Website claim" "unreachable ($CLAIM_PROBE_DETAIL)"
+            ;;
+        registered_false)
+            STATUS_CLAIM_REGISTERED="$CLAIM_PROBE_REGISTERED"
+            status_line warn "Website claim" "not registered; run sudo apl-feed claim register"
+            ;;
+        authenticated)
+            STATUS_CLAIM_REGISTERED='true'
+            STATUS_CLAIM_VERSION="$CLAIM_PROBE_VERSION"
+            STATUS_OWNER_PRESENT="$CLAIM_PROBE_OWNER_PRESENT"
+            write_version_file "$CLAIM_PROBE_VERSION"
+            # Claim-secret version is internal bookkeeping; exposed
+            # via --json (.claim.version) and the local mirror file
+            # ($IPATH/feeder-claim-secret.version) for tooling.
+            # Omitting it from the human line keeps the output
+            # readable — a `v1`-vs-`vN` number tells operators
+            # nothing actionable.
+            if [[ "$CLAIM_PROBE_OWNER_PRESENT" == "true" ]]; then
+                status_line ok "Website claim" "registered and claimed"
             else
-                status_line warn "Website claim" "registered, but local secret did not authenticate"
+                status_line ok "Website claim" "registered, not yet claimed"
+            fi
+            if [[ -n "$CLAIM_PROBE_RESET_UNTIL" && "$CLAIM_PROBE_RESET_UNTIL" != "null" ]]; then
+                status_line warn "Claim reset" "locked until $CLAIM_PROBE_RESET_UNTIL"
+            fi
+            if [[ "$CLAIM_PROBE_LAST_SEEN_PRESENT" == "true" ]]; then
+                STATUS_LAST_SEEN_AT="$CLAIM_PROBE_LAST_SEEN_AT"
+                STATUS_LAST_SEEN_AGE_SECONDS="$CLAIM_PROBE_LAST_SEEN_AGE"
+                server_reception_status_line
             fi
             ;;
-        423)
-            status_line fail "Website claim" "${error:-blocked}: $preview"
+        minimal)
+            STATUS_CLAIM_REGISTERED='true'
+            status_line warn "Website claim" "registered, but local secret did not authenticate"
             ;;
-        429)
-            status_line warn "Website claim" "rate-limited: $preview"
+        blocked)
+            status_line fail "Website claim" "${CLAIM_PROBE_ERROR:-blocked}: $CLAIM_PROBE_DETAIL"
+            ;;
+        rate_limited)
+            status_line warn "Website claim" "rate-limited: $CLAIM_PROBE_DETAIL"
             ;;
         *)
-            status_line warn "Website claim" "unexpected HTTP $status: $preview"
+            status_line warn "Website claim" "unexpected HTTP $CLAIM_PROBE_HTTP: $CLAIM_PROBE_DETAIL"
             ;;
     esac
 }

--- a/test/test_claim_status.bats
+++ b/test/test_claim_status.bats
@@ -1,0 +1,262 @@
+#!/usr/bin/env bats
+
+# Unit tests for `apl-feed claim status` (claim.sh:claim_status) and the
+# shared probe it leans on (http.sh:claim_status_probe).
+#
+# Most cases stub `post_json_bearer` to write a prepared response and
+# return a chosen HTTP code — no Python server needed. Local-state cases
+# (no_identity / unregistered / secret_invalid) assert the probe is never
+# reached.
+
+setup() {
+    LIB_DIR="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    TMPDIR="$ROOT_DIR/tmp"
+    mkdir -p "$TMPDIR" "$ROOT_DIR/etc/airplanes"
+    export TMPDIR
+    APL_FEED_SECRET_OWNER="$(id -un)"
+    APL_FEED_SECRET_GROUP="$(id -gn)"
+    export APL_FEED_SECRET_OWNER APL_FEED_SECRET_GROUP
+
+    # common.sh installs an EXIT trap; save/restore bats's own so teardown
+    # still fires (mirrors test_apl_feed_status.bats).
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$LIB_DIR/common.sh"
+    # shellcheck source=../scripts/apl-feed/http.sh
+    source "$LIB_DIR/http.sh"
+    # shellcheck source=../scripts/apl-feed/claim.sh
+    source "$LIB_DIR/claim.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    # post_json_bearer is stubbed in every server-path test; this URL is
+    # never actually dialed.
+    WEBSITE_URL="http://127.0.0.1:0"
+    UUID='11111111-2222-3333-4444-555555555555'
+    SECRET='ABCDEFGHIJKLMNOP'
+    PROBE_CALLS="$ROOT_DIR/probe.calls"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Seed feeder-id (+ optionally a valid claim secret).
+setup_claim_state() {
+    local write_secret="${1:-1}"
+    printf '%s\n' "$UUID" > "$ROOT_DIR/etc/airplanes/feeder-id"
+    if (( write_secret )); then
+        printf '%s\n' "$SECRET" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+        chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    fi
+}
+
+# Stub post_json_bearer to write a prepared response and return a code.
+# Records each call so local-state tests can assert "no probe". On the
+# rc=99 sentinel, simulates a transport failure (curl rc != 0).
+stub_post_json() {
+    local code="$1" body="$2"
+    eval "
+post_json_bearer() {
+    printf 'called\n' >> '$PROBE_CALLS'
+    local response_file=\"\$4\"
+    if [[ '$code' == '99' ]]; then
+        return 7
+    fi
+    printf '%s' '$body' > \"\$response_file\"
+    printf '%s' '$code'
+    return 0
+}
+"
+}
+
+jqr() { printf '%s' "$1" | jq -r "$2"; }
+
+# --- local state (no network) -------------------------------------------
+
+@test "claim status: no Feeder ID → no_identity, no probe" {
+    stub_post_json 200 '{}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'no_identity' ]
+    [ ! -f "$PROBE_CALLS" ]
+}
+
+@test "claim status: Feeder ID but no secret → unregistered, no probe" {
+    setup_claim_state 0
+    stub_post_json 200 '{}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'unregistered' ]
+    [ ! -f "$PROBE_CALLS" ]
+}
+
+@test "claim status: zero-byte secret → secret_invalid, no probe" {
+    setup_claim_state 0
+    : > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    stub_post_json 200 '{}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'secret_invalid' ]
+    [ ! -f "$PROBE_CALLS" ]
+}
+
+@test "claim status: non-canonical secret → secret_invalid, no probe" {
+    setup_claim_state 0
+    printf 'not-a-valid-secret\n' > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    stub_post_json 200 '{}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'secret_invalid' ]
+    [ ! -f "$PROBE_CALLS" ]
+}
+
+# --- server outcomes ----------------------------------------------------
+
+@test "claim status: 200 registered+owner → claimed (exit 0)" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":true,"reset_until":null,"last_seen_at":"2026-06-03T10:00:00Z","last_seen_age_seconds":12}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.schema_version')" = '1' ]
+    [ "$(jqr "$output" '.result')" = 'claimed' ]
+    [ "$(jqr "$output" '.registered')" = 'true' ]
+    [ "$(jqr "$output" '.owner_present')" = 'true' ]
+    [ "$(jqr "$output" '.version')" = '7' ]
+    [ "$(jqr "$output" '.last_seen_at')" = '2026-06-03T10:00:00Z' ]
+    [ "$(jqr "$output" '.last_seen_age_seconds')" = '12' ]
+}
+
+@test "claim status: 200 registered, owner_present:false → unclaimed" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'unclaimed' ]
+    [ "$(jqr "$output" '.owner_present')" = 'false' ]
+}
+
+@test "claim status: 200 registered:true, no version (minimal) → secret_mismatch" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'secret_mismatch' ]
+}
+
+@test "claim status: 200 registered:false → server_unregistered" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":false}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'server_unregistered' ]
+    [ "$(jqr "$output" '.registered')" = 'false' ]
+}
+
+@test "claim status: 200 registered:true+version but missing owner_present → error" {
+    # An authenticated reply must carry a boolean owner_present; its
+    # absence is a contract fault, not an "unclaimed" feeder.
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7}'
+    run claim_status --json
+    [ "$status" -eq 2 ]
+    [ "$(jqr "$output" '.result')" = 'error' ]
+}
+
+@test "claim status: 423 → blocked (exit 0)" {
+    setup_claim_state 1
+    stub_post_json 423 '{"error":"data_blocked"}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'blocked' ]
+}
+
+@test "claim status: 429 → rate_limited with retry_after_seconds" {
+    setup_claim_state 1
+    stub_post_json 429 '{"error":"rate_limited","retry_after":42}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'rate_limited' ]
+    [ "$(jqr "$output" '.retry_after_seconds')" = '42' ]
+}
+
+@test "claim status: transport failure → unreachable (exit 2)" {
+    setup_claim_state 1
+    stub_post_json 99 ''
+    run claim_status --json
+    [ "$status" -eq 2 ]
+    [ "$(jqr "$output" '.result')" = 'unreachable' ]
+}
+
+@test "claim status: unexpected HTTP → error (exit 2)" {
+    setup_claim_state 1
+    stub_post_json 503 '{"error":"upstream_down"}'
+    run claim_status --json
+    [ "$status" -eq 2 ]
+    [ "$(jqr "$output" '.result')" = 'error' ]
+}
+
+@test "claim status: 200 with non-JSON body → error (not server_unregistered)" {
+    setup_claim_state 1
+    stub_post_json 200 '<html>gateway error</html>'
+    run claim_status --json
+    [ "$status" -eq 2 ]
+    [ "$(jqr "$output" '.result')" = 'error' ]
+}
+
+@test "claim status: 200 valid JSON missing 'registered' → error" {
+    setup_claim_state 1
+    stub_post_json 200 '{"foo":1}'
+    run claim_status --json
+    [ "$status" -eq 2 ]
+    [ "$(jqr "$output" '.result')" = 'error' ]
+}
+
+@test "claim status: present but unreadable secret → error, no probe" {
+    if [[ "$(id -u)" -eq 0 ]]; then skip "root bypasses file permissions"; fi
+    setup_claim_state 1
+    chmod 000 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":true}'
+    run claim_status --json
+    [ "$status" -eq 2 ]
+    [ "$(jqr "$output" '.result')" = 'error' ]
+    [ ! -f "$PROBE_CALLS" ]
+}
+
+# --- human output -------------------------------------------------------
+
+@test "claim status (human): claimed prints 'Claimed: yes'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":true}'
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Claimed: yes'* ]]
+}
+
+@test "claim status (human): unclaimed points at the claim page" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false}'
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Claimed: no'* ]]
+    [[ "$output" == *'/feeder/claim'* ]]
+}
+
+# --- dispatch + usage ---------------------------------------------------
+
+@test "claim status: --help exits 0 and prints usage" {
+    run claim_status --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'apl-feed claim status'* ]]
+}
+
+@test "dispatch_claim routes 'status' to claim_status" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":true}'
+    run dispatch_claim status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'claimed' ]
+}


### PR DESCRIPTION
Adds `apl-feed claim status` — a read-only command that reports whether a feeder is registered with airplanes.live and whether a user account has actually claimed it. It probes the feeder-status endpoint with the local claim secret and prints a short human summary, or a stable machine-readable object with `--json`.

The command writes nothing and needs no elevated privileges, so on-device tooling can call it directly. Response parsing is shared with `apl-feed status` so the two stay consistent on the wire shape.