### PR TITLE
Preserve operator config when setup rewrites feed.env

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -36,6 +36,13 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
 # shellcheck source=scripts/lib/configure-validators.sh
 source "$SCRIPT_DIR/scripts/lib/configure-validators.sh"
+# feed-env-keys.sh + feed-env-apply.sh are sourced for the feed.meta.json
+# sidecar helpers (read/write/iso-now/tracked-keys) used by write_feed_env
+# to stamp feeder-edit metadata. Both are side-effect-free to source.
+# shellcheck source=scripts/lib/feed-env-keys.sh
+source "$SCRIPT_DIR/scripts/lib/feed-env-keys.sh"
+# shellcheck source=scripts/lib/feed-env-apply.sh
+source "$SCRIPT_DIR/scripts/lib/feed-env-apply.sh"
 airplanes_enable_build_mode_from_args "$@"
 airplanes_init_paths
 
@@ -73,10 +80,11 @@ detect_receiver_input() {
 # DEFAULT_MLAT_NAME — except in build mode, where it is left empty so a
 # generic baked image defers to airplanes-mlat's per-device
 # "Anonymous-<short-id>" runtime fallback instead of freezing one shared
-# literal name into every flashed card. This function does not set
-# MLAT_ENABLED — that's the caller's job (set explicitly from
-# AIRPLANES_MLAT_ENABLED in non-interactive mode, defaulted to "true"
-# in the interactive flow).
+# literal name into every flashed card. On a re-run, write_feed_env
+# overrides the empty-input fallback with a valid existing on-disk name.
+# This function does not set MLAT_ENABLED — that's resolved in
+# write_feed_env (explicit AIRPLANES_MLAT_ENABLED wins, else a valid
+# existing on-disk value is preserved, else "true").
 derive_mlat_keys() {
     if [[ -n "$NOSPACENAME" ]]; then
         MLAT_USER="$NOSPACENAME"
@@ -108,15 +116,122 @@ derive_geo_configured() {
     fi
 }
 
+# Keys write_feed_env re-derives and emits via its template. Any other
+# KEY= line in an existing feed.env is operator data (backend overrides
+# like TARGET/MLATSERVER/APL_FEED_WEBSITE_URL, or apl-feed-apply-written
+# keys like GAIN/REPORT_STATUS) and is carried over verbatim on rewrite.
+# Spaces around each name make the `case` containment match exact.
+WRITE_FEED_ENV_OWNED_KEYS=" LATITUDE LONGITUDE ALTITUDE GEO_CONFIGURED MLAT_USER MLAT_ENABLED MLAT_PRIVATE INPUT INPUT_TYPE "
+
+# Strict single-key read from an existing feed.env: double-quoted,
+# single-quoted, or bare-until-whitespace/comment forms; last occurrence
+# wins (matches `source` last-write-wins). Deliberately NOT `source` —
+# configure.sh must not execute operator-supplied shell content. Returns
+# 1 when the key is absent, empty, or doesn't match a strict form.
+read_existing_feed_env_value() {
+    local key="$1" file="$2" output
+    [[ -f "$file" ]] || return 1
+    output="$(sed -n \
+        -e "s/^${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
+        -e "s/^${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
+        -e "s/^${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
+        "$file" | tail -n 1)"
+    [[ -n "$output" ]] || return 1
+    printf '%s' "$output"
+}
+
+# Collect unowned KEY= lines from the existing feed.env into the
+# caller-visible CARRIED_FEED_ENV_LINES array — verbatim bytes, original
+# order, duplicates kept (`source` last-write-wins still applies). The
+# key is extracted after stripping leading whitespace so an indented
+# owned key (e.g. "  LATITUDE=…") counts as owned and cannot ride along
+# to shadow the freshly templated value. Comments and non-KEY= lines are
+# not carried.
+harvest_feed_env_overrides() {
+    local file="$1" line stripped key
+    CARRIED_FEED_ENV_LINES=()
+    [[ -f "$file" ]] || return 0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        stripped="${line#"${line%%[![:space:]]*}"}"
+        [[ "$stripped" =~ ^([A-Za-z_][A-Za-z0-9_]*)= ]] || continue
+        key="${BASH_REMATCH[1]}"
+        case "$WRITE_FEED_ENV_OWNED_KEYS" in
+            *" $key "*) continue ;;
+        esac
+        CARRIED_FEED_ENV_LINES+=("$line")
+    done < "$file"
+}
+
+# Resolve a true/false toggle: explicit caller choice wins, else a valid
+# existing on-disk value is preserved, else the default. An existing
+# value that doesn't strictly parse as true|false (hand-edited junk, or
+# a quoted value with a trailing comment) falls back to the default.
+resolve_feed_env_toggle() {
+    local explicit="$1" key="$2" file="$3" default="$4" existing
+    case "$explicit" in
+        true|false)
+            printf '%s' "$explicit"
+            return 0
+            ;;
+    esac
+    if existing="$(read_existing_feed_env_value "$key" "$file")"; then
+        case "$existing" in
+            true|false)
+                printf '%s' "$existing"
+                return 0
+                ;;
+        esac
+    fi
+    printf '%s' "$default"
+}
+
+# Stamp feeder-edit metadata into feed.meta.json for tracked keys whose
+# value changed in this rewrite. Without fresh stamps, a feeder with
+# REMOTE_CONFIG_ENABLED=true would let the next config sync overwrite
+# just-entered values: absent sidecar metadata sorts as the legacy epoch,
+# so the server's tuple would win last-write-wins against this setup run.
+# Sidecar failure is a warning, not fatal — feed.env is already written
+# and must not be held hostage by an informational sidecar.
+stamp_feed_env_sidecar() {
+    # shellcheck disable=SC2178  # nameref to the caller's assoc array
+    local -n prev_ref="$1"
+    local meta_path key new_value now_iso changed=0
+    meta_path="$(dirname "$FEED_ENV")/$APL_FEED_APPLY_META_BASENAME"
+    local -A meta_at=() meta_by=()
+    _apl_feed_apply_read_meta "$meta_path" meta_at meta_by
+    now_iso="$(_apl_feed_apply_iso_now)"
+    for key in "${APL_FEED_APPLY_META_TRACKED_KEYS[@]}"; do
+        case "$key" in
+            LATITUDE) new_value="$RECEIVERLATITUDE" ;;
+            LONGITUDE) new_value="$RECEIVERLONGITUDE" ;;
+            ALTITUDE) new_value="$RECEIVERALTITUDE" ;;
+            MLAT_USER) new_value="$MLAT_USER" ;;
+            MLAT_ENABLED) new_value="$MLAT_ENABLED" ;;
+            MLAT_PRIVATE) new_value="$MLAT_PRIVATE" ;;
+            *) continue ;;
+        esac
+        if [[ -z "${prev_ref[$key]+set}" || "${prev_ref[$key]}" != "$new_value" ]]; then
+            meta_at[$key]="$now_iso"
+            meta_by[$key]="feeder"
+            changed=1
+        fi
+    done
+    (( changed )) || return 0
+    if ! _apl_feed_apply_write_meta "$meta_path" "$FEED_ENV" meta_at meta_by; then
+        echo "configure: warning: could not update feed.meta.json (feed.env was written)" >&2
+    fi
+}
+
 write_feed_env() {
     derive_mlat_keys
     derive_geo_configured
     mkdir -p "$ETC_AIRPLANES"
-    # Hold /run/airplanes/feed-env.lock for the write window so a
-    # concurrent apl-feed apply (privileged writer in webconfig and the
-    # CLI) cannot land an update between the two `tee` blocks below.
-    # Build mode and missing-/run rootfs skip the lock; acquired but
-    # timed-out is a hard failure to prevent silent interleaving.
+    # Hold /run/airplanes/feed-env.lock for the whole read-then-rewrite
+    # window so a concurrent apl-feed apply (privileged writer in
+    # webconfig and the CLI) cannot land an update between the harvest
+    # below and the final rename. Build mode and missing-/run rootfs skip
+    # the lock; acquired but timed-out is a hard failure to prevent
+    # silent interleaving.
     local _feed_lock_fd=""
     if ! airplanes_is_build_mode 2>/dev/null \
         && command -v flock >/dev/null 2>&1 \
@@ -132,7 +247,46 @@ write_feed_env() {
             _feed_lock_fd=""
         fi
     fi
-    tee "$FEED_ENV" >/dev/null <<EOF
+
+    # All reads of the previous file happen inside the lock window:
+    # carried operator lines, toggle preservation, receiver-input
+    # preservation, and the pre-rewrite snapshot of sidecar-tracked
+    # values used to decide which metadata stamps to refresh.
+    harvest_feed_env_overrides "$FEED_ENV"
+    MLAT_ENABLED="$(resolve_feed_env_toggle "${MLAT_ENABLED:-}" MLAT_ENABLED "$FEED_ENV" true)"
+    MLAT_PRIVATE="$(resolve_feed_env_toggle "${MLAT_PRIVATE:-}" MLAT_PRIVATE "$FEED_ENV" false)"
+    # An existing feeder name survives a re-run when the operator didn't
+    # supply one (blank prompt input or unset AIRPLANES_MLAT_USER would
+    # otherwise reset the map name to the default).
+    local _existing
+    if [[ -z "$NOSPACENAME" ]] \
+        && _existing="$(read_existing_feed_env_value MLAT_USER "$FEED_ENV")" \
+        && valid_mlat_user_strict "$_existing"; then
+        MLAT_USER="$_existing"
+    fi
+    # A hand-set receiver override (custom INPUT/INPUT_TYPE) survives a
+    # setup re-run; detect_receiver_input's heuristic only fills keys the
+    # operator never set.
+    if _existing="$(read_existing_feed_env_value INPUT "$FEED_ENV")"; then
+        INPUT="$_existing"
+    fi
+    if _existing="$(read_existing_feed_env_value INPUT_TYPE "$FEED_ENV")"; then
+        INPUT_TYPE="$_existing"
+    fi
+    local -A _prev_tracked=()
+    local _tk _tv
+    for _tk in "${APL_FEED_APPLY_META_TRACKED_KEYS[@]}"; do
+        if _tv="$(read_existing_feed_env_value "$_tk" "$FEED_ENV")"; then
+            _prev_tracked[$_tk]="$_tv"
+        fi
+    done
+
+    # Compose the whole new file in a temp sibling and rename it into
+    # place: the daemons `source` feed.env directly at activation and
+    # must never observe a truncated half-written file.
+    local _tmp
+    _tmp="$(mktemp "${FEED_ENV}.XXXXXX")"
+    cat > "$_tmp" <<EOF
 # /etc/airplanes/feed.env — operator-supplied configuration for the
 # airplanes.live feeder daemons. Product-side defaults (brand endpoints,
 # readsb tuning, the local RESULTS output bundle, REDUCE_INTERVAL) live
@@ -178,13 +332,37 @@ EOF
     # both together (Radarcape uses 127.0.0.1:10003 / radarcape_gps),
     # so emit them as a pair to keep the override consistent.
     if [[ "$INPUT" != "127.0.0.1:30005" ]] || [[ "$INPUT_TYPE" != "dump1090" ]]; then
-        tee -a "$FEED_ENV" >/dev/null <<EOF
+        cat >> "$_tmp" <<EOF
 
 # Non-default receiver decoder. Defaults are 127.0.0.1:30005 / dump1090.
 INPUT="$INPUT"
 INPUT_TYPE="$INPUT_TYPE"
 EOF
     fi
+
+    if (( ${#CARRIED_FEED_ENV_LINES[@]} > 0 )); then
+        {
+            printf '\n# Carried over from the previous feed.env by setup. Keys not managed\n'
+            printf '# by setup are preserved verbatim; comments around them are not.\n'
+            printf '%s\n' "${CARRIED_FEED_ENV_LINES[@]}"
+        } >> "$_tmp"
+    fi
+
+    if [[ -f "$FEED_ENV" ]]; then
+        chmod --reference="$FEED_ENV" "$_tmp" 2>/dev/null || chmod 0644 "$_tmp" || true
+        chown --reference="$FEED_ENV" "$_tmp" 2>/dev/null || true
+    else
+        chmod 0644 "$_tmp" 2>/dev/null || true
+    fi
+    mv -f "$_tmp" "$FEED_ENV"
+
+    # Stamp sidecar metadata for tracked keys this rewrite changed, while
+    # still holding the lock. Skipped in build mode — the image freeze is
+    # not an operator edit and the chroot has no /run.
+    if ! airplanes_is_build_mode 2>/dev/null; then
+        stamp_feed_env_sidecar _prev_tracked
+    fi
+
     if [[ -n "$_feed_lock_fd" ]]; then
         eval "exec ${_feed_lock_fd}>&-"
     fi
@@ -211,26 +389,35 @@ configure_noninteractive() {
     ADSBFIUSERNAME="${AIRPLANES_MLAT_USER:-}"
     NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
 
-    # MLAT_ENABLED is optional and defaults to "true". Only "true" or
-    # "false" are accepted; silently coercing other values would mask
-    # operator typos.
-    case "${AIRPLANES_MLAT_ENABLED:-true}" in
-        true|false) MLAT_ENABLED="${AIRPLANES_MLAT_ENABLED:-true}" ;;
-        *)
-            echo "AIRPLANES_MLAT_ENABLED must be 'true' or 'false' (got: '${AIRPLANES_MLAT_ENABLED:-}')" >&2
-            exit 1
-            ;;
-    esac
+    # MLAT_ENABLED is optional. Unset or empty → preserve an existing
+    # valid value from feed.env, falling back to "true" (resolved inside
+    # write_feed_env's lock window). Set non-empty → strict true|false;
+    # silently coercing other values would mask operator typos.
+    if [[ -n "${AIRPLANES_MLAT_ENABLED:-}" ]]; then
+        case "$AIRPLANES_MLAT_ENABLED" in
+            true|false) MLAT_ENABLED="$AIRPLANES_MLAT_ENABLED" ;;
+            *)
+                echo "AIRPLANES_MLAT_ENABLED must be 'true' or 'false' (got: '$AIRPLANES_MLAT_ENABLED')" >&2
+                exit 1
+                ;;
+        esac
+    else
+        MLAT_ENABLED=""
+    fi
 
-    # MLAT_PRIVATE is optional and defaults to "false" (name shown on
-    # the MLAT map). Same strict true|false validation as MLAT_ENABLED.
-    case "${AIRPLANES_MLAT_PRIVATE:-false}" in
-        true|false) MLAT_PRIVATE="${AIRPLANES_MLAT_PRIVATE:-false}" ;;
-        *)
-            echo "AIRPLANES_MLAT_PRIVATE must be 'true' or 'false' (got: '${AIRPLANES_MLAT_PRIVATE:-}')" >&2
-            exit 1
-            ;;
-    esac
+    # MLAT_PRIVATE is optional; same preserve-or-default contract as
+    # MLAT_ENABLED, with "false" (name shown on the MLAT map) as default.
+    if [[ -n "${AIRPLANES_MLAT_PRIVATE:-}" ]]; then
+        case "$AIRPLANES_MLAT_PRIVATE" in
+            true|false) MLAT_PRIVATE="$AIRPLANES_MLAT_PRIVATE" ;;
+            *)
+                echo "AIRPLANES_MLAT_PRIVATE must be 'true' or 'false' (got: '$AIRPLANES_MLAT_PRIVATE')" >&2
+                exit 1
+                ;;
+        esac
+    else
+        MLAT_PRIVATE=""
+    fi
 
     RECEIVERLATITUDE="$AIRPLANES_LATITUDE"
     RECEIVERLONGITUDE="$AIRPLANES_LONGITUDE"
