### PR TITLE
Show non-default backend endpoints in apl-feed status

### DIFF
--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -83,6 +83,43 @@ else
     FEED_IMAGE_OPTIONS=""
 fi
 
+# Effective first ADS-B connector, published to the state file below so
+# status surfaces (apl-feed status, the image dashboard) can flag a
+# feeder pointed at a non-default backend. First connector only — the
+# failover endpoint inside the same connector arg is not compared.
+# Empty host + empty is_default means TARGET was present but did not
+# parse as a `--net-connector host,port,...` flag; consumers surface
+# that as invalid rather than silently rendering it as the default.
+TARGET_HOST=""
+TARGET_PORT=""
+TARGET_IS_DEFAULT=""
+_target_rest="${TARGET#*--net-connector}"
+if [[ "$_target_rest" != "$TARGET" ]]; then
+    _target_rest="${_target_rest#=}"
+    _target_rest="${_target_rest#"${_target_rest%%[![:space:]]*}"}"
+    _target_rest="${_target_rest%%[[:space:]]*}"
+    _target_host="${_target_rest%%,*}"
+    _target_port=""
+    if [[ "$_target_rest" == *,* ]]; then
+        _target_port="${_target_rest#*,}"
+        _target_port="${_target_port%%,*}"
+    fi
+    # Charset mirrors apl-feed's website-host guard, plus [] for
+    # bracketed IPv6 literals. Keeps arbitrary feed.env content out of
+    # state-file values that consumers render onto a root tty.
+    if [[ "$_target_host" =~ ^[][A-Za-z0-9._:-]+$ && "$_target_port" =~ ^[0-9]+$ ]]; then
+        TARGET_HOST="$_target_host"
+        TARGET_PORT="$_target_port"
+        if [[ "$_target_host" == "feed.airplanes.live" && "$_target_port" == "30004" ]]; then
+            TARGET_IS_DEFAULT="true"
+        else
+            TARGET_IS_DEFAULT="false"
+        fi
+    fi
+    unset _target_host _target_port
+fi
+unset _target_rest
+
 # State writer (defensive: a partial install where this script is in
 # place but the lib isn't yet must not take down the daemon).
 STATE_WRITER="$(airplanes_path /usr/local/share/airplanes/lib/state-writer.sh)"
@@ -108,6 +145,9 @@ airplanes_write_state "$STATE_FILE" \
     "latitude=${LATITUDE:-}" \
     "longitude=${LONGITUDE:-}" \
     "input=${INPUT:-}" \
+    "target_host=$TARGET_HOST" \
+    "target_port=$TARGET_PORT" \
+    "target_is_default=$TARGET_IS_DEFAULT" \
     "feed_bin=$FEED_BIN" || true
 
 exec "$FEED_BIN" --net --net-only --quiet \

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -144,6 +144,23 @@ MLATSERVER="${MLATSERVER:-feed.airplanes.live:31090}"
 INPUT="${INPUT:-127.0.0.1:30005}"
 INPUT_TYPE="${INPUT_TYPE:-dump1090}"
 
+# Effective MLAT endpoint, published to the state file below so status
+# surfaces can flag a feeder pointed at a non-default backend. Charset
+# guard (same as the feed wrapper's, [] for bracketed IPv6) keeps
+# arbitrary feed.env content out of state-file values that consumers
+# render onto a root tty; empty value + empty is_default means the
+# configured MLATSERVER was rejected, surfaced as invalid downstream.
+MLAT_SERVER_STATE=""
+MLAT_SERVER_IS_DEFAULT=""
+if [[ "$MLATSERVER" =~ ^[][A-Za-z0-9._:-]+$ ]]; then
+    MLAT_SERVER_STATE="$MLATSERVER"
+    if [[ "$MLATSERVER" == "feed.airplanes.live:31090" ]]; then
+        MLAT_SERVER_IS_DEFAULT="true"
+    else
+        MLAT_SERVER_IS_DEFAULT="false"
+    fi
+fi
+
 # RESULTS bundle: only apply the default outputs when none of the
 # RESULTS* slots are set on disk. Legacy single-line feed.env may carry
 # a combined `RESULTS="--results ... --results ..."` and we must not
@@ -241,6 +258,8 @@ airplanes_write_state "$STATE_FILE" \
     "mlat_enabled=${MLAT_ENABLED:-}" \
     "mlat_user=${MLAT_USER:-}" \
     "mlat_private=${MLAT_PRIVATE:-}" \
+    "mlat_server=$MLAT_SERVER_STATE" \
+    "mlat_server_is_default=$MLAT_SERVER_IS_DEFAULT" \
     "geo_configured=${GEO_CONFIGURED:-}" \
     "latitude=${LATITUDE:-}" \
     "longitude=${LONGITUDE:-}" \

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -41,9 +41,11 @@ STATUS_FEED_TARGET_PRESENT=0
 STATUS_FEED_TARGET_HOST=''
 STATUS_FEED_TARGET_PORT=''
 STATUS_FEED_TARGET_IS_DEFAULT=''
