### PR TITLE
Add READSB_SDR_SERIAL feed.env key for 1090 SDR pinning

### DIFF
--- a/scripts/lib/configure-validators.sh
+++ b/scripts/lib/configure-validators.sh
@@ -123,6 +123,15 @@ valid_gain() {
     awk -v G="$1" 'BEGIN { exit !(G >= 0 && G <= 60) }'
 }
 
+# READSB_SDR_SERIAL: empty (single-SDR default, no --device) or 1-32 chars
+# in [0-9A-Za-z_-]. Same rules as valid_dump978_serial, kept separate so the
+# webconfig JS twin (isValidReadsbSdrSerial) maps 1:1 and the two keys can
+# diverge later.
+valid_readsb_sdr_serial() {
+    [[ -z "$1" ]] && return 0
+    [[ "$1" =~ ^[0-9A-Za-z_-]{1,32}$ ]]
+}
+
 # UAT_INPUT v1: only "" (978 disabled) or the local dump978-fa endpoint.
 # Mirrors Go configspec.validateUATInput.
 valid_uat_input() {

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -182,6 +182,12 @@ _apl_feed_apply_validate_one() {
                 return 1
             fi
             ;;
+        readsb_sdr_serial)
+            if ! valid_readsb_sdr_serial "$value"; then
+                APL_APPLY_ERRORS[$key]='must match [0-9A-Za-z_-]{1,32} or be empty'
+                return 1
+            fi
+            ;;
         uat_input)
             if ! valid_uat_input "$value"; then
                 APL_APPLY_ERRORS[$key]='must be "" or "127.0.0.1:30978"'

--- a/scripts/lib/feed-env-keys.sh
+++ b/scripts/lib/feed-env-keys.sh
@@ -24,6 +24,7 @@ declare -ga APL_FEED_WRITABLE_KEYS=(
     MLAT_ENABLED
     MLAT_PRIVATE
     GAIN
+    READSB_SDR_SERIAL
     UAT_INPUT
     DUMP978_SDR_SERIAL
     DUMP978_GAIN
@@ -42,6 +43,7 @@ declare -ga APL_FEED_READABLE_KEYS=(
     INPUT
     INPUT_TYPE
     GAIN
+    READSB_SDR_SERIAL
     UAT_INPUT
     DUMP978_SDR_SERIAL
     DUMP978_GAIN
@@ -58,6 +60,7 @@ declare -gA APL_FEED_KEY_TYPE=(
     [MLAT_ENABLED]=bool
     [MLAT_PRIVATE]=bool
     [GAIN]=gain
+    [READSB_SDR_SERIAL]=readsb_sdr_serial
     [UAT_INPUT]=uat_input
     [DUMP978_SDR_SERIAL]=dump978_serial
     [DUMP978_GAIN]=dump978_gain
@@ -79,6 +82,7 @@ declare -gA APL_FEED_KEY_RESTART=(
     [MLAT_ENABLED]="airplanes-mlat"
     [MLAT_PRIVATE]="airplanes-mlat"
     [GAIN]="readsb"
+    [READSB_SDR_SERIAL]="readsb"
     [UAT_INPUT]="airplanes-feed dump978-fa airplanes-978"
     [DUMP978_SDR_SERIAL]="dump978-fa airplanes-978"
     [DUMP978_GAIN]="dump978-fa"

--- a/test/test_apl_feed_apply.bats
+++ b/test/test_apl_feed_apply.bats
@@ -58,8 +58,8 @@ run_apply() {
     [ "$(jq -r .version <<<"$OUT")" = "1" ]
     [ "$(jq -r '.writable_keys | type' <<<"$OUT")" = "array" ]
     [ "$(jq -r '.readable_keys | type' <<<"$OUT")" = "array" ]
-    [ "$(jq -r '.writable_keys | contains(["LATITUDE","LONGITUDE","MLAT_ENABLED"])' <<<"$OUT")" = "true" ]
-    [ "$(jq -r '.readable_keys | contains(["INPUT","INPUT_TYPE"])' <<<"$OUT")" = "true" ]
+    [ "$(jq -r '.writable_keys | contains(["LATITUDE","LONGITUDE","MLAT_ENABLED","READSB_SDR_SERIAL"])' <<<"$OUT")" = "true" ]
+    [ "$(jq -r '.readable_keys | contains(["INPUT","INPUT_TYPE","READSB_SDR_SERIAL"])' <<<"$OUT")" = "true" ]
 }
 
 @test "apply with empty payload returns no_change" {

--- a/test/test_configure_validators.bats
+++ b/test/test_configure_validators.bats
@@ -166,6 +166,19 @@ setup() {
     ! valid_gain abc
 }
 
+@test "valid_readsb_sdr_serial accepts empty or 1-32 chars in [0-9A-Za-z_-]" {
+    valid_readsb_sdr_serial ''
+    valid_readsb_sdr_serial 1090
+    # All-numeric serials are valid here even though readsb may interpret
+    # small integers as device indexes — that ambiguity is a UI concern.
+    valid_readsb_sdr_serial 0
+    valid_readsb_sdr_serial 00000001
+    valid_readsb_sdr_serial 'SDR-Alpha_2'
+    ! valid_readsb_sdr_serial 'has space'
+    ! valid_readsb_sdr_serial '1090;rm'
+    ! valid_readsb_sdr_serial "$(printf 'a%.0s' {1..33})"
+}
+
 @test "valid_uat_input accepts only empty or the local dump978-fa endpoint" {
     valid_uat_input ''
     valid_uat_input 127.0.0.1:30978

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -304,6 +304,50 @@ EOF
     grep -q '^systemctl restart airplanes-mlat$' "$SYSTEMCTL_LOG"
 }
 
+@test "READSB_SDR_SERIAL change restarts readsb and nothing else" {
+    seed_feed_env
+    do_apply READSB_SDR_SERIAL=1090
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "${APL_APPLY_CHANGED[*]}" = "READSB_SDR_SERIAL" ]
+    grep -q '^READSB_SDR_SERIAL="1090"$' "$FEED_ENV"
+    grep -q '^systemctl restart readsb$' "$SYSTEMCTL_LOG"
+    ! grep -q 'restart airplanes-feed' "$SYSTEMCTL_LOG"
+    ! grep -q 'restart airplanes-mlat' "$SYSTEMCTL_LOG"
+    ! grep -q 'restart airplanes-978' "$SYSTEMCTL_LOG"
+    ! grep -q 'restart dump978-fa' "$SYSTEMCTL_LOG"
+}
+
+@test "clearing READSB_SDR_SERIAL also restarts readsb" {
+    seed_feed_env
+    printf 'READSB_SDR_SERIAL="1090"\n' >> "$FEED_ENV"
+    do_apply READSB_SDR_SERIAL=
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "${APL_APPLY_CHANGED[*]}" = "READSB_SDR_SERIAL" ]
+    grep -q '^READSB_SDR_SERIAL=""$' "$FEED_ENV"
+    grep -q '^systemctl restart readsb$' "$SYSTEMCTL_LOG"
+}
+
+@test "rejects bad READSB_SDR_SERIAL without touching feed.env or restarting" {
+    seed_feed_env
+    cp "$FEED_ENV" "$FEED_ENV.before"
+    do_apply READSB_SDR_SERIAL="$(printf 'a%.0s' {1..33})"
+    [ "$APL_APPLY_RC" -eq 2 ]
+    [ "$APL_APPLY_STATUS" = "rejected" ]
+    [ -n "${APL_APPLY_ERRORS[READSB_SDR_SERIAL]}" ]
+    diff -u "$FEED_ENV.before" "$FEED_ENV"
+    [ ! -s "$SYSTEMCTL_LOG" ]
+}
+
+@test "GAIN and READSB_SDR_SERIAL in one apply restart readsb once" {
+    seed_feed_env
+    do_apply GAIN=43.9 READSB_SDR_SERIAL=1090
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    [ "$(grep -c '^systemctl restart readsb$' "$SYSTEMCTL_LOG")" -eq 1 ]
+}
+
 @test "GEO_CONFIGURED-only change does not restart anything" {
     cat > "$FEED_ENV" <<EOF
 LATITUDE="1"


### PR DESCRIPTION
On feeders with two RTL-SDRs (1090 + 978 UAT), USB enumeration order can change across reboots and replugs, so readsb may open the wrong dongle. The feeder image's readsb wrapper already honors `READSB_SDR_SERIAL` from `feed.env` to pin the 1090 role to a specific stick by EEPROM serial; this adds the key to the feed.env schema so it can be set through `apl-feed apply` (and the webconfig on top of it). Value is empty (default, no pinning) or 1–32 chars of `[0-9A-Za-z_-]`; a change restarts readsb only.