### PR TITLE
Tell users when a registered feeder is not yet claimable

### DIFF
--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -619,6 +619,8 @@ _claim_status_emit() {
             --arg registered "${CLAIM_PROBE_REGISTERED:-}" \
             --arg owner_present "${CLAIM_PROBE_OWNER_PRESENT:-}" \
             --arg version "${CLAIM_PROBE_VERSION:-}" \
+            --arg claimable "${CLAIM_PROBE_CLAIMABLE:-}" \
+            --arg claim_unavailable_reason "${CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON:-}" \
             --arg reset_until "${CLAIM_PROBE_RESET_UNTIL:-}" \
             --arg last_seen_at "${CLAIM_PROBE_LAST_SEEN_AT:-}" \
             --arg last_seen_age "${CLAIM_PROBE_LAST_SEEN_AGE:-}" \
@@ -634,6 +636,8 @@ _claim_status_emit() {
               registered: ($registered | boolish),
               owner_present: ($owner_present | boolish),
               version: ($version | numberish),
+              claimable: ($claimable | boolish),
+              claim_unavailable_reason: ($claim_unavailable_reason | nullempty),
               reset_until: ($reset_until | nullempty),
               last_seen_at: ($last_seen_at | nullempty),
               last_seen_age_seconds: ($last_seen_age | numberish),
@@ -652,8 +656,23 @@ _claim_status_human() {
         claimed)
             echo "Claimed: yes — this feeder is linked to an airplanes.live account." ;;
         unclaimed)
-            echo "Claimed: no — registered, but not yet linked to an account."
-            echo "Claim it at: $(claim_page_url)" ;;
+            # The claimability pair refines the unclaimed copy; result
+            # token stays "unclaimed" so downstream consumers (webconfig)
+            # never see a new token.
+            if [[ "${CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON:-}" == "not_seen_feeding" ]]; then
+                if [[ -n "${CLAIM_PROBE_LAST_SEEN_AT:-}" && "${CLAIM_PROBE_LAST_SEEN_AT:-}" != "null" ]]; then
+                    echo "Claimed: no — registered, but not seen feeding recently."
+                    echo "Claiming unlocks a few minutes after the feeder reconnects and data flows."
+                else
+                    echo "Claimed: no — registered, waiting for first data before it can be claimed."
+                    echo "Claiming unlocks a few minutes after data starts flowing."
+                fi
+            elif [[ "${CLAIM_PROBE_CLAIMABLE:-}" == "false" ]]; then
+                echo "Claimed: no — registered, but not currently claimable."
+            else
+                echo "Claimed: no — registered, but not yet linked to an account."
+                echo "Claim it at: $(claim_page_url)"
+            fi ;;
         secret_mismatch)
             echo "The claim secret on this feeder did not authenticate with airplanes.live."
             echo "Re-register: sudo apl-feed claim register" ;;