+STATUS_FEED_TARGET_INVALID=''
 STATUS_MLAT_SERVER_PRESENT=0
 STATUS_MLAT_SERVER=''
 STATUS_MLAT_SERVER_IS_DEFAULT=''
+STATUS_MLAT_SERVER_INVALID=''
 
 status_init() {
     STATUS_CHECKS_FILE="$(new_tmp_file)"
@@ -70,9 +72,11 @@ status_init() {
     STATUS_FEED_TARGET_HOST=''
     STATUS_FEED_TARGET_PORT=''
     STATUS_FEED_TARGET_IS_DEFAULT=''
+    STATUS_FEED_TARGET_INVALID=''
     STATUS_MLAT_SERVER_PRESENT=0
     STATUS_MLAT_SERVER=''
     STATUS_MLAT_SERVER_IS_DEFAULT=''
+    STATUS_MLAT_SERVER_INVALID=''
 }
 
 status_line() {
@@ -141,8 +145,10 @@ status_finish() {
             --arg feed_target_host "$STATUS_FEED_TARGET_HOST" \
             --arg feed_target_port "$STATUS_FEED_TARGET_PORT" \
             --arg feed_target_is_default "$STATUS_FEED_TARGET_IS_DEFAULT" \
+            --arg feed_target_invalid "$STATUS_FEED_TARGET_INVALID" \
             --arg mlat_server "$STATUS_MLAT_SERVER" \
             --arg mlat_server_is_default "$STATUS_MLAT_SERVER_IS_DEFAULT" \
+            --arg mlat_server_invalid "$STATUS_MLAT_SERVER_INVALID" \
             '
             def nullempty: if . == "" then null else . end;
             def boolish:
@@ -184,8 +190,10 @@ status_finish() {
                 feed_target_host: ($feed_target_host | nullempty),
                 feed_target_port: ($feed_target_port | numberish),
                 feed_target_is_default: ($feed_target_is_default | boolish),
+                feed_target_invalid: ($feed_target_invalid | boolish),
                 mlat_server: ($mlat_server | nullempty),
-                mlat_server_is_default: ($mlat_server_is_default | boolish)
+                mlat_server_is_default: ($mlat_server_is_default | boolish),
+                mlat_server_invalid: ($mlat_server_invalid | boolish)
               },
               checks: .
             }' \
@@ -220,6 +228,11 @@ _derive_backend_endpoints() {
             || STATUS_FEED_TARGET_PORT=''
         STATUS_FEED_TARGET_IS_DEFAULT="$(airplanes_read_state "$state_file" target_is_default)" \
             || STATUS_FEED_TARGET_IS_DEFAULT=''
+        if [[ -z "$value" ]]; then
+            STATUS_FEED_TARGET_INVALID='true'
+        else
+            STATUS_FEED_TARGET_INVALID='false'
+        fi
     fi
     state_file="$(root_path /run/airplanes-mlat/state)"
     if value="$(airplanes_read_state "$state_file" mlat_server)"; then
@@ -227,6 +240,11 @@ _derive_backend_endpoints() {
         STATUS_MLAT_SERVER="$value"
         STATUS_MLAT_SERVER_IS_DEFAULT="$(airplanes_read_state "$state_file" mlat_server_is_default)" \
             || STATUS_MLAT_SERVER_IS_DEFAULT=''
+        if [[ -z "$value" ]]; then
+            STATUS_MLAT_SERVER_INVALID='true'
+        else
+            STATUS_MLAT_SERVER_INVALID='false'
+        fi
     fi
     # WEBSITE_HOST is resolved per-invocation by common.sh (env var >
     # feed.env > default), so this process's value IS the effective one
@@ -691,16 +709,16 @@ claim_registration_status_line() {
             ;;
         minimal)
             STATUS_CLAIM_REGISTERED='true'
-            status_line warn "Website claim" "registered, but local secret did not authenticate"
+            status_line warn "Website claim" "registered, but local secret did not authenticate$(_website_host_suffix)"
             ;;
         blocked)
-            status_line fail "Website claim" "${CLAIM_PROBE_ERROR:-blocked}: $CLAIM_PROBE_DETAIL"
+            status_line fail "Website claim" "${CLAIM_PROBE_ERROR:-blocked}: $CLAIM_PROBE_DETAIL$(_website_host_suffix)"
             ;;
         rate_limited)
-            status_line warn "Website claim" "rate-limited: $CLAIM_PROBE_DETAIL"
+            status_line warn "Website claim" "rate-limited: $CLAIM_PROBE_DETAIL$(_website_host_suffix)"
             ;;
         *)