@@ -252,7 +439,16 @@ fi
 
 whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "Thanks for choosing to share your data with airplanes.live!\n\nairplanes.live is a co-op of ADS-B/Mode S/MLAT feeders from around the world. This script will configure your current ADS-B receiver to feed data to airplanes.live.\n\nWould you like to continue setup?" 13 78 || abort
 
-ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy).\n\nExample: \"william34-london\", \"william34-jersey\", etc.\n\nLeave blank to use the default name \"$DEFAULT_MLAT_NAME\".\n\n(To disable MLAT after setup, run: sudo apl-feed mlat disable)" 14 78 3>&1 1>&2 2>&3) || abort
+# On a re-run, blank input keeps the existing name (write_feed_env
+# preserves it); tell the operator which behavior blank gets them.
+EXISTING_MLAT_USER="$(read_existing_feed_env_value MLAT_USER "$FEED_ENV" 2>/dev/null || true)"
+if [[ -n "$EXISTING_MLAT_USER" ]] && valid_mlat_user_strict "$EXISTING_MLAT_USER"; then
+    MLAT_NAME_BLANK_HINT="Leave blank to keep the current name \"$EXISTING_MLAT_USER\"."
+else
+    MLAT_NAME_BLANK_HINT="Leave blank to use the default name \"$DEFAULT_MLAT_NAME\"."
+fi
+
+ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy).\n\nExample: \"william34-london\", \"william34-jersey\", etc.\n\n$MLAT_NAME_BLANK_HINT\n\n(To disable MLAT after setup, run: sudo apl-feed mlat disable)" 14 78 3>&1 1>&2 2>&3) || abort
 
 NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
 