--- a/scripts/apl-feed/claim.sh
+++ b/scripts/apl-feed/claim.sh
@@ -667,6 +667,11 @@ _claim_status_human() {
                     echo "Claimed: no — registered, waiting for first data before it can be claimed."
                     echo "Claiming unlocks a few minutes after data starts flowing."
                 fi
+            elif [[ "${CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON:-}" == "reset_locked" ]]; then
+                echo "Claimed: no — an administrator reset is in progress; claiming is locked."
+                if [[ -n "${CLAIM_PROBE_RESET_UNTIL:-}" && "${CLAIM_PROBE_RESET_UNTIL:-}" != "null" ]]; then
+                    echo "Locked until: $CLAIM_PROBE_RESET_UNTIL"
+                fi
             elif [[ "${CLAIM_PROBE_CLAIMABLE:-}" == "false" ]]; then
                 echo "Claimed: no — registered, but not currently claimable."
             else

--- a/scripts/apl-feed/http.sh
+++ b/scripts/apl-feed/http.sh
@@ -122,6 +122,11 @@ status_probe_version() {
 #   CLAIM_PROBE_OWNER_PRESENT raw .owner_present ("true"/"false"/"")
 #   CLAIM_PROBE_VERSION   raw .version
 #   CLAIM_PROBE_RESET_UNTIL  raw .reset_until
+#   CLAIM_PROBE_CLAIMABLE  raw .claimable ("true"/"false"; "" when the
+#                          server predates the field — render as today)
+#   CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON  raw .claim_unavailable_reason
+#                          (not_seen_feeding|reset_locked|claim_blocked;
+#                          "" when null/absent)
 #   CLAIM_PROBE_LAST_SEEN_PRESENT  "true" when the last_seen_at key exists
 #                                  (distinct from a present-but-null value)
 #   CLAIM_PROBE_LAST_SEEN_AT  raw .last_seen_at ("" when null or key absent)
@@ -140,6 +145,8 @@ claim_status_probe() {
     CLAIM_PROBE_OWNER_PRESENT=''
     CLAIM_PROBE_VERSION=''
     CLAIM_PROBE_RESET_UNTIL=''
+    CLAIM_PROBE_CLAIMABLE=''
+    CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON=''
     CLAIM_PROBE_LAST_SEEN_PRESENT=''
     CLAIM_PROBE_LAST_SEEN_AT=''
     CLAIM_PROBE_LAST_SEEN_AGE=''
@@ -207,6 +214,11 @@ claim_status_probe() {
             # rather than "claimed".
             if [[ -n "$CLAIM_PROBE_VERSION" ]]; then
                 CLAIM_PROBE_OUTCOME='authenticated'
+                # Absent and null both collapse to "" = unknown (older
+                # server) — callers then render exactly as before the
+                # field existed.
+                CLAIM_PROBE_CLAIMABLE="$(parse_field_from "$response_file" '.claimable')"
+                CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON="$(parse_field_from "$response_file" '.claim_unavailable_reason')"
                 CLAIM_PROBE_LAST_SEEN_PRESENT="$(json_has_key "$response_file" 'last_seen_at')"
                 if [[ "$CLAIM_PROBE_LAST_SEEN_PRESENT" == "true" ]]; then
                     CLAIM_PROBE_LAST_SEEN_AT="$(parse_field_from "$response_file" '.last_seen_at')"

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -29,6 +29,8 @@ STATUS_RECEIVER_ACTIVITY_BYTES=''
 STATUS_CLAIM_REGISTERED=''
 STATUS_CLAIM_VERSION=''
 STATUS_OWNER_PRESENT=''
+STATUS_CLAIM_CLAIMABLE=''
+STATUS_CLAIM_UNAVAILABLE_REASON=''
 STATUS_LAST_SEEN_AT=''
 STATUS_LAST_SEEN_AGE_SECONDS=''
 STATUS_SERVER_RECEPTION_STATE=''
@@ -60,6 +62,8 @@ status_init() {
     STATUS_CLAIM_REGISTERED=''
     STATUS_CLAIM_VERSION=''
     STATUS_OWNER_PRESENT=''
+    STATUS_CLAIM_CLAIMABLE=''
+    STATUS_CLAIM_UNAVAILABLE_REASON=''
     STATUS_LAST_SEEN_AT=''
     STATUS_LAST_SEEN_AGE_SECONDS=''
     STATUS_SERVER_RECEPTION_STATE=''
@@ -133,6 +137,8 @@ status_finish() {
             --arg claim_registered "$STATUS_CLAIM_REGISTERED" \
             --arg claim_version "$STATUS_CLAIM_VERSION" \
             --arg owner_present "$STATUS_OWNER_PRESENT" \
+            --arg claimable "$STATUS_CLAIM_CLAIMABLE" \
+            --arg claim_unavailable_reason "$STATUS_CLAIM_UNAVAILABLE_REASON" \
             --arg last_seen_at "$STATUS_LAST_SEEN_AT" \
             --arg last_seen_age_seconds "$STATUS_LAST_SEEN_AGE_SECONDS" \
             --arg reception_state "$STATUS_SERVER_RECEPTION_STATE" \
@@ -169,7 +175,9 @@ status_finish() {
               claim: {
                 registered: ($claim_registered | boolish),
                 version: ($claim_version | numberish),
-                owner_present: ($owner_present | boolish)
+                owner_present: ($owner_present | boolish),
+                claimable: ($claimable | boolish),
+                claim_unavailable_reason: ($claim_unavailable_reason | nullempty)
               },
               website: {
                 reception_state: ($reception_state | nullempty),
@@ -686,6 +694,8 @@ claim_registration_status_line() {
             STATUS_CLAIM_REGISTERED='true'
             STATUS_CLAIM_VERSION="$CLAIM_PROBE_VERSION"
             STATUS_OWNER_PRESENT="$CLAIM_PROBE_OWNER_PRESENT"
+            STATUS_CLAIM_CLAIMABLE="$CLAIM_PROBE_CLAIMABLE"
+            STATUS_CLAIM_UNAVAILABLE_REASON="$CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON"
             write_version_file "$CLAIM_PROBE_VERSION"
             # Claim-secret version is internal bookkeeping; exposed
             # via --json (.claim.version) and the local mirror file
@@ -695,6 +705,19 @@ claim_registration_status_line() {
             # nothing actionable.
             if [[ "$CLAIM_PROBE_OWNER_PRESENT" == "true" ]]; then
                 status_line ok "Website claim" "registered and claimed$(_website_host_suffix)"
+            elif [[ "$CLAIM_PROBE_CLAIM_UNAVAILABLE_REASON" == "not_seen_feeding" ]]; then
+                # Server says the claim gate is the liveness flag. Split
+                # the copy on whether it has EVER been seen so the fix
+                # ("start feeding" vs "reconnect") is the right one.
+                if [[ -n "$CLAIM_PROBE_LAST_SEEN_AT" && "$CLAIM_PROBE_LAST_SEEN_AT" != "null" ]]; then
+                    status_line warn "Website claim" "registered, but not seen feeding recently — not claimable until it reconnects$(_website_host_suffix)"
+                else
+                    status_line warn "Website claim" "registered, waiting for first data — not yet claimable$(_website_host_suffix)"
+                fi
+            elif [[ "$CLAIM_PROBE_CLAIMABLE" == "false" ]]; then
+                # Unclaimable for some other (or unreported) reason —
+                # stay generic; this is not a data problem.
+                status_line warn "Website claim" "registered, not currently claimable$(_website_host_suffix)"
             else
                 status_line ok "Website claim" "registered, not yet claimed$(_website_host_suffix)"
             fi

--- a/test/contracts/feeder-api-v1.json
+++ b/test/contracts/feeder-api-v1.json
@@ -211,7 +211,7 @@
         "body": {
           "registered": true,
           "version": 1,
-          "set_at": "2026-04-28T18:00:00+00:00",
+          "set_at": "2026-04-20T18:00:00+00:00",
           "owner_present": false,
           "reset_until": null,
           "last_seen_at": null,

--- a/test/contracts/feeder-api-v1.json
+++ b/test/contracts/feeder-api-v1.json
@@ -1,5 +1,4 @@
 {
-  "_doc": "Fixture shape for /api/feeders/secret (DEV-427): request.uuid is the bearer UUID identifier and is NOT a body field. The body sent on the wire is exactly {\"new_secret\": <request.new_secret>}. The Authorization header is Bearer alv1.<request.uuid>.<bearer_secret>. Mirrors the /status fixture shape used elsewhere.",
   "schema_version": 1,
   "secret": {
     "create_success": {
@@ -156,7 +155,9 @@
           "owner_present": true,
           "reset_until": null,
           "last_seen_at": "2026-04-28T18:40:30+00:00",
-          "last_seen_age_seconds": 90
+          "last_seen_age_seconds": 90,
+          "claimable": true,
+          "claim_unavailable_reason": null
         }
       }
     },
@@ -174,7 +175,9 @@
           "owner_present": false,
           "reset_until": null,
           "last_seen_at": "2026-04-28T18:12:00+00:00",
-          "last_seen_age_seconds": 1800
+          "last_seen_age_seconds": 1800,
+          "claimable": true,
+          "claim_unavailable_reason": null
         }
       }
     },
@@ -192,7 +195,29 @@
           "owner_present": false,
           "reset_until": null,
           "last_seen_at": null,
-          "last_seen_age_seconds": null
+          "last_seen_age_seconds": null,
+          "claimable": true,
+          "claim_unavailable_reason": null
+        }
+      }
+    },
+    "authenticated_not_claimable": {
+      "request": {
+        "uuid": "55555555-6666-7777-8888-999999999999"
+      },
+      "bearer_secret": "ABCDEFGHIJKLMNOP",
+      "response": {
+        "status": 200,
+        "body": {
+          "registered": true,
+          "version": 1,
+          "set_at": "2026-04-28T18:00:00+00:00",
+          "owner_present": false,
+          "reset_until": null,
+          "last_seen_at": null,
+          "last_seen_age_seconds": null,
+          "claimable": false,
+          "claim_unavailable_reason": "not_seen_feeding"
         }
       }
     },

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -1052,20 +1052,24 @@ setup_claim_state() {
     setup_claim_state 1
     stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"claimable":false,"claim_unavailable_reason":"not_seen_feeding","last_seen_at":null,"last_seen_age_seconds":null}'
     status_init
-    STATUS_OUTPUT_JSON=0
+    STATUS_OUTPUT_JSON=1
     claim_registration_status_line >/dev/null
-    [ "$STATUS_CLAIM_CLAIMABLE" = 'false' ]
-    [ "$STATUS_CLAIM_UNAVAILABLE_REASON" = 'not_seen_feeding' ]
+    run status_finish
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.claimable')" = 'false' ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.claim_unavailable_reason')" = 'not_seen_feeding' ]
 }
 
 @test "status --json: .claim.claimable null when server omits the field" {
     setup_claim_state 1
     stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
     status_init
-    STATUS_OUTPUT_JSON=0
+    STATUS_OUTPUT_JSON=1
     claim_registration_status_line >/dev/null
-    [ "$STATUS_CLAIM_CLAIMABLE" = '' ]
-    [ "$STATUS_CLAIM_UNAVAILABLE_REASON" = '' ]
+    run status_finish
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.claimable')" = 'null' ]
+    [ "$(printf '%s' "$output" | jq -r '.claim.claim_unavailable_reason')" = 'null' ]
 }
 
 @test "claim_registration_status_line: 200 + registered:true + missing version → warn 'did not authenticate'" {

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -1006,6 +1006,68 @@ setup_claim_state() {
     [[ "$output" != *'(v'* ]]
 }
 
+@test "claim_registration_status_line: claimable:false not_seen_feeding never seen → warn 'waiting for first data'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"claimable":false,"claim_unavailable_reason":"not_seen_feeding","last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'waiting for first data'* ]]
+    [[ "$output" != *'not yet claimed'* ]]
+}
+
+@test "claim_registration_status_line: claimable:false not_seen_feeding with stale last_seen → warn 'reconnects'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"claimable":false,"claim_unavailable_reason":"not_seen_feeding","last_seen_at":"2026-04-01T10:00:00+00:00","last_seen_age_seconds":3000000}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'not claimable until it reconnects'* ]]
+}
+
+@test "claim_registration_status_line: claimable:false with other reason → warn 'not currently claimable'" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"claimable":false,"claim_unavailable_reason":"claim_blocked","last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'CHECK'* ]]
+    [[ "$output" == *'not currently claimable'* ]]
+    [[ "$output" != *'waiting for first data'* ]]
+}
+
+@test "claim_registration_status_line: claimable absent (older server) → unchanged ok line" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    run claim_registration_status_line
+    [[ "$output" == *'OK'* ]]
+    [[ "$output" == *'not yet claimed'* ]]
+}
+
+@test "status --json: .claim.claimable false + reason round-trip" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"claimable":false,"claim_unavailable_reason":"not_seen_feeding","last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    claim_registration_status_line >/dev/null
+    [ "$STATUS_CLAIM_CLAIMABLE" = 'false' ]
+    [ "$STATUS_CLAIM_UNAVAILABLE_REASON" = 'not_seen_feeding' ]
+}
+
+@test "status --json: .claim.claimable null when server omits the field" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":5,"owner_present":false,"reset_until":null,"last_seen_at":null,"last_seen_age_seconds":null}'
+    status_init
+    STATUS_OUTPUT_JSON=0
+    claim_registration_status_line >/dev/null
+    [ "$STATUS_CLAIM_CLAIMABLE" = '' ]
+    [ "$STATUS_CLAIM_UNAVAILABLE_REASON" = '' ]
+}
+
 @test "claim_registration_status_line: 200 + registered:true + missing version → warn 'did not authenticate'" {
     setup_claim_state 1
     stub_post_json 200 '{"registered":true,"owner_present":true}'

--- a/test/test_claim_status.bats
+++ b/test/test_claim_status.bats
@@ -183,6 +183,16 @@ jqr() { printf '%s' "$1" | jq -r "$2"; }
     [[ "$output" != *"waiting for first data"* ]]
 }
 