-            status_line warn "Website claim" "unexpected HTTP $CLAIM_PROBE_HTTP: $CLAIM_PROBE_DETAIL"
+            status_line warn "Website claim" "unexpected HTTP $CLAIM_PROBE_HTTP: $CLAIM_PROBE_DETAIL$(_website_host_suffix)"
             ;;
     esac
 }

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -36,6 +36,14 @@ STATUS_DIAGNOSTICS_TOGGLE=''
 STATUS_DIAGNOSTICS_LAST_PUSH_AGE_SECONDS=''
 STATUS_CONFIG_SYNC_TOGGLE=''
 STATUS_CONFIG_SYNC_LAST_SYNC_AGE_SECONDS=''
+STATUS_WEBSITE_IS_DEFAULT=''
+STATUS_FEED_TARGET_PRESENT=0
+STATUS_FEED_TARGET_HOST=''
+STATUS_FEED_TARGET_PORT=''
+STATUS_FEED_TARGET_IS_DEFAULT=''
+STATUS_MLAT_SERVER_PRESENT=0
+STATUS_MLAT_SERVER=''
+STATUS_MLAT_SERVER_IS_DEFAULT=''
 
 status_init() {
     STATUS_CHECKS_FILE="$(new_tmp_file)"
@@ -57,6 +65,14 @@ status_init() {
     STATUS_DIAGNOSTICS_LAST_PUSH_AGE_SECONDS=''
     STATUS_CONFIG_SYNC_TOGGLE=''
     STATUS_CONFIG_SYNC_LAST_SYNC_AGE_SECONDS=''
+    STATUS_WEBSITE_IS_DEFAULT=''
+    STATUS_FEED_TARGET_PRESENT=0
+    STATUS_FEED_TARGET_HOST=''
+    STATUS_FEED_TARGET_PORT=''
+    STATUS_FEED_TARGET_IS_DEFAULT=''
+    STATUS_MLAT_SERVER_PRESENT=0
+    STATUS_MLAT_SERVER=''
+    STATUS_MLAT_SERVER_IS_DEFAULT=''
 }
 
 status_line() {
@@ -120,6 +136,13 @@ status_finish() {
             --arg diagnostics_last_push_age "$STATUS_DIAGNOSTICS_LAST_PUSH_AGE_SECONDS" \
             --arg config_sync_toggle "$STATUS_CONFIG_SYNC_TOGGLE" \
             --arg config_sync_last_sync_age "$STATUS_CONFIG_SYNC_LAST_SYNC_AGE_SECONDS" \
+            --arg website_host "$WEBSITE_HOST" \
+            --arg website_is_default "$STATUS_WEBSITE_IS_DEFAULT" \
+            --arg feed_target_host "$STATUS_FEED_TARGET_HOST" \
+            --arg feed_target_port "$STATUS_FEED_TARGET_PORT" \
+            --arg feed_target_is_default "$STATUS_FEED_TARGET_IS_DEFAULT" \
+            --arg mlat_server "$STATUS_MLAT_SERVER" \
+            --arg mlat_server_is_default "$STATUS_MLAT_SERVER_IS_DEFAULT" \
             '
             def nullempty: if . == "" then null else . end;
             def boolish:
@@ -155,6 +178,15 @@ status_finish() {
                 remote_config: ($config_sync_toggle | nullempty),
                 last_sync_age_seconds: ($config_sync_last_sync_age | numberish)
               },
+              backend: {
+                website_host: ($website_host | nullempty),
+                website_is_default: ($website_is_default | boolish),
+                feed_target_host: ($feed_target_host | nullempty),
+                feed_target_port: ($feed_target_port | numberish),
+                feed_target_is_default: ($feed_target_is_default | boolish),
+                mlat_server: ($mlat_server | nullempty),
+                mlat_server_is_default: ($mlat_server_is_default | boolish)
+              },
               checks: .
             }' \
             "$STATUS_CHECKS_FILE"
@@ -170,22 +202,96 @@ status_finish() {
     echo "Result: $result_text"
 }
 
+# _derive_backend_endpoints — read the effective ADS-B / MLAT endpoints
+# the daemons published to their /run state files, and classify the
+# website host common.sh already resolved. Populates the STATUS_*
+# backend globals consumed by the bracket-suffix helpers below and the
+# --json backend object. Key present but empty means the daemon saw a
+# value it could not accept (surfaced as invalid); key absent means an
+# older daemon or a service that has not run this boot (no signal, no
+# bracket).
+_derive_backend_endpoints() {
+    local state_file value
+    state_file="$(root_path /run/airplanes-feed/state)"
+    if value="$(airplanes_read_state "$state_file" target_host)"; then
+        STATUS_FEED_TARGET_PRESENT=1
+        STATUS_FEED_TARGET_HOST="$value"
+        STATUS_FEED_TARGET_PORT="$(airplanes_read_state "$state_file" target_port)" \
+            || STATUS_FEED_TARGET_PORT=''
+        STATUS_FEED_TARGET_IS_DEFAULT="$(airplanes_read_state "$state_file" target_is_default)" \
+            || STATUS_FEED_TARGET_IS_DEFAULT=''
+    fi
+    state_file="$(root_path /run/airplanes-mlat/state)"
+    if value="$(airplanes_read_state "$state_file" mlat_server)"; then
+        STATUS_MLAT_SERVER_PRESENT=1
+        STATUS_MLAT_SERVER="$value"
+        STATUS_MLAT_SERVER_IS_DEFAULT="$(airplanes_read_state "$state_file" mlat_server_is_default)" \
+            || STATUS_MLAT_SERVER_IS_DEFAULT=''
+    fi
+    # WEBSITE_HOST is resolved per-invocation by common.sh (env var >
+    # feed.env > default), so this process's value IS the effective one
+    # — `invalid` (malformed URL) counts as non-default on purpose: an
+    # override exists and the operator should see that.
+    if [[ -n "$WEBSITE_HOST" && "$WEBSITE_HOST" != "airplanes.live" ]]; then
+        STATUS_WEBSITE_IS_DEFAULT='false'
+    else
+        STATUS_WEBSITE_IS_DEFAULT='true'
+    fi
+}
+
+# Bracket suffixes appended to status details when the feeder points at
+# a non-default backend. Empty on the default endpoints so production
+# feeders render unchanged.
+_feed_target_suffix() {
+    if (( ! STATUS_FEED_TARGET_PRESENT )); then
+        return 0
+    fi
+    if [[ -z "$STATUS_FEED_TARGET_HOST" ]]; then
+        printf ' [invalid TARGET]'
+        return 0
+    fi
+    [[ "$STATUS_FEED_TARGET_IS_DEFAULT" == "false" ]] || return 0
+    if [[ -n "$STATUS_FEED_TARGET_PORT" && "$STATUS_FEED_TARGET_PORT" != "30004" ]]; then
+        printf ' [%s:%s]' "$STATUS_FEED_TARGET_HOST" "$STATUS_FEED_TARGET_PORT"
+    else
+        printf ' [%s]' "$STATUS_FEED_TARGET_HOST"
+    fi
+}
+
+_mlat_server_suffix() {
+    if (( ! STATUS_MLAT_SERVER_PRESENT )); then
+        return 0
+    fi
+    if [[ -z "$STATUS_MLAT_SERVER" ]]; then
+        printf ' [invalid MLATSERVER]'
+        return 0
+    fi
+    [[ "$STATUS_MLAT_SERVER_IS_DEFAULT" == "false" ]] || return 0
+    printf ' [%s]' "$STATUS_MLAT_SERVER"
+}
+
+_website_host_suffix() {
+    [[ "$STATUS_WEBSITE_IS_DEFAULT" == "false" ]] || return 0
+    printf ' [%s]' "$WEBSITE_HOST"
+}
+
 service_status_line() {
     local unit="$1"
     local label="$2"
+    local suffix="${3-}"
     if ! command -v systemctl >/dev/null 2>&1; then
         status_line warn "$label" "systemctl unavailable"
         return
     fi
     if systemctl is-active --quiet "$unit" 2>/dev/null; then
-        status_line ok "$label" "running"
+        status_line ok "$label" "running$suffix"
         return
     fi
     if [[ "$(systemctl is-enabled "$unit" 2>/dev/null || true)" == "masked" ]]; then
-        status_line fail "$label" "masked"
+        status_line fail "$label" "masked$suffix"
         return
     fi
-    status_line fail "$label" "not running"
+    status_line fail "$label" "not running$suffix"
 }
 
 # _render_systemd_state <unit> <label> <active_state>
@@ -196,24 +302,24 @@ service_status_line() {
 # masked units report ActiveState=inactive AND is-enabled=masked, so
 # we check is-enabled separately.
 _render_systemd_state() {
-    local unit="$1" label="$2" active_state="$3"
+    local unit="$1" label="$2" active_state="$3" suffix="${4-}"
     local enabled
     enabled="$(systemctl is-enabled "$unit" 2>/dev/null || true)"
     if [[ "$enabled" == "masked" ]]; then
-        status_line fail "$label" "masked"
+        status_line fail "$label" "masked$suffix"
         return
     fi
     case "$active_state" in
         failed)
             local exit_code
             exit_code="$(systemctl show --property=ExecMainStatus --value "$unit" 2>/dev/null || true)"
-            status_line fail "$label" "failed${exit_code:+ (exit $exit_code)}"
+            status_line fail "$label" "failed${exit_code:+ (exit $exit_code)}$suffix"
             ;;
         inactive|deactivating|'')
-            status_line fail "$label" "not running"
+            status_line fail "$label" "not running$suffix"
             ;;
         *)
-            status_line fail "$label" "not running ($active_state)"
+            status_line fail "$label" "not running ($active_state)$suffix"
             ;;
     esac
 }