@@ -306,12 +502,12 @@ RECEIVERALTITUDE="$ALT"
 
 #RECEIVERPORT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Receiver Feed Port" --nocancel --inputbox "\nChange only if you were assigned a custom feed port.\nFor most all users it is required this port remain set to port 30005." 10 78 "30005" 3>&1 1>&2 2>&3)
 
-# Interactive setup always enables MLAT and shows the feeder name on the
-# map. Operators who want either off run, after setup completes:
-#   sudo apl-feed mlat disable
-#   sudo apl-feed mlat private enable
-MLAT_ENABLED="true"
-MLAT_PRIVATE="false"
+# Interactive setup takes no explicit MLAT toggle choice: an existing
+# MLAT_ENABLED/MLAT_PRIVATE survives a re-run (so fixing coordinates
+# doesn't undo `apl-feed mlat disable` / `mlat private enable`); first
+# setup defaults to enabled + name shown on the map.
+MLAT_ENABLED=""
+MLAT_PRIVATE=""
 
 detect_receiver_input
 write_feed_env

--- a/configure.sh
+++ b/configure.sh
@@ -125,16 +125,19 @@ WRITE_FEED_ENV_OWNED_KEYS=" LATITUDE LONGITUDE ALTITUDE GEO_CONFIGURED MLAT_USER
 
 # Strict single-key read from an existing feed.env: double-quoted,
 # single-quoted, or bare-until-whitespace/comment forms; last occurrence
