### PR TITLE
Stop hourly restart churn while MLAT is disabled

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -77,7 +77,7 @@ Format: `schema_version=1`, env-style `KEY=value` lines, atomic mktemp+rename so
 
 **`MLAT_ENABLED` is checked before geo** in `airplanes-mlat.sh`'s state classifier — explicit disable wins over a 0/0 (unset coords) misconfiguration. The classifier produces `enabled` / `disabled` / `misconfigured`.
 
-**`update.sh` does NOT disable `airplanes-mlat` at the systemd level** based on config-derived disable. The unit stays enabled; the daemon self-disables via `sleep`+`exit`. User-visible: a `MLAT_ENABLED=false` feeder shows the unit as `enabled+active(sleeping)` rather than `disabled+inactive`. This keeps the daemon-owned state-file pattern coherent — future state consumers don't need to re-derive the predicate from `feed.env`.
+**`update.sh` does NOT disable `airplanes-mlat` at the systemd level** based on config-derived disable. The unit stays enabled; the daemon self-disables by idling in a config-watch loop that exits 0 (→ `Restart=always` re-exec) only when a config source actually changes — a blind periodic exit would climb the systemd restart counter forever on disabled feeders. User-visible: a `MLAT_ENABLED=false` feeder shows the unit as `enabled+active(sleeping)` rather than `disabled+inactive`. This keeps the daemon-owned state-file pattern coherent — future state consumers don't need to re-derive the predicate from `feed.env`.
 
 Daemons use a **defensive `source`** of the state-writer so a partial install (lib missing or unreadable) can't take the daemon down at startup.
 

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -21,13 +21,23 @@ FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
 # PRIVACY / MLAT_MARKER / GEO_CONFIGURED (e.g. from a Drop-In) would
 # otherwise mask the on-disk value.
 unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER GEO_CONFIGURED
+# _mlat_config_sources records which files govern this activation so the
+# disabled branch's watch below only restarts on changes the next
+# activation would actually see. The legacy branch also watches feed.env
+# (its creation flips the feeder to the canonical branch); the canonical
+# branch does NOT watch the boot files — the legacy web UI keeps writing
+# /boot/airplanes-config.txt on migrated feeders, and those writes are
+# invisible to a feed.env-governed daemon.
 if [[ -f "$FEED_ENV" ]]; then
     source "$FEED_ENV"
+    _mlat_config_sources=("$FEED_ENV")
 elif [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && -f "$BOOT_CONFIG" ]]; then
     source "$BOOT_CONFIG"
     [[ -f "$BOOT_ENV" ]] && source "$BOOT_ENV"
+    _mlat_config_sources=("$FEED_ENV" "$BOOT_CONFIG" "$BOOT_ENV")
 else
     source "$FEED_ENV"
+    _mlat_config_sources=("$FEED_ENV")
 fi
 
 # Schema guard: this wrapper requires the new MLAT_USER + MLAT_ENABLED