+@test "claim status: reset_locked reason → admin-reset copy with expiry" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false,"claimable":false,"claim_unavailable_reason":"reset_locked","reset_until":"2026-06-13T10:00:00Z"}'
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"administrator reset is in progress"* ]]
+    [[ "$output" == *"2026-06-13T10:00:00Z"* ]]
+    [[ "$output" != *"waiting for first data"* ]]
+}
+
 @test "claim status: claimable:false with non-liveness reason → generic copy, no data hint" {
     setup_claim_state 1
     stub_post_json 200 '{"registered":true,"version":7,"owner_present":false,"claimable":false,"claim_unavailable_reason":"claim_blocked"}'

--- a/test/test_claim_status.bats
+++ b/test/test_claim_status.bats
@@ -139,6 +139,63 @@ jqr() { printf '%s' "$1" | jq -r "$2"; }
     [ "$(jqr "$output" '.owner_present')" = 'false' ]
 }
 
+@test "claim status: claimable absent (older server) → .claimable null, default copy" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.claimable')" = 'null' ]
+    [ "$(jqr "$output" '.claim_unavailable_reason')" = 'null' ]
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Claim it at:"* ]]
+}
+
+@test "claim status: claimable:true passes through" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false,"claimable":true,"claim_unavailable_reason":null}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'unclaimed' ]
+    [ "$(jqr "$output" '.claimable')" = 'true' ]
+}
+
+@test "claim status: not_seen_feeding, never seen → waiting-for-first-data copy" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false,"claimable":false,"claim_unavailable_reason":"not_seen_feeding","last_seen_at":null,"last_seen_age_seconds":null}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.result')" = 'unclaimed' ]
+    [ "$(jqr "$output" '.claimable')" = 'false' ]
+    [ "$(jqr "$output" '.claim_unavailable_reason')" = 'not_seen_feeding' ]
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"waiting for first data"* ]]
+    [[ "$output" != *"Claim it at:"* ]]
+}
+
+@test "claim status: not_seen_feeding, stale last_seen → reconnect copy" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false,"claimable":false,"claim_unavailable_reason":"not_seen_feeding","last_seen_at":"2026-04-01T10:00:00Z","last_seen_age_seconds":3000000}'
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not seen feeding recently"* ]]
+    [[ "$output" != *"waiting for first data"* ]]
+}
+
+@test "claim status: claimable:false with non-liveness reason → generic copy, no data hint" {
+    setup_claim_state 1
+    stub_post_json 200 '{"registered":true,"version":7,"owner_present":false,"claimable":false,"claim_unavailable_reason":"claim_blocked"}'
+    run claim_status --json
+    [ "$status" -eq 0 ]
+    [ "$(jqr "$output" '.claim_unavailable_reason')" = 'claim_blocked' ]
+    run claim_status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not currently claimable"* ]]
+    [[ "$output" != *"waiting for first data"* ]]
+    [[ "$output" != *"Claim it at:"* ]]
+}
+
 @test "claim status: 200 registered:true, no version (minimal) → secret_mismatch" {
     setup_claim_state 1
     stub_post_json 200 '{"registered":true}'


### PR DESCRIPTION
`apl-feed status` showed "registered, not yet claimed" even when the website would refuse a claim because the feeder had not been seen feeding — the device said one thing, the claim page another.

The authenticated status reply from the website now carries `claimable` and `claim_unavailable_reason`. `apl-feed status` and `apl-feed claim status` use them to say the feeder is waiting for first data (or needs to reconnect after a long absence) before it can be claimed, and the fields pass through both JSON outputs for the on-device webconfig. Against older servers that don't send the fields, the output is unchanged.