-# wins (matches `source` last-write-wins). Deliberately NOT `source` —
-# configure.sh must not execute operator-supplied shell content. Returns
-# 1 when the key is absent, empty, or doesn't match a strict form.
+# wins (matches `source` last-write-wins). Leading whitespace is
+# tolerated, mirroring harvest_feed_env_overrides' owned-key match (an
+# indented owned key must be readable here, or it would be neither
+# carried nor preserved). Deliberately NOT `source` — configure.sh must
+# not execute operator-supplied shell content. Returns 1 when the key is
+# absent, empty, or doesn't match a strict form.
 read_existing_feed_env_value() {
     local key="$1" file="$2" output
     [[ -f "$file" ]] || return 1
     output="$(sed -n \
-        -e "s/^${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
-        -e "s/^${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
-        -e "s/^${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
+        -e "s/^[[:space:]]*${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
+        -e "s/^[[:space:]]*${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
+        -e "s/^[[:space:]]*${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
         "$file" | tail -n 1)"
     [[ -n "$output" ]] || return 1
     printf '%s' "$output"
@@ -266,11 +269,16 @@ write_feed_env() {
     fi
     # A hand-set receiver override (custom INPUT/INPUT_TYPE) survives a
     # setup re-run; detect_receiver_input's heuristic only fills keys the
-    # operator never set.
-    if _existing="$(read_existing_feed_env_value INPUT "$FEED_ENV")"; then
+    # operator never set. Charset-guarded: the preserved value is
+    # re-emitted inside double quotes by the template, so anything that
+    # could change meaning there (quotes, $, backticks, whitespace) falls
+    # back to detection instead of being rewritten into a live shape.
+    if _existing="$(read_existing_feed_env_value INPUT "$FEED_ENV")" \
+        && [[ "$_existing" =~ ^[A-Za-z0-9._:-]+$ ]]; then
         INPUT="$_existing"
     fi
-    if _existing="$(read_existing_feed_env_value INPUT_TYPE "$FEED_ENV")"; then
+    if _existing="$(read_existing_feed_env_value INPUT_TYPE "$FEED_ENV")" \
+        && [[ "$_existing" =~ ^[A-Za-z0-9_]+$ ]]; then
         INPUT_TYPE="$_existing"
     fi
     local -A _prev_tracked=()

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -388,3 +388,317 @@ run_configure_env() {
     [[ "$output" =~ "Missing required non-interactive configure value: AIRPLANES_LATITUDE" ]]
     [ ! -e "$WHIPTAIL_LOG" ]
 }
+
+## Preservation on re-run (feed#131): write_feed_env must not clobber
+## operator data it doesn't own.
+
+seed_feed_env() {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    cat > "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+rerun_coords_only() {
+    run_configure_env \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+}
+
+@test "configure.sh re-run carries unowned keys over verbatim" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.00000"
+LONGITUDE="8.00000"
+ALTITUDE="100"
+MLAT_USER="alice"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+MLATSERVER="feed.airplanes.test:31090"
+APL_FEED_WEBSITE_URL="https://airplanes.test"
+REPORT_STATUS="false"
+GAIN="auto"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    local env_file="$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$env_file"
+    grep -qx 'MLATSERVER="feed.airplanes.test:31090"' "$env_file"
+    grep -qx 'APL_FEED_WEBSITE_URL="https://airplanes.test"' "$env_file"
+    grep -qx 'REPORT_STATUS="false"' "$env_file"
+    grep -qx 'GAIN="auto"' "$env_file"
+    grep -q 'Carried over from the previous feed.env' "$env_file"
+    # New coordinates landed; owned keys are not duplicated by carry-over.
+    grep -q 'LATITUDE="52.52000"' "$env_file"
+    [ "$(grep -c '^LATITUDE=' "$env_file")" -eq 1 ]
+    [ "$(grep -c '^MLAT_USER=' "$env_file")" -eq 1 ]
+}
+
+@test "configure.sh re-run keeps duplicate unowned lines in order" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+GAIN="auto"
+GAIN="42"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    # Both occurrences survive, original order (source last-write-wins).
+    [ "$(grep -c '^GAIN=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 2 ]
+    grep -A1 '^GAIN="auto"' "$ROOT_DIR/etc/airplanes/feed.env" | grep -qx 'GAIN="42"'
+}
+
+@test "configure.sh re-run does not carry comments or non-KEY= lines" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+# operator note about the override below
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+export SHELLISH=1
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q 'operator note about the override' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q 'SHELLISH' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run twice is idempotent (byte-identical file)" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+REPORT_STATUS="false"
+EOF
+    rerun_coords_only
+    [ "$status" -eq 0 ]
+    cp "$ROOT_DIR/etc/airplanes/feed.env" "$ROOT_DIR/first-pass"
+
+    rerun_coords_only
+    [ "$status" -eq 0 ]
+    cmp "$ROOT_DIR/first-pass" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh fresh install writes no carried-over section" {
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'Carried over from the previous feed.env' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run preserves MLAT_ENABLED=false and MLAT_PRIVATE=true" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false"
+MLAT_PRIVATE=true
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh interactive re-run preserves MLAT toggles and name on blank input" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_USER="keepme"
+MLAT_ENABLED="false"
+MLAT_PRIVATE=true
+EOF
+    run_configure $'\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="keepme"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+    # The name prompt advertises keep-current semantics on a re-run.
+    grep -q 'keep the current name "keepme"' "$WHIPTAIL_LOG"
+}
+
+@test "configure.sh interactive re-run: explicit name input still wins" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_USER="keepme"
+EOF
+    run_configure $'newname\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="newname"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh explicit AIRPLANES_MLAT_ENABLED=true overrides preserved false" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false"
+EOF
+    run_configure_env \
+        AIRPLANES_MLAT_ENABLED="true" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh empty AIRPLANES_MLAT_ENABLED preserves the existing value" {
+    # Set-but-empty means "no explicit choice" — same as unset.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false"
+EOF
+    run_configure_env \
+        AIRPLANES_MLAT_ENABLED="" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run: invalid existing toggle falls back to default" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="banana"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run: quoted toggle with trailing comment falls back to default" {
+    # `MLAT_ENABLED="false" # note` doesn't match any strict read form
+    # (the bare rule captures the opening quote), so preservation
+    # refuses it and the default applies. Pinned: this is the parser
+    # behavior that makes same-line comments a forbidden shape.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false" # operator note
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run preserves a custom INPUT/INPUT_TYPE" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+INPUT="192.168.1.10:30005"
+INPUT_TYPE="dump1090"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -qx 'INPUT="192.168.1.10:30005"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'INPUT_TYPE="dump1090"' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ "$(grep -c '^INPUT=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 1 ]
+}
+
+@test "configure.sh re-run preserves MLAT_USER when no name is supplied" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_USER="keepme"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="keepme"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh build mode with pre-existing overrides preserves them, no sidecar" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+EOF
+    run_configure_env \
+        AIRPLANES_BUILD_MODE=1 \
+        AIRPLANES_LATITUDE="0" \
+        AIRPLANES_LONGITUDE="0" \
+        AIRPLANES_ALTITUDE=""
+
+    [ "$status" -eq 0 ]
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Build mode is not an operator edit — no metadata stamps.
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.meta.json" ]
+}
+
+@test "configure.sh stamps sidecar metadata for changed tracked keys only" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.00000"
+LONGITUDE="8.00000"
+ALTITUDE="35"
+MLAT_USER="alice"
+MLAT_ENABLED="false"
+MLAT_PRIVATE=false
+EOF
+    cat > "$ROOT_DIR/etc/airplanes/feed.meta.json" <<'EOF'
+{"schema_version":1,"fields":{"MLAT_USER":{"edited_at":"2026-01-01T00:00:00.000000Z","edited_by":"website"}}}
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    local meta="$ROOT_DIR/etc/airplanes/feed.meta.json"
+    # Coordinates changed → fresh feeder stamps.
+    [ "$(jq -r '.fields.LATITUDE.edited_by' "$meta")" = "feeder" ]
+    [ "$(jq -r '.fields.LATITUDE.edited_at' "$meta")" != "2026-01-01T00:00:00.000000Z" ]
+    # MLAT_USER unchanged (preserved) → existing website tuple kept.
+    [ "$(jq -r '.fields.MLAT_USER.edited_by' "$meta")" = "website" ]
+    [ "$(jq -r '.fields.MLAT_USER.edited_at' "$meta")" = "2026-01-01T00:00:00.000000Z" ]
+    # MLAT_ENABLED preserved unchanged → no stamp materializes.
+    [ "$(jq -r '.fields.MLAT_ENABLED' "$meta")" = "null" ]
+}
+
+@test "configure.sh carried keys survive a subsequent apl_feed_apply write" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+EOF
+    rerun_coords_only
+    [ "$status" -eq 0 ]
+
+    # Run the canonical key-level writer over the rewritten file the way
+    # apl-feed diagnostics/config would; the carried TARGET value must
+    # survive (apply normalizes formatting but keeps the value).
+    mkdir -p "$ROOT_DIR/run/airplanes"
+    run bash -c '
+        source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/configure-validators.sh"
+        source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-keys.sh"
+        source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-apply.sh"
+        apl_feed_apply --no-restart --no-audit \
+            --feed-env "'"$ROOT_DIR"'/etc/airplanes/feed.env" \
+            --lock-file "'"$ROOT_DIR"'/run/airplanes/feed-env.lock" \
+            REPORT_STATUS=false
+    '
+    [ "$status" -eq 0 ]
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'REPORT_STATUS="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -702,3 +702,39 @@ EOF
     grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
     grep -qx 'REPORT_STATUS="false"' "$ROOT_DIR/etc/airplanes/feed.env"
 }