@@ -269,10 +375,10 @@ mlat_status_line() {
                 status_line fail "$label" "failed (exit 64; check feed.env MLAT config)"
                 return
             fi
-            _render_systemd_state "$unit" "$label" "$active_state"
+            _render_systemd_state "$unit" "$label" "$active_state" "$(_mlat_server_suffix)"
             ;;
         *)
-            _render_systemd_state "$unit" "$label" "$active_state"
+            _render_systemd_state "$unit" "$label" "$active_state" "$(_mlat_server_suffix)"
             ;;
     esac
 }
@@ -316,7 +422,7 @@ _render_mlat_decision() {
     case "$decision" in
         enabled)
             if [[ "$active_state" == "active" ]]; then
-                status_line ok "$label" "running$(_mlat_privacy_suffix)"
+                status_line ok "$label" "running$(_mlat_privacy_suffix)$(_mlat_server_suffix)"
                 local unknown
                 unknown="$(_mlat_privacy_unknown_value)"
                 if [[ -n "$unknown" ]]; then
@@ -552,11 +658,11 @@ claim_registration_status_line() {
     claim_status_probe "$uuid" "$secret"
     case "$CLAIM_PROBE_OUTCOME" in
         unreachable)
-            status_line warn "Website claim" "unreachable ($CLAIM_PROBE_DETAIL)"
+            status_line warn "Website claim" "unreachable ($CLAIM_PROBE_DETAIL)$(_website_host_suffix)"
             ;;
         registered_false)
             STATUS_CLAIM_REGISTERED="$CLAIM_PROBE_REGISTERED"