@@ -194,21 +204,27 @@ _mlat_classify() {
 AIRPLANES_MLAT_DISABLED_SLEEP="${AIRPLANES_MLAT_DISABLED_SLEEP:-60}"
 if [[ "$AIRPLANES_MLAT_DISABLED_SLEEP" =~ ^[0-9]+$ ]]; then
     AIRPLANES_MLAT_DISABLED_SLEEP=$((10#$AIRPLANES_MLAT_DISABLED_SLEEP))
+    # An absurd digit string overflows bash arithmetic to a negative
+    # value, and a failing `sleep -N` would hot-loop the watch (no set -e
+    # here to stop it).
+    if (( AIRPLANES_MLAT_DISABLED_SLEEP < 0 )); then
+        echo "AIRPLANES_MLAT_DISABLED_SLEEP overflowed; using 60." >&2
+        AIRPLANES_MLAT_DISABLED_SLEEP=60
+    fi
 else
     echo "AIRPLANES_MLAT_DISABLED_SLEEP='$AIRPLANES_MLAT_DISABLED_SLEEP' is not a non-negative integer; using 60." >&2
     AIRPLANES_MLAT_DISABLED_SLEEP=60
 fi
 
-# Fingerprint of every config source this wrapper may have sourced above
-# (feed.env on current installs; the boot config + boot env on legacy
-# images). device:inode:size plus nanosecond mtime/ctime catch atomic-
-# rename replacement, in-place rewrites, and creation/deletion ("missing",
-# so a file appearing counts as a change). stat needs only search
-# permission on the parent directory, so this works for the unprivileged
-# service user.
+# Fingerprint of the config sources governing this activation (see
+# _mlat_config_sources above). device:inode:size plus nanosecond
+# mtime/ctime catch atomic-rename replacement, in-place rewrites, and
+# creation/deletion ("missing", so a file appearing counts as a change).
+# stat needs only search permission on the parent directory, so this
+# works for the unprivileged service user.
 _mlat_config_fingerprint() {
     local f out=""
-    for f in "$FEED_ENV" "$BOOT_CONFIG" "$BOOT_ENV"; do
+    for f in "${_mlat_config_sources[@]}"; do
         out+="$(stat -c '%d:%i:%s:%y:%z' "$f" 2>/dev/null || printf 'missing');"
     done
     printf '%s' "$out"

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -185,6 +185,35 @@ _mlat_classify() {
     printf 'enabled ok\n'
 }
 
+# Watch poll interval for the disabled branch below; 0 is a test-only knob
+# that makes the branch single-pass (bats). Do not set 0 in production:
+# 0 + Restart=always = restart storm. Non-integer values fall back to the
+# default rather than crashing `sleep`; the base-10 normalization collapses
+# leading zeros ("00" → "0") so the single-pass comparison can't be
+# bypassed into a zero-second loop.
+AIRPLANES_MLAT_DISABLED_SLEEP="${AIRPLANES_MLAT_DISABLED_SLEEP:-60}"
+if [[ "$AIRPLANES_MLAT_DISABLED_SLEEP" =~ ^[0-9]+$ ]]; then
+    AIRPLANES_MLAT_DISABLED_SLEEP=$((10#$AIRPLANES_MLAT_DISABLED_SLEEP))
+else
+    echo "AIRPLANES_MLAT_DISABLED_SLEEP='$AIRPLANES_MLAT_DISABLED_SLEEP' is not a non-negative integer; using 60." >&2
+    AIRPLANES_MLAT_DISABLED_SLEEP=60
+fi
+
+# Fingerprint of every config source this wrapper may have sourced above
+# (feed.env on current installs; the boot config + boot env on legacy
+# images). device:inode:size plus nanosecond mtime/ctime catch atomic-
+# rename replacement, in-place rewrites, and creation/deletion ("missing",
+# so a file appearing counts as a change). stat needs only search
+# permission on the parent directory, so this works for the unprivileged
+# service user.
+_mlat_config_fingerprint() {
+    local f out=""
+    for f in "$FEED_ENV" "$BOOT_CONFIG" "$BOOT_ENV"; do
+        out+="$(stat -c '%d:%i:%s:%y:%z' "$f" 2>/dev/null || printf 'missing');"
+    done
+    printf '%s' "$out"
+}
+
 read -r STATE REASON < <(_mlat_classify)
 STATE_FILE="$(airplanes_path /run/airplanes-mlat/state)"
 mkdir -p "$(dirname "$STATE_FILE")"
@@ -204,8 +233,24 @@ airplanes_write_state "$STATE_FILE" \
 case "$STATE" in
     disabled)
         echo MLAT DISABLED
-        sleep 3600
-        exit
+        # Idle until a config source changes, then exit 0 so Restart=always
+        # re-execs the wrapper against the fresh config. The supported
+        # config tools (webconfig, apl-feed apply) restart this unit
+        # explicitly when relevant keys change, so the watch only serves
+        # hand-edited files. The previous blind hourly exit climbed the
+        # systemd restart counter forever on every MLAT-disabled feeder —
+        # including every feeder without configured coordinates.
+        _mlat_config_baseline="$(_mlat_config_fingerprint)"
+        while :; do
+            sleep "$AIRPLANES_MLAT_DISABLED_SLEEP"
+            if [[ "$(_mlat_config_fingerprint)" != "$_mlat_config_baseline" ]]; then
+                exit 0
+            fi
+            # Test knob: interval 0 means single-pass.
+            if [[ "$AIRPLANES_MLAT_DISABLED_SLEEP" == "0" ]]; then
+                exit 0
+            fi
+        done
         ;;
     misconfigured)
         # Matches RestartPreventExitStatus=64 in the unit file so

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -756,9 +756,69 @@ SH
     [[ "$output" == *'MLAT DISABLED'* ]]
 }
 
-@test "airplanes-mlat.sh: disabled watch — legacy boot config change also wakes the watch" {
-    # Legacy images source the boot config; the watch covers every config
-    # source, not just feed.env.
+# Write a legacy-image layout: no feed.env, the airplanes-feeder binary
+# marker present, and a post-migration-schema boot config that classifies
+# as disabled. The wrapper then takes the BOOT_CONFIG source branch.
+write_legacy_disabled_boot_config() {
+    local root="$1"
+    mkdir -p "$root/boot" "$root/usr/bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/usr/bin/airplanes-feeder"
+    cat > "$root/boot/airplanes-config.txt" <<'EOF'
+MLAT_USER="legacy-feeder"
+MLAT_ENABLED=false
+LATITUDE="52.52000"
+LONGITUDE="13.40500"
+ALTITUDE="35"
+EOF
+}
+
+@test "airplanes-mlat.sh: disabled watch — legacy mode, boot config change → exit 0" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_legacy_disabled_boot_config "$root"
+    cat > "$ROOT_DIR/bin/sleep" <<SH
+#!/usr/bin/env bash
+printf 'HOSTNAME=feeder\n' >> "$root/boot/airplanes-config.txt"
+SH
+    chmod +x "$ROOT_DIR/bin/sleep"
+
+    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
+        PATH="$ROOT_DIR/bin:$PATH" timeout 10 bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'MLAT DISABLED'* ]]
+}
+
+@test "airplanes-mlat.sh: disabled watch — legacy mode, feed.env creation → exit 0" {
+    # feed.env appearing flips the feeder to the canonical config branch
+    # on the next activation, so its creation must wake the legacy watch.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_legacy_disabled_boot_config "$root"
+    cat > "$ROOT_DIR/bin/sleep" <<SH
+#!/usr/bin/env bash
+mkdir -p "$root/etc/airplanes"
+printf 'MLAT_ENABLED=false\n' > "$root/etc/airplanes/feed.env"
+SH
+    chmod +x "$ROOT_DIR/bin/sleep"
+
+    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
+        PATH="$ROOT_DIR/bin:$PATH" timeout 10 bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "airplanes-mlat.sh: disabled watch — unchanged feed.env keeps idling (no blind exit)" {
+    # The core regression guard: with the governing config unchanged the
+    # wrapper must NOT exit on its own (the old behavior slept once and
+    # exited). The sleep stub rewrites the boot config on every pass —
+    # which the canonical (feed.env) branch must ignore: the legacy web UI
+    # keeps writing boot files on migrated feeders and those writes are
+    # invisible to a feed.env-governed daemon. timeout kills the spin at
+    # 2s and reports 124, proving it was still idling.
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
@@ -769,22 +829,6 @@ SH
 printf 'HOSTNAME=feeder\n' > "$root/boot/airplanes-config.txt"
 SH
     chmod +x "$ROOT_DIR/bin/sleep"
-
-    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
-        PATH="$ROOT_DIR/bin:$PATH" timeout 10 bash "$MLAT_SCRIPT"
-
-    [ "$status" -eq 0 ]
-}
-
-@test "airplanes-mlat.sh: disabled watch — unchanged config keeps idling (no blind exit)" {
-    # The core regression guard: with no config change the wrapper must
-    # NOT exit on its own (the old behavior slept once and exited). The
-    # no-op sleep stub from setup_mlat_runtime spins the loop fast;
-    # timeout kills it at 2s and reports 124, proving it was still idling.
-    local root="$ROOT_DIR/root"
-    install_state_writer_lib "$root"
-    setup_mlat_runtime "$root"
-    write_feed_env "$root" 'MLAT_ENABLED=false'
 
     run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
         PATH="$ROOT_DIR/bin:$PATH" timeout 2 bash "$MLAT_SCRIPT"

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -4,6 +4,11 @@ setup() {
     FEED_SCRIPT="$BATS_TEST_DIRNAME/../scripts/airplanes-feed.sh"
     MLAT_SCRIPT="$BATS_TEST_DIRNAME/../scripts/airplanes-mlat.sh"
     ROOT_DIR="$(mktemp -d)"
+    # Interval 0 makes the disabled branch's config-watch single-pass so
+    # wrapper invocations return promptly (the stubbed no-op `sleep` would
+    # otherwise spin the watch loop forever). Watch-specific tests override
+    # this with a positive interval.
+    export AIRPLANES_MLAT_DISABLED_SLEEP=0
 }
 
 teardown() {
@@ -591,7 +596,8 @@ install_legacy_mlat_translation_lib() {
 
 # Set up an mlat run with stubbed nc/sleep/mlat-client so the daemon
 # proceeds through its decision and either (a) emits MLAT DISABLED +
-# sleep + exit 0, (b) exits 64, or (c) execs the mlat-client stub.
+# single-pass watch + exit 0, (b) exits 64, or (c) execs the mlat-client
+# stub.
 setup_mlat_runtime() {
     local root="$1"
     local stub_bin="$ROOT_DIR/bin"
@@ -723,6 +729,90 @@ write_feed_env() {
     grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
     grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
     grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+}
+
+# ---- disabled branch: config watch loop -----------------------------------
+# The disabled branch idles until a config source changes and only then
+# exits 0 for a systemd restart (Restart=always). A mutating `sleep` stub
+# drives the loop deterministically; `timeout` turns a watch regression
+# into status 124 instead of a bats hang. AIRPLANES_MLAT_DISABLED_SLEEP=5
+# overrides the single-pass 0 exported by setup().
+
+@test "airplanes-mlat.sh: disabled watch — feed.env change → exit 0" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" 'MLAT_ENABLED=false' 'ALTITUDE=35'
+    cat > "$ROOT_DIR/bin/sleep" <<SH
+#!/usr/bin/env bash
+printf 'LATITUDE=52\n' >> "$root/etc/airplanes/feed.env"
+SH
+    chmod +x "$ROOT_DIR/bin/sleep"
+
+    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
+        PATH="$ROOT_DIR/bin:$PATH" timeout 10 bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'MLAT DISABLED'* ]]
+}
+
+@test "airplanes-mlat.sh: disabled watch — legacy boot config change also wakes the watch" {
+    # Legacy images source the boot config; the watch covers every config
+    # source, not just feed.env.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" 'MLAT_ENABLED=false'
+    mkdir -p "$root/boot"
+    cat > "$ROOT_DIR/bin/sleep" <<SH
+#!/usr/bin/env bash
+printf 'HOSTNAME=feeder\n' > "$root/boot/airplanes-config.txt"
+SH
+    chmod +x "$ROOT_DIR/bin/sleep"
+
+    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
+        PATH="$ROOT_DIR/bin:$PATH" timeout 10 bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "airplanes-mlat.sh: disabled watch — unchanged config keeps idling (no blind exit)" {
+    # The core regression guard: with no config change the wrapper must
+    # NOT exit on its own (the old behavior slept once and exited). The
+    # no-op sleep stub from setup_mlat_runtime spins the loop fast;
+    # timeout kills it at 2s and reports 124, proving it was still idling.
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" 'MLAT_ENABLED=false'
+
+    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=5 \
+        PATH="$ROOT_DIR/bin:$PATH" timeout 2 bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 124 ]
+    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh: disabled watch — invalid interval falls back to 60" {
+    local root="$ROOT_DIR/root"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" 'MLAT_ENABLED=false'
+    # The stub asserts the fallback value actually reached sleep (a non-60
+    # argv fails the stub, the fingerprint never changes, and timeout
+    # reports 124), then mutates the config so the wrapper exits promptly.
+    cat > "$ROOT_DIR/bin/sleep" <<SH
+#!/usr/bin/env bash
+[ "\$1" = "60" ] || exit 99
+printf 'LATITUDE=52\n' >> "$root/etc/airplanes/feed.env"
+SH
+    chmod +x "$ROOT_DIR/bin/sleep"
+
+    run env AIRPLANES_ROOT="$root" AIRPLANES_MLAT_DISABLED_SLEEP=abc \
+        PATH="$ROOT_DIR/bin:$PATH" timeout 10 bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'not a non-negative integer'* ]]
 }
 
 @test "airplanes-mlat.sh derives GEO_CONFIGURED=false from legacy LATITUDE=0/LONGITUDE=0 pair" {


### PR DESCRIPTION
With MLAT disabled — which includes every feeder that hasn't configured coordinates yet — `airplanes-mlat.sh` slept an hour and exited, so systemd's restart counter climbed ~24/day forever: noise in the journal and in the per-service restart counts the feeder reports.

The disabled branch now idles and only exits for a restart when a config source actually changes (feed.env, or the boot config files on legacy images — detected via a device:inode:size:mtime:ctime fingerprint checked once a minute). The supported config paths (webconfig, `apl-feed apply`) already restart the unit explicitly when relevant keys change, so the watch only serves hand-edited files, and picks those up faster than the old hourly cycle did. The unit still reports active while disabled and the `/run/airplanes-mlat/state` contract is unchanged.