+
+@test "configure.sh re-run: unsafe existing INPUT falls back to detection" {
+    # A single-quoted command substitution is inert when sourced; the
+    # template re-emits preserved values double-quoted, which would make
+    # it live. The charset guard must refuse to preserve it.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+INPUT='$(reboot)'
+INPUT_TYPE="dump1090"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'reboot' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Detection yields the defaults, so no INPUT block is emitted at all.
+    ! grep -q '^INPUT=' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run preserves an indented owned key's value" {
+    # An indented MLAT_ENABLED is valid for `source`; the harvest treats
+    # it as owned (not carried), so the preservation reader must see it
+    # too — otherwise the value would be silently reset.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+  MLAT_ENABLED="false"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ "$(grep -c 'MLAT_ENABLED=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 1 ]
+}


### PR DESCRIPTION
Re-running `setup.sh` / `configure.sh` (for example to fix coordinates) regenerated `feed.env` from a fixed template and silently dropped everything the template didn't know about: backend overrides like `TARGET`, `MLATSERVER`, and `APL_FEED_WEBSITE_URL`, keys written by `apl-feed` such as `GAIN`, `UAT_INPUT`, and `REPORT_STATUS` (so a diagnostics opt-out was quietly reverted), and a custom receiver `INPUT`. The interactive flow additionally reset `MLAT_ENABLED`, `MLAT_PRIVATE`, and the feeder name on every run.

The rewrite now reads the previous file under the same lock the other writers use: keys setup doesn't own are carried over verbatim into a marked section, existing MLAT toggles, feeder name, and receiver input survive unless the operator explicitly chooses new values, and the whole file is composed in a temp file and renamed into place so the daemons can never source a half-written config. Tracked keys whose value actually changed get fresh edit metadata in `feed.meta.json`, so a setup run counts as a local edit for remote-config conflict resolution instead of losing to older server state.

Addresses #131.