-            status_line warn "Website claim" "not registered; run sudo apl-feed claim register"
+            status_line warn "Website claim" "not registered; run sudo apl-feed claim register$(_website_host_suffix)"
             ;;
         authenticated)
             STATUS_CLAIM_REGISTERED='true'
@@ -570,9 +676,9 @@ claim_registration_status_line() {
             # readable — a `v1`-vs-`vN` number tells operators
             # nothing actionable.
             if [[ "$CLAIM_PROBE_OWNER_PRESENT" == "true" ]]; then
-                status_line ok "Website claim" "registered and claimed"
+                status_line ok "Website claim" "registered and claimed$(_website_host_suffix)"
             else
-                status_line ok "Website claim" "registered, not yet claimed"
+                status_line ok "Website claim" "registered, not yet claimed$(_website_host_suffix)"
             fi
             if [[ -n "$CLAIM_PROBE_RESET_UNTIL" && "$CLAIM_PROBE_RESET_UNTIL" != "null" ]]; then
                 status_line warn "Claim reset" "locked until $CLAIM_PROBE_RESET_UNTIL"
@@ -806,9 +912,10 @@ feed_status() {
     # outbound socket, then identity (gates the server-side ack query),
     # then the server-side reception ack, then MLAT (parallel feed) and
     # diagnostics (telemetry side-channel) below.
+    _derive_backend_endpoints
     receiver_status_line
     receiver_activity_status_line
-    service_status_line airplanes-feed "Feed service"
+    service_status_line airplanes-feed "Feed service" "$(_feed_target_suffix)"
     adsb_uplink_status_line
     claim_registration_status_line
     mlat_status_line

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -1426,3 +1426,38 @@ STUB
     [ "$(jq -r '.backend.website_host' <<< "$output")" = "airplanes.live" ]
     [ "$(jq -r '.backend.website_is_default' <<< "$output")" = "true" ]
 }
+
+@test "website suffix: rate-limited probe names the overridden backend" {
+    setup_claim_state 1
+    stub_post_json 429 '{"retry_after":60}'
+    WEBSITE_HOST="web.dev.airplanes.live"
+    status_init
+    _derive_backend_endpoints
+    run claim_registration_status_line
+    [[ "$output" == *'rate-limited'* ]]
+    [[ "$output" == *'[web.dev.airplanes.live]'* ]]
+}
+
+@test "status --json: present-but-empty endpoint keys set the invalid flags" {
+    write_feed_daemon_state '' '' ''
+    write_mlat_state_with_server enabled ok '' ''
+    status_init
+    _derive_backend_endpoints
+    STATUS_OUTPUT_JSON=1
+    run status_finish
+    [ "$(jq -r '.backend.feed_target_host' <<< "$output")" = "null" ]
+    [ "$(jq -r '.backend.feed_target_invalid' <<< "$output")" = "true" ]
+    [ "$(jq -r '.backend.mlat_server' <<< "$output")" = "null" ]
+    [ "$(jq -r '.backend.mlat_server_invalid' <<< "$output")" = "true" ]
+}
+
+@test "status --json: invalid flags are false when endpoints parsed, null when absent" {
+    write_feed_daemon_state feed.airplanes.test 30004 false
+    status_init
+    _derive_backend_endpoints
+    STATUS_OUTPUT_JSON=1
+    run status_finish
+    [ "$(jq -r '.backend.feed_target_invalid' <<< "$output")" = "false" ]
+    # No mlat state file at all → absent, not invalid.
+    [ "$(jq -r '.backend.mlat_server_invalid' <<< "$output")" = "null" ]
+}

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -1241,3 +1241,188 @@ _seed_config_sync_sentinel() {
     [ "$(jq -r '.config_sync.remote_config' <<< "$output")" = "enabled" ]
     [ "$(jq -r '.config_sync.last_sync_age_seconds | type' <<< "$output")" = "number" ]
 }
+
+# --- backend endpoint brackets (non-default backends) ---
+
+# Helper: write a feed daemon state file carrying the published
+# effective-endpoint keys. write_feed_daemon_state <host> <port> <is_default>
+write_feed_daemon_state() {
+    mkdir -p "$ROOT_DIR/run/airplanes-feed"
+    {
+        printf 'schema_version=1\n'
+        printf 'service=airplanes-feed\n'
+        printf 'state=enabled\n'
+        printf 'reason=ok\n'
+        printf 'target_host=%s\n' "$1"
+        printf 'target_port=%s\n' "$2"
+        printf 'target_is_default=%s\n' "$3"
+    } > "$ROOT_DIR/run/airplanes-feed/state"
+}
+
+# Helper: like write_mlat_state but with the endpoint keys.
+# write_mlat_state_with_server <decision> <reason> <server> <is_default>
+write_mlat_state_with_server() {
+    mkdir -p "$ROOT_DIR/run/airplanes-mlat"
+    {
+        printf 'schema_version=1\n'
+        printf 'service=airplanes-mlat\n'
+        printf 'state=%s\n' "$1"
+        printf 'reason=%s\n' "$2"
+        printf 'mlat_server=%s\n' "$3"
+        printf 'mlat_server_is_default=%s\n' "$4"
+    } > "$ROOT_DIR/run/airplanes-mlat/state"
+}
+
+@test "feed target suffix: non-default host renders bracket" {
+    write_feed_daemon_state feed.airplanes.test 30004 false
+    status_init
+    _derive_backend_endpoints
+    [ "$(_feed_target_suffix)" = " [feed.airplanes.test]" ]
+}
+
+@test "feed target suffix: default endpoint renders nothing" {
+    write_feed_daemon_state feed.airplanes.live 30004 true
+    status_init
+    _derive_backend_endpoints
+    [ -z "$(_feed_target_suffix)" ]
+}
+
+@test "feed target suffix: non-default port renders host:port" {
+    write_feed_daemon_state feed.airplanes.live 9999 false
+    status_init
+    _derive_backend_endpoints
+    [ "$(_feed_target_suffix)" = " [feed.airplanes.live:9999]" ]
+}
+
+@test "feed target suffix: present-but-empty keys render invalid TARGET" {
+    write_feed_daemon_state '' '' ''
+    status_init
+    _derive_backend_endpoints
+    [ "$(_feed_target_suffix)" = " [invalid TARGET]" ]
+}
+
+@test "feed target suffix: no state file renders nothing" {
+    status_init
+    _derive_backend_endpoints
+    [ -z "$(_feed_target_suffix)" ]
+}
+
+@test "service_status_line: running Feed service carries the backend bracket" {
+    write_feed_daemon_state feed.airplanes.test 30004 false
+    cat > "$STUB_DIR/systemctl" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+    is-active) exit 0 ;;
+    is-enabled) printf 'enabled\n'; exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_DIR/systemctl"
+    status_init
+    _derive_backend_endpoints
+    run service_status_line airplanes-feed 'Feed service' "$(_feed_target_suffix)"
+    [[ "$output" == *'running [feed.airplanes.test]'* ]]
+}
+
+@test "service_status_line: not-running Feed service still carries the bracket" {
+    write_feed_daemon_state feed.airplanes.test 30004 false
+    status_init
+    _derive_backend_endpoints
+    run service_status_line airplanes-feed 'Feed service' "$(_feed_target_suffix)"
+    [[ "$output" == *'not running [feed.airplanes.test]'* ]]
+}
+
+@test "mlat_status_line: running line carries a non-default MLATSERVER bracket" {
+    write_mlat_state_with_server enabled ok feed.airplanes.test:31090 false
+    stub_systemctl_active_state active
+    status_init
+    _derive_backend_endpoints
+    run mlat_status_line
+    [[ "$output" == *'running'* ]]
+    [[ "$output" == *'[feed.airplanes.test:31090]'* ]]
+}
+
+@test "mlat_status_line: default MLATSERVER renders no bracket" {
+    write_mlat_state_with_server enabled ok feed.airplanes.live:31090 true
+    stub_systemctl_active_state active
+    status_init
+    _derive_backend_endpoints
+    run mlat_status_line
+    [[ "$output" == *'running'* ]]
+    [[ "$output" != *'['* ]]
+}
+
+@test "mlat_status_line: failed unit still carries the MLATSERVER bracket" {
+    # RuntimeDirectoryPreserve keeps the state file across the failure,
+    # so the endpoint stays visible while the service is down.
+    write_mlat_state_with_server enabled ok feed.airplanes.test:31090 false
+    stub_systemctl_active_state failed 1
+    status_init
+    _derive_backend_endpoints
+    run mlat_status_line
+    [[ "$output" == *'FIX'* ]]
+    [[ "$output" == *'[feed.airplanes.test:31090]'* ]]
+}
+
+@test "website suffix: non-default WEBSITE_HOST renders on the Website claim line" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":true,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    WEBSITE_HOST="web.dev.airplanes.live"
+    status_init
+    _derive_backend_endpoints
+    run claim_registration_status_line
+    [[ "$output" == *'registered and claimed [web.dev.airplanes.live]'* ]]
+}
+
+@test "website suffix: default WEBSITE_HOST renders no bracket" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":true,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    WEBSITE_HOST="airplanes.live"
+    status_init
+    _derive_backend_endpoints
+    run claim_registration_status_line
+    [[ "$output" == *'registered and claimed'* ]]
+    [[ "$output" != *'['* ]]
+}
+
+@test "website suffix: unreachable probe names the overridden backend" {
+    setup_claim_state 1
+    stub_post_json 99 ''
+    WEBSITE_HOST="web.dev.airplanes.live"
+    status_init
+    _derive_backend_endpoints
+    run claim_registration_status_line
+    [[ "$output" == *'unreachable'* ]]
+    [[ "$output" == *'[web.dev.airplanes.live]'* ]]
+}
+
+@test "status --json: backend object carries non-default endpoint fields" {
+    write_feed_daemon_state feed.airplanes.test 9999 false
+    write_mlat_state_with_server enabled ok feed.airplanes.test:31090 false
+    WEBSITE_HOST="web.dev.airplanes.live"
+    status_init
+    _derive_backend_endpoints
+    STATUS_OUTPUT_JSON=1
+    run status_finish
+    [ "$(jq -r '.backend.feed_target_host' <<< "$output")" = "feed.airplanes.test" ]
+    [ "$(jq -r '.backend.feed_target_port' <<< "$output")" = "9999" ]
+    [ "$(jq -r '.backend.feed_target_port | type' <<< "$output")" = "number" ]
+    [ "$(jq -r '.backend.feed_target_is_default' <<< "$output")" = "false" ]
+    [ "$(jq -r '.backend.mlat_server' <<< "$output")" = "feed.airplanes.test:31090" ]
+    [ "$(jq -r '.backend.mlat_server_is_default' <<< "$output")" = "false" ]
+    [ "$(jq -r '.backend.website_host' <<< "$output")" = "web.dev.airplanes.live" ]
+    [ "$(jq -r '.backend.website_is_default' <<< "$output")" = "false" ]
+}
+
+@test "status --json: backend object is null/default without daemon state" {
+    WEBSITE_HOST="airplanes.live"
+    status_init
+    _derive_backend_endpoints
+    STATUS_OUTPUT_JSON=1
+    run status_finish
+    [ "$(jq -r '.backend.feed_target_host' <<< "$output")" = "null" ]
+    [ "$(jq -r '.backend.feed_target_is_default' <<< "$output")" = "null" ]
+    [ "$(jq -r '.backend.mlat_server' <<< "$output")" = "null" ]
+    [ "$(jq -r '.backend.website_host' <<< "$output")" = "airplanes.live" ]
+    [ "$(jq -r '.backend.website_is_default' <<< "$output")" = "true" ]
+}

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -658,8 +658,57 @@ write_feed_env() {
     grep -qx 'longitude=13' "$root/run/airplanes-mlat/state"
     grep -qx 'altitude=35' "$root/run/airplanes-mlat/state"
     grep -qE '^decided_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$root/run/airplanes-mlat/state"
+    # Default MLATSERVER → endpoint keys carry the default and flag it.
+    grep -qx 'mlat_server=feed.airplanes.live:31090' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_server_is_default=true' "$root/run/airplanes-mlat/state"
     # mlat-client was invoked.
     [ -f "$arg_log" ]
+}
+
+@test "airplanes-mlat.sh publishes a non-default MLATSERVER endpoint to the state file" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="feed.airplanes.test:31090"'
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'mlat_server=feed.airplanes.test:31090' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_server_is_default=false' "$root/run/airplanes-mlat/state"
+}
+
+@test "airplanes-mlat.sh publishes empty endpoint keys for a charset-invalid MLATSERVER" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/mlat-args.log"
+    install_state_writer_lib "$root"
+    setup_mlat_runtime "$root"
+    write_feed_env "$root" \
+        'MLAT_USER="alice"' \
+        'MLAT_ENABLED=true' \
+        'LATITUDE=52' \
+        'LONGITUDE=13' \
+        'ALTITUDE=35' \
+        'INPUT="127.0.0.1:30005"' \
+        'INPUT_TYPE="dump1090"' \
+        'MLATSERVER="bad host;rm -rf"'
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" \
+        PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'mlat_server=' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_server_is_default=' "$root/run/airplanes-mlat/state"
 }
 
 @test "airplanes-mlat.sh writes state=disabled,reason=mlat_enabled_false when MLAT_ENABLED=false" {
@@ -1307,6 +1356,94 @@ SH
     grep -qx 'longitude=13.40500' "$root/run/airplanes-feed/state"
     grep -qx 'input=127.0.0.1:30005' "$root/run/airplanes-feed/state"
     grep -q -- "feed_bin=$root/usr/bin/airplanes-feeder" "$root/run/airplanes-feed/state"
+    # Default TARGET → endpoint keys carry the default and flag it as such.
+    grep -qx 'target_host=feed.airplanes.live' "$root/run/airplanes-feed/state"
+    grep -qx 'target_port=30004' "$root/run/airplanes-feed/state"
+    grep -qx 'target_is_default=true' "$root/run/airplanes-feed/state"
+}
+
+@test "airplanes-feed.sh publishes a non-default TARGET endpoint to the state file" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/feed-args.log"
+    install_state_writer_lib "$root"
+    write_image_config "$root"
+    write_feed_env "$root" \
+        'LATITUDE="52.52"' \
+        'LONGITUDE="13.40"' \
+        'ALTITUDE="35"' \
+        'MLAT_USER="image-feeder"' \
+        'MLAT_ENABLED=true' \
+        'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"'
+    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$root/usr/bin/airplanes-feeder"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -qx 'target_host=feed.airplanes.test' "$root/run/airplanes-feed/state"
+    grep -qx 'target_port=30004' "$root/run/airplanes-feed/state"
+    grep -qx 'target_is_default=false' "$root/run/airplanes-feed/state"
+}
+
+@test "airplanes-feed.sh parses --net-connector=host TARGET form and flags a non-default port" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/feed-args.log"
+    install_state_writer_lib "$root"
+    write_image_config "$root"
+    write_feed_env "$root" \
+        'LATITUDE="52.52"' \
+        'LONGITUDE="13.40"' \
+        'ALTITUDE="35"' \
+        'MLAT_USER="image-feeder"' \
+        'MLAT_ENABLED=true' \
+        'TARGET="--net-connector=feed.airplanes.live,9999,beast_reduce_plus_out"'
+    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$root/usr/bin/airplanes-feeder"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Default host on a non-default port is still a non-default endpoint.
+    grep -qx 'target_host=feed.airplanes.live' "$root/run/airplanes-feed/state"
+    grep -qx 'target_port=9999' "$root/run/airplanes-feed/state"
+    grep -qx 'target_is_default=false' "$root/run/airplanes-feed/state"
+}
+
+@test "airplanes-feed.sh publishes empty endpoint keys for an unparseable TARGET" {
+    local root="$ROOT_DIR/root"
+    local arg_log="$ROOT_DIR/feed-args.log"
+    install_state_writer_lib "$root"
+    write_image_config "$root"
+    write_feed_env "$root" \
+        'LATITUDE="52.52"' \
+        'LONGITUDE="13.40"' \
+        'ALTITUDE="35"' \
+        'MLAT_USER="image-feeder"' \
+        'MLAT_ENABLED=true' \
+        'TARGET="no connector flag here"'
+    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARG_LOG"
+exit 0
+SH
+    chmod +x "$root/usr/bin/airplanes-feeder"
+
+    run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Present-but-empty keys signal "configured but unparseable" to
+    # consumers, distinct from key-absent (older daemon, no state).
+    grep -qx 'target_host=' "$root/run/airplanes-feed/state"
+    grep -qx 'target_port=' "$root/run/airplanes-feed/state"
+    grep -qx 'target_is_default=' "$root/run/airplanes-feed/state"
 }
 
 @test "airplanes-mlat.sh: RESULTS bundle default routes to 30104 + 31015 + 30157" {


### PR DESCRIPTION
A feeder pointed at a non-production backend (overridden TARGET, MLATSERVER, or APL_FEED_WEBSITE_URL in feed.env) looks identical to a production feeder in every status output, which makes it easy to forget an override or misread a staging device as healthy production.

The feed and MLAT daemons now publish their effective endpoint (host, port, and whether it is the default) to their /run state files at activation. `apl-feed status` reads those keys and appends the backend in brackets — e.g. `Feed service    running [feed.airplanes.test]` or `Website claim    registered and claimed [web.dev.airplanes.live]` — only when the endpoint differs from the default, so output on normally-configured feeders is unchanged. `--json` gains an additive `backend` object with the same data. An unparseable hand-edited TARGET is surfaced as `[invalid TARGET]` instead of silently looking like the default.
