### PR TITLE
Never restart third-party dump978-fa or readsb units on config apply

### DIFF
--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -21,10 +21,11 @@ DEFAULT_DUMP978_SDR_SERIAL="978"
 DEFAULT_DUMP978_GAIN="42.1"
 LOCAL_UAT_ENDPOINT="127.0.0.1:30978"
 
-# Image-only systemd units. On a standalone-feed install these don't
-# exist; the apply library tries to restart them and reports the failure
-# via APL_APPLY_PENDING_RESTART without aborting the write. status
-# inspection still uses these helpers.
+# Image-only systemd units. On a standalone-feed install these are
+# either absent or — name collision — belong to a third-party package
+# (dump978-fa is also FlightAware's unit name); the apply library's
+# unit-ownership gate skips both cases silently. status inspection
+# still uses these helpers.
 _UAT_OPTIONAL_UNITS=(dump978-fa.service airplanes-978.service)
 
 _uat_unit_exists() {

--- a/scripts/apl-feed/uat.sh
+++ b/scripts/apl-feed/uat.sh
@@ -255,10 +255,15 @@ apl_feed_uat_status() {
     echo
     local unit
     for unit in "${_UAT_OPTIONAL_UNITS[@]}"; do
-        if _uat_unit_exists "$unit"; then
+        if _apl_feed_apply_unit_is_ours "$unit"; then
             local active
             active="$(systemctl is-active "$unit" 2>/dev/null || true)"
             printf '  %-26s %s\n' "$unit" "${active:-unknown}"
+        elif _uat_unit_exists "$unit"; then
+            # Name collision: the unit exists but belongs to a third-party
+            # package (e.g. FlightAware's dump978-fa). Its systemd state
+            # says nothing about our 978 chain — don't present it as ours.
+            printf '  %-26s %s\n' "$unit" "owned by another package (not managed)"
         else
             printf '  %-26s %s\n' "$unit" "not installed (image-only)"
         fi

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -421,6 +421,23 @@ _apl_feed_apply_restart_set() {
 # standalone-feed install) is silently skipped — that matches the
 # pre-refactor _uat_unit_exists gate. The library does not consider
 # absent-unit cases a failure.
+#
+# A unit that exists but is NOT ours is also skipped. Unit names collide
+# with third-party packages: dump978-fa is also FlightAware's unit name,
+# readsb is also the wiedehopf adsb-scripts decoder unit. `systemctl
+# restart` STARTS a stopped unit, so restarting a foreign unit can bring
+# up an SDR daemon that steals the dongle another decoder was using —
+# and a foreign unit doesn't read feed.env, so the restart could never
+# apply the change anyway. Ownership test: every unit installed by the
+# feed scripts or the image runtime overlay ExecStarts a wrapper under
+# /usr/local/share/airplanes/.
+_apl_feed_apply_unit_is_ours() {
+    local unit="$1"
+    # `systemctl cat` returns 0 iff the unit (or a generator-emitted
+    # instance) is known to systemd; output includes drop-ins.
+    systemctl cat "$unit" 2>/dev/null | grep -q '/usr/local/share/airplanes/'
+}
+
 _apl_feed_apply_restart_services() {
     local services=("$@")
     APL_APPLY_PENDING_RESTART=()
@@ -435,9 +452,7 @@ _apl_feed_apply_restart_services() {
 
     local svc
     for svc in "${services[@]}"; do
-        # Skip units that aren't installed. `systemctl cat` returns 0 iff
-        # the unit (or a generator-emitted instance) is known to systemd.
-        if ! systemctl cat "$svc" >/dev/null 2>&1; then
+        if ! _apl_feed_apply_unit_is_ours "$svc"; then
             continue
         fi
         if ! systemctl restart "$svc" 2>/dev/null; then

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -432,10 +432,14 @@ _apl_feed_apply_restart_set() {
 # feed scripts or the image runtime overlay ExecStarts a wrapper under
 # /usr/local/share/airplanes/.
 _apl_feed_apply_unit_is_ours() {
-    local unit="$1"
+    local unit="$1" unit_def
     # `systemctl cat` returns 0 iff the unit (or a generator-emitted
-    # instance) is known to systemd; output includes drop-ins.
-    systemctl cat "$unit" 2>/dev/null | grep -q '/usr/local/share/airplanes/'
+    # instance) is known to systemd; output includes drop-ins. Capture
+    # instead of piping into `grep -q`: under a pipefail caller, grep
+    # exiting at first match can SIGPIPE systemctl and fail the whole
+    # pipeline — skipping the restart of a unit we do own.
+    unit_def="$(systemctl cat "$unit" 2>/dev/null)" || return 1
+    [[ "$unit_def" == *'/usr/local/share/airplanes/'* ]]
 }
 
 _apl_feed_apply_restart_services() {

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -39,6 +39,9 @@ setup() {
 printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
 case "\$1" in
     is-active) echo active ;;
+    # Ownership gate in the apply lib reads `systemctl cat` output and
+    # only restarts units that ExecStart our wrappers.
+    cat) printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\${@: -1}" ;;
 esac
 exit 0
 STUB

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -11,6 +11,7 @@ setup() {
     STUB_DIR="$ROOT_DIR/bin"
     SYSTEMCTL_LOG="$ROOT_DIR/systemctl.log"
     INSTALLED_UNITS_FILE="$ROOT_DIR/installed-units"
+    FOREIGN_UNITS_FILE="$ROOT_DIR/foreign-units"
     mkdir -p "$TMPDIR" "$STUB_DIR" "$ROOT_DIR/etc/airplanes"
     export TMPDIR
 
@@ -46,8 +47,15 @@ printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
 case "\$1" in
     cat)
         unit="\${@: -1}"
+        # Foreign units (e.g. FlightAware's dump978-fa on a PiAware box)
+        # exist but ExecStart a path outside /usr/local/share/airplanes/,
+        # so the apply lib's ownership gate must skip them.
+        if grep -Fxq "\$unit" "$FOREIGN_UNITS_FILE" 2>/dev/null; then
+            printf 'ExecStart=/usr/bin/%s\n' "\$unit"
+            exit 0
+        fi
         if grep -Fxq "\$unit" "$INSTALLED_UNITS_FILE" 2>/dev/null; then
-            printf '# %s\n' "\$unit"
+            printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\$unit"
             exit 0
         fi
         exit 1
@@ -90,6 +98,13 @@ teardown() {
 
 mark_unit_installed() {
     printf '%s\n' "$1" >> "$INSTALLED_UNITS_FILE"
+}
+
+# A unit that exists on the host but belongs to a third-party package
+# (ExecStart outside /usr/local/share/airplanes/), e.g. FlightAware's
+# dump978-fa on a PiAware install.
+mark_unit_foreign() {
+    printf '%s\n' "$1" >> "$FOREIGN_UNITS_FILE"
 }
 
 plug_sdr() {
@@ -171,6 +186,41 @@ EOF
     run grep -q '^systemctl restart airplanes-978$' "$SYSTEMCTL_LOG"
     [ "$status" -ne 0 ]
     grep -q '^systemctl restart airplanes-feed$' "$SYSTEMCTL_LOG"
+}
+
+@test "enable: a foreign dump978-fa unit is never restarted" {
+    write_feed_env
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    # PiAware shape: dump978-fa.service exists but is FlightAware's unit.
+    # `systemctl restart` would START it even when stopped, and with FA's
+    # unpinned SDR config it can grab the dongle another decoder is using.
+    mark_unit_foreign dump978-fa
+
+    run apl_feed_uat_enable
+    [ "$status" -eq 0 ]
+    grep -q '^UAT_INPUT="127.0.0.1:30978"$' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q '^systemctl restart airplanes-feed$' "$SYSTEMCTL_LOG"
+    run grep -q '^systemctl restart dump978-fa$' "$SYSTEMCTL_LOG"
+    [ "$status" -ne 0 ]
+    # The skip is silent — not surfaced as a failed restart.
+    [[ "$output" != *'failed to restart'* ]]
+}
+
+@test "disable: a foreign dump978-fa unit is never restarted" {
+    write_feed_env
+    printf 'UAT_INPUT="127.0.0.1:30978"\n' >> "$ROOT_DIR/etc/airplanes/feed.env"
+    ROOT="/"
+    feed_env_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    feed_env_write_path() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    mark_unit_foreign dump978-fa
+
+    run apl_feed_uat_disable
+    [ "$status" -eq 0 ]
+    grep -q '^UAT_INPUT=""$' "$ROOT_DIR/etc/airplanes/feed.env"
+    run grep -q '^systemctl restart dump978-fa$' "$SYSTEMCTL_LOG"
+    [ "$status" -ne 0 ]
 }
 
 @test "enable --serial / --gain pin the wrapper defaults in feed.env" {

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -388,6 +388,31 @@ EOF
     [[ "$output" == *'airplanes-978'*'not installed (image-only)'* ]]
 }
 
+@test "status: shows systemd state for image-managed 978 units" {
+    write_feed_env
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    mark_unit_installed dump978-fa.service
+    mark_unit_installed airplanes-978.service
+
+    run apl_feed_uat_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'dump978-fa.service'*'active'* ]]
+    [[ "$output" == *'airplanes-978.service'*'active'* ]]
+}
+
+@test "status: flags a foreign dump978-fa unit as not managed" {
+    write_feed_env
+    feed_env_paths() { printf '%s\n' "$ROOT_DIR/etc/airplanes/feed.env"; }
+    # PiAware shape: the unit name exists but it's FlightAware's — its
+    # systemd state must not be presented as our 978 chain's state.
+    mark_unit_foreign dump978-fa.service
+
+    run apl_feed_uat_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'dump978-fa.service'*'owned by another package (not managed)'* ]]
+    [[ "$output" == *'airplanes-978'*'not installed (image-only)'* ]]
+}
+
 @test "bridged-legacy: _uat_apply targets canonical feed.env, not boot config" {
     # Same shape as the mlat bridged-legacy regression — guards against
     # the writer side resolving via feed_env_path()'s reader fallback

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -26,9 +26,15 @@ setup() {
     FEED_ENV="$ROOT_DIR/etc/airplanes/feed.env"
     LOCK_FILE="$ROOT_DIR/run/airplanes/feed-env.lock"
 
+    # `cat` answers with an ExecStart under /usr/local/share/airplanes/ so
+    # the apply lib's unit-ownership gate treats every unit as ours by
+    # default; the foreign-unit tests override this stub per-test.
     cat > "$STUB_DIR/systemctl" <<STUB
 #!/usr/bin/env bash
 printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+if [ "\$1" = cat ]; then
+    printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\${@: -1}"
+fi
 exit 0
 STUB
     chmod +x "$STUB_DIR/systemctl"
@@ -346,6 +352,54 @@ EOF
     [ "$APL_APPLY_RC" -eq 0 ]
     [ "$APL_APPLY_STATUS" = "applied" ]
     [ "$(grep -c '^systemctl restart readsb$' "$SYSTEMCTL_LOG")" -eq 1 ]
+}
+
+# Replace the systemctl stub with one where the named units exist but
+# belong to a third-party package (ExecStart outside our install tree),
+# while every other unit stays ours. Models a PiAware box, where
+# dump978-fa.service is FlightAware's, or a wiedehopf adsb-scripts box,
+# where readsb.service ExecStarts /usr/bin/readsb.
+stub_foreign_units() {
+    local foreign="$*"
+    cat > "$STUB_DIR/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
+if [ "\$1" = cat ]; then
+    unit="\${@: -1}"
+    case " $foreign " in
+        *" \$unit "*) printf 'ExecStart=/usr/bin/%s\n' "\$unit" ;;
+        *) printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\$unit" ;;
+    esac
+fi
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+}
+
+@test "UAT_INPUT change skips a foreign dump978-fa unit" {
+    seed_feed_env
+    stub_foreign_units dump978-fa airplanes-978
+    do_apply UAT_INPUT=127.0.0.1:30978
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    grep -q '^systemctl restart airplanes-feed$' "$SYSTEMCTL_LOG"
+    run grep -q '^systemctl restart dump978-fa$' "$SYSTEMCTL_LOG"
+    [ "$status" -ne 0 ]
+    run grep -q '^systemctl restart airplanes-978$' "$SYSTEMCTL_LOG"
+    [ "$status" -ne 0 ]
+    # Skipped foreign units are not failures.
+    [ "${#APL_APPLY_PENDING_RESTART[@]}" -eq 0 ]
+}
+
+@test "GAIN change skips a foreign readsb unit" {
+    seed_feed_env
+    stub_foreign_units readsb
+    do_apply GAIN=38.6
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    run grep -q '^systemctl restart readsb$' "$SYSTEMCTL_LOG"
+    [ "$status" -ne 0 ]
+    [ "${#APL_APPLY_PENDING_RESTART[@]}" -eq 0 ]
 }
 
 @test "GEO_CONFIGURED-only change does not restart anything" {


### PR DESCRIPTION
Applying feed.env changes restarts the services that consume the changed keys. That restart list includes `dump978-fa` and `readsb` — names also used by third-party packages: `dump978-fa` is FlightAware's unit, and `readsb` can be the wiedehopf adsb-scripts decoder. Since `systemctl restart` also starts a stopped unit, running `apl-feed 978 enable` (or even `disable`) on such a box could start FlightAware's dump978 with its own SDR config, grabbing a dongle another decoder was using and taking every co-hosted feed down with it. Foreign units don't read feed.env, so these restarts could never apply the change in the first place.

Apply-time restarts are now gated on unit ownership: only units whose definition ExecStarts a wrapper under `/usr/local/share/airplanes/` are touched. On the feeder image all managed units pass the gate, so behavior there is unchanged.