### PR TITLE
Add ADSBexchange and airplanes.live copyright lines to LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,8 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2016 Joe Prochazka
+Copyright (c) 2016-2023 ADSBexchange contributors
+Copyright (c) 2023-2026 airplanes.live contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The license file still credited only the 2015-2016 origin of these scripts. The repo has since accumulated a decade of contributions, first under ADSBexchange and then under airplanes.live. This keeps the original MIT notice intact (as the license requires) and adds copyright lines for the later contributor eras.