### PR TITLE
Add apl-feed config show and pin the feed.env value contract

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -36,6 +36,13 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/scripts/lib/install-update-common.sh"
 # shellcheck source=scripts/lib/configure-validators.sh
 source "$SCRIPT_DIR/scripts/lib/configure-validators.sh"
+# feed-env-keys.sh + feed-env-apply.sh are sourced for the feed.meta.json
+# sidecar helpers (read/write/iso-now/tracked-keys) used by write_feed_env
+# to stamp feeder-edit metadata. Both are side-effect-free to source.
+# shellcheck source=scripts/lib/feed-env-keys.sh
+source "$SCRIPT_DIR/scripts/lib/feed-env-keys.sh"
+# shellcheck source=scripts/lib/feed-env-apply.sh
+source "$SCRIPT_DIR/scripts/lib/feed-env-apply.sh"
 airplanes_enable_build_mode_from_args "$@"
 airplanes_init_paths
 
@@ -73,10 +80,11 @@ detect_receiver_input() {
 # DEFAULT_MLAT_NAME — except in build mode, where it is left empty so a
 # generic baked image defers to airplanes-mlat's per-device
 # "Anonymous-<short-id>" runtime fallback instead of freezing one shared
-# literal name into every flashed card. This function does not set
-# MLAT_ENABLED — that's the caller's job (set explicitly from
-# AIRPLANES_MLAT_ENABLED in non-interactive mode, defaulted to "true"
-# in the interactive flow).
+# literal name into every flashed card. On a re-run, write_feed_env
+# overrides the empty-input fallback with a valid existing on-disk name.
+# This function does not set MLAT_ENABLED — that's resolved in
+# write_feed_env (explicit AIRPLANES_MLAT_ENABLED wins, else a valid
+# existing on-disk value is preserved, else "true").
 derive_mlat_keys() {
     if [[ -n "$NOSPACENAME" ]]; then
         MLAT_USER="$NOSPACENAME"
@@ -108,15 +116,122 @@ derive_geo_configured() {
     fi
 }
 
+# Keys write_feed_env re-derives and emits via its template. Any other
+# KEY= line in an existing feed.env is operator data (backend overrides
+# like TARGET/MLATSERVER/APL_FEED_WEBSITE_URL, or apl-feed-apply-written
+# keys like GAIN/REPORT_STATUS) and is carried over verbatim on rewrite.
+# Spaces around each name make the `case` containment match exact.
+WRITE_FEED_ENV_OWNED_KEYS=" LATITUDE LONGITUDE ALTITUDE GEO_CONFIGURED MLAT_USER MLAT_ENABLED MLAT_PRIVATE INPUT INPUT_TYPE "
+
+# Strict single-key read from an existing feed.env: double-quoted,
+# single-quoted, or bare-until-whitespace/comment forms; last occurrence
+# wins (matches `source` last-write-wins). Deliberately NOT `source` —
+# configure.sh must not execute operator-supplied shell content. Returns
+# 1 when the key is absent, empty, or doesn't match a strict form.
+read_existing_feed_env_value() {
+    local key="$1" file="$2" output
+    [[ -f "$file" ]] || return 1
+    output="$(sed -n \
+        -e "s/^${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
+        -e "s/^${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
+        -e "s/^${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
+        "$file" | tail -n 1)"
+    [[ -n "$output" ]] || return 1
+    printf '%s' "$output"
+}
+
+# Collect unowned KEY= lines from the existing feed.env into the
+# caller-visible CARRIED_FEED_ENV_LINES array — verbatim bytes, original
+# order, duplicates kept (`source` last-write-wins still applies). The
+# key is extracted after stripping leading whitespace so an indented
+# owned key (e.g. "  LATITUDE=…") counts as owned and cannot ride along
+# to shadow the freshly templated value. Comments and non-KEY= lines are
+# not carried.
+harvest_feed_env_overrides() {
+    local file="$1" line stripped key
+    CARRIED_FEED_ENV_LINES=()
+    [[ -f "$file" ]] || return 0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        stripped="${line#"${line%%[![:space:]]*}"}"
+        [[ "$stripped" =~ ^([A-Za-z_][A-Za-z0-9_]*)= ]] || continue
+        key="${BASH_REMATCH[1]}"
+        case "$WRITE_FEED_ENV_OWNED_KEYS" in
+            *" $key "*) continue ;;
+        esac
+        CARRIED_FEED_ENV_LINES+=("$line")
+    done < "$file"
+}
+
+# Resolve a true/false toggle: explicit caller choice wins, else a valid
+# existing on-disk value is preserved, else the default. An existing
+# value that doesn't strictly parse as true|false (hand-edited junk, or
+# a quoted value with a trailing comment) falls back to the default.
+resolve_feed_env_toggle() {
+    local explicit="$1" key="$2" file="$3" default="$4" existing
+    case "$explicit" in
+        true|false)
+            printf '%s' "$explicit"
+            return 0
+            ;;
+    esac
+    if existing="$(read_existing_feed_env_value "$key" "$file")"; then
+        case "$existing" in
+            true|false)
+                printf '%s' "$existing"
+                return 0
+                ;;
+        esac
+    fi
+    printf '%s' "$default"
+}
+
+# Stamp feeder-edit metadata into feed.meta.json for tracked keys whose
+# value changed in this rewrite. Without fresh stamps, a feeder with
+# REMOTE_CONFIG_ENABLED=true would let the next config sync overwrite
+# just-entered values: absent sidecar metadata sorts as the legacy epoch,
+# so the server's tuple would win last-write-wins against this setup run.
+# Sidecar failure is a warning, not fatal — feed.env is already written
+# and must not be held hostage by an informational sidecar.
+stamp_feed_env_sidecar() {
+    # shellcheck disable=SC2178  # nameref to the caller's assoc array
+    local -n prev_ref="$1"
+    local meta_path key new_value now_iso changed=0
+    meta_path="$(dirname "$FEED_ENV")/$APL_FEED_APPLY_META_BASENAME"
+    local -A meta_at=() meta_by=()
+    _apl_feed_apply_read_meta "$meta_path" meta_at meta_by
+    now_iso="$(_apl_feed_apply_iso_now)"
+    for key in "${APL_FEED_APPLY_META_TRACKED_KEYS[@]}"; do
+        case "$key" in
+            LATITUDE) new_value="$RECEIVERLATITUDE" ;;
+            LONGITUDE) new_value="$RECEIVERLONGITUDE" ;;
+            ALTITUDE) new_value="$RECEIVERALTITUDE" ;;
+            MLAT_USER) new_value="$MLAT_USER" ;;
+            MLAT_ENABLED) new_value="$MLAT_ENABLED" ;;
+            MLAT_PRIVATE) new_value="$MLAT_PRIVATE" ;;
+            *) continue ;;
+        esac
+        if [[ -z "${prev_ref[$key]+set}" || "${prev_ref[$key]}" != "$new_value" ]]; then
+            meta_at[$key]="$now_iso"
+            meta_by[$key]="feeder"
+            changed=1
+        fi
+    done
+    (( changed )) || return 0
+    if ! _apl_feed_apply_write_meta "$meta_path" "$FEED_ENV" meta_at meta_by; then
+        echo "configure: warning: could not update feed.meta.json (feed.env was written)" >&2
+    fi
+}
+
 write_feed_env() {
     derive_mlat_keys
     derive_geo_configured
     mkdir -p "$ETC_AIRPLANES"
-    # Hold /run/airplanes/feed-env.lock for the write window so a
-    # concurrent apl-feed apply (privileged writer in webconfig and the
-    # CLI) cannot land an update between the two `tee` blocks below.
-    # Build mode and missing-/run rootfs skip the lock; acquired but
-    # timed-out is a hard failure to prevent silent interleaving.
+    # Hold /run/airplanes/feed-env.lock for the whole read-then-rewrite
+    # window so a concurrent apl-feed apply (privileged writer in
+    # webconfig and the CLI) cannot land an update between the harvest
+    # below and the final rename. Build mode and missing-/run rootfs skip
+    # the lock; acquired but timed-out is a hard failure to prevent
+    # silent interleaving.
     local _feed_lock_fd=""
     if ! airplanes_is_build_mode 2>/dev/null \
         && command -v flock >/dev/null 2>&1 \
@@ -132,7 +247,46 @@ write_feed_env() {
             _feed_lock_fd=""
         fi
     fi
-    tee "$FEED_ENV" >/dev/null <<EOF
+
+    # All reads of the previous file happen inside the lock window:
+    # carried operator lines, toggle preservation, receiver-input
+    # preservation, and the pre-rewrite snapshot of sidecar-tracked
+    # values used to decide which metadata stamps to refresh.
+    harvest_feed_env_overrides "$FEED_ENV"
+    MLAT_ENABLED="$(resolve_feed_env_toggle "${MLAT_ENABLED:-}" MLAT_ENABLED "$FEED_ENV" true)"
+    MLAT_PRIVATE="$(resolve_feed_env_toggle "${MLAT_PRIVATE:-}" MLAT_PRIVATE "$FEED_ENV" false)"
+    # An existing feeder name survives a re-run when the operator didn't
+    # supply one (blank prompt input or unset AIRPLANES_MLAT_USER would
+    # otherwise reset the map name to the default).
+    local _existing
+    if [[ -z "$NOSPACENAME" ]] \
+        && _existing="$(read_existing_feed_env_value MLAT_USER "$FEED_ENV")" \
+        && valid_mlat_user_strict "$_existing"; then
+        MLAT_USER="$_existing"
+    fi
+    # A hand-set receiver override (custom INPUT/INPUT_TYPE) survives a
+    # setup re-run; detect_receiver_input's heuristic only fills keys the
+    # operator never set.
+    if _existing="$(read_existing_feed_env_value INPUT "$FEED_ENV")"; then
+        INPUT="$_existing"
+    fi
+    if _existing="$(read_existing_feed_env_value INPUT_TYPE "$FEED_ENV")"; then
+        INPUT_TYPE="$_existing"
+    fi
+    local -A _prev_tracked=()
+    local _tk _tv
+    for _tk in "${APL_FEED_APPLY_META_TRACKED_KEYS[@]}"; do
+        if _tv="$(read_existing_feed_env_value "$_tk" "$FEED_ENV")"; then
+            _prev_tracked[$_tk]="$_tv"
+        fi
+    done
+
+    # Compose the whole new file in a temp sibling and rename it into
+    # place: the daemons `source` feed.env directly at activation and
+    # must never observe a truncated half-written file.
+    local _tmp
+    _tmp="$(mktemp "${FEED_ENV}.XXXXXX")"
+    cat > "$_tmp" <<EOF
 # /etc/airplanes/feed.env — operator-supplied configuration for the
 # airplanes.live feeder daemons. Product-side defaults (brand endpoints,
 # readsb tuning, the local RESULTS output bundle, REDUCE_INTERVAL) live
@@ -178,13 +332,37 @@ EOF
     # both together (Radarcape uses 127.0.0.1:10003 / radarcape_gps),
     # so emit them as a pair to keep the override consistent.
     if [[ "$INPUT" != "127.0.0.1:30005" ]] || [[ "$INPUT_TYPE" != "dump1090" ]]; then
-        tee -a "$FEED_ENV" >/dev/null <<EOF
+        cat >> "$_tmp" <<EOF
 
 # Non-default receiver decoder. Defaults are 127.0.0.1:30005 / dump1090.
 INPUT="$INPUT"
 INPUT_TYPE="$INPUT_TYPE"
 EOF
     fi
+
+    if (( ${#CARRIED_FEED_ENV_LINES[@]} > 0 )); then
+        {
+            printf '\n# Carried over from the previous feed.env by setup. Keys not managed\n'
+            printf '# by setup are preserved verbatim; comments around them are not.\n'
+            printf '%s\n' "${CARRIED_FEED_ENV_LINES[@]}"
+        } >> "$_tmp"
+    fi
+
+    if [[ -f "$FEED_ENV" ]]; then
+        chmod --reference="$FEED_ENV" "$_tmp" 2>/dev/null || chmod 0644 "$_tmp" || true
+        chown --reference="$FEED_ENV" "$_tmp" 2>/dev/null || true
+    else
+        chmod 0644 "$_tmp" 2>/dev/null || true
+    fi
+    mv -f "$_tmp" "$FEED_ENV"
+
+    # Stamp sidecar metadata for tracked keys this rewrite changed, while
+    # still holding the lock. Skipped in build mode — the image freeze is
+    # not an operator edit and the chroot has no /run.
+    if ! airplanes_is_build_mode 2>/dev/null; then
+        stamp_feed_env_sidecar _prev_tracked
+    fi
+
     if [[ -n "$_feed_lock_fd" ]]; then
         eval "exec ${_feed_lock_fd}>&-"
     fi
@@ -211,26 +389,35 @@ configure_noninteractive() {
     ADSBFIUSERNAME="${AIRPLANES_MLAT_USER:-}"
     NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
 
-    # MLAT_ENABLED is optional and defaults to "true". Only "true" or
-    # "false" are accepted; silently coercing other values would mask
-    # operator typos.
-    case "${AIRPLANES_MLAT_ENABLED:-true}" in
-        true|false) MLAT_ENABLED="${AIRPLANES_MLAT_ENABLED:-true}" ;;
-        *)
-            echo "AIRPLANES_MLAT_ENABLED must be 'true' or 'false' (got: '${AIRPLANES_MLAT_ENABLED:-}')" >&2
-            exit 1
-            ;;
-    esac
+    # MLAT_ENABLED is optional. Unset or empty → preserve an existing
+    # valid value from feed.env, falling back to "true" (resolved inside
+    # write_feed_env's lock window). Set non-empty → strict true|false;
+    # silently coercing other values would mask operator typos.
+    if [[ -n "${AIRPLANES_MLAT_ENABLED:-}" ]]; then
+        case "$AIRPLANES_MLAT_ENABLED" in
+            true|false) MLAT_ENABLED="$AIRPLANES_MLAT_ENABLED" ;;
+            *)
+                echo "AIRPLANES_MLAT_ENABLED must be 'true' or 'false' (got: '$AIRPLANES_MLAT_ENABLED')" >&2
+                exit 1
+                ;;
+        esac
+    else
+        MLAT_ENABLED=""
+    fi
 
-    # MLAT_PRIVATE is optional and defaults to "false" (name shown on
-    # the MLAT map). Same strict true|false validation as MLAT_ENABLED.
-    case "${AIRPLANES_MLAT_PRIVATE:-false}" in
-        true|false) MLAT_PRIVATE="${AIRPLANES_MLAT_PRIVATE:-false}" ;;
-        *)
-            echo "AIRPLANES_MLAT_PRIVATE must be 'true' or 'false' (got: '${AIRPLANES_MLAT_PRIVATE:-}')" >&2
-            exit 1
-            ;;
-    esac
+    # MLAT_PRIVATE is optional; same preserve-or-default contract as
+    # MLAT_ENABLED, with "false" (name shown on the MLAT map) as default.
+    if [[ -n "${AIRPLANES_MLAT_PRIVATE:-}" ]]; then
+        case "$AIRPLANES_MLAT_PRIVATE" in
+            true|false) MLAT_PRIVATE="$AIRPLANES_MLAT_PRIVATE" ;;
+            *)
+                echo "AIRPLANES_MLAT_PRIVATE must be 'true' or 'false' (got: '$AIRPLANES_MLAT_PRIVATE')" >&2
+                exit 1
+                ;;
+        esac
+    else
+        MLAT_PRIVATE=""
+    fi
 
     RECEIVERLATITUDE="$AIRPLANES_LATITUDE"
     RECEIVERLONGITUDE="$AIRPLANES_LONGITUDE"
@@ -252,7 +439,16 @@ fi
 
 whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "Thanks for choosing to share your data with airplanes.live!\n\nairplanes.live is a co-op of ADS-B/Mode S/MLAT feeders from around the world. This script will configure your current ADS-B receiver to feed data to airplanes.live.\n\nWould you like to continue setup?" 13 78 || abort
 
-ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy).\n\nExample: \"william34-london\", \"william34-jersey\", etc.\n\nLeave blank to use the default name \"$DEFAULT_MLAT_NAME\".\n\n(To disable MLAT after setup, run: sudo apl-feed mlat disable)" 14 78 3>&1 1>&2 2>&3) || abort
+# On a re-run, blank input keeps the existing name (write_feed_env
+# preserves it); tell the operator which behavior blank gets them.
+EXISTING_MLAT_USER="$(read_existing_feed_env_value MLAT_USER "$FEED_ENV" 2>/dev/null || true)"
+if [[ -n "$EXISTING_MLAT_USER" ]] && valid_mlat_user_strict "$EXISTING_MLAT_USER"; then
+    MLAT_NAME_BLANK_HINT="Leave blank to keep the current name \"$EXISTING_MLAT_USER\"."
+else
+    MLAT_NAME_BLANK_HINT="Leave blank to use the default name \"$DEFAULT_MLAT_NAME\"."
+fi
+
+ADSBFIUSERNAME=$(whiptail --backtitle "$BACKTITLETEXT" --title "Feeder MLAT Name" --nocancel --inputbox "\nPlease enter a unique name to be shown on the MLAT map (the pin will be offset for privacy).\n\nExample: \"william34-london\", \"william34-jersey\", etc.\n\n$MLAT_NAME_BLANK_HINT\n\n(To disable MLAT after setup, run: sudo apl-feed mlat disable)" 14 78 3>&1 1>&2 2>&3) || abort
 
 NOSPACENAME="$(sanitize_mlat_user "$ADSBFIUSERNAME")"
 
@@ -306,12 +502,12 @@ RECEIVERALTITUDE="$ALT"
 
 #RECEIVERPORT=$(whiptail --backtitle "$BACKTITLETEXT" --title "Receiver Feed Port" --nocancel --inputbox "\nChange only if you were assigned a custom feed port.\nFor most all users it is required this port remain set to port 30005." 10 78 "30005" 3>&1 1>&2 2>&3)
 
-# Interactive setup always enables MLAT and shows the feeder name on the
-# map. Operators who want either off run, after setup completes:
-#   sudo apl-feed mlat disable
-#   sudo apl-feed mlat private enable
-MLAT_ENABLED="true"
-MLAT_PRIVATE="false"
+# Interactive setup takes no explicit MLAT toggle choice: an existing
+# MLAT_ENABLED/MLAT_PRIVATE survives a re-run (so fixing coordinates
+# doesn't undo `apl-feed mlat disable` / `mlat private enable`); first
+# setup defaults to enabled + name shown on the map.
+MLAT_ENABLED=""
+MLAT_PRIVATE=""
 
 detect_receiver_input
 write_feed_env

--- a/configure.sh
+++ b/configure.sh
@@ -125,16 +125,19 @@ WRITE_FEED_ENV_OWNED_KEYS=" LATITUDE LONGITUDE ALTITUDE GEO_CONFIGURED MLAT_USER
 
 # Strict single-key read from an existing feed.env: double-quoted,
 # single-quoted, or bare-until-whitespace/comment forms; last occurrence
-# wins (matches `source` last-write-wins). Deliberately NOT `source` —
-# configure.sh must not execute operator-supplied shell content. Returns
-# 1 when the key is absent, empty, or doesn't match a strict form.
+# wins (matches `source` last-write-wins). Leading whitespace is
+# tolerated, mirroring harvest_feed_env_overrides' owned-key match (an
+# indented owned key must be readable here, or it would be neither
+# carried nor preserved). Deliberately NOT `source` — configure.sh must
+# not execute operator-supplied shell content. Returns 1 when the key is
+# absent, empty, or doesn't match a strict form.
 read_existing_feed_env_value() {
     local key="$1" file="$2" output
     [[ -f "$file" ]] || return 1
     output="$(sed -n \
-        -e "s/^${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
-        -e "s/^${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
-        -e "s/^${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
+        -e "s/^[[:space:]]*${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
+        -e "s/^[[:space:]]*${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
+        -e "s/^[[:space:]]*${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
         "$file" | tail -n 1)"
     [[ -n "$output" ]] || return 1
     printf '%s' "$output"
@@ -266,11 +269,16 @@ write_feed_env() {
     fi
     # A hand-set receiver override (custom INPUT/INPUT_TYPE) survives a
     # setup re-run; detect_receiver_input's heuristic only fills keys the
-    # operator never set.
-    if _existing="$(read_existing_feed_env_value INPUT "$FEED_ENV")"; then
+    # operator never set. Charset-guarded: the preserved value is
+    # re-emitted inside double quotes by the template, so anything that
+    # could change meaning there (quotes, $, backticks, whitespace) falls
+    # back to detection instead of being rewritten into a live shape.
+    if _existing="$(read_existing_feed_env_value INPUT "$FEED_ENV")" \
+        && [[ "$_existing" =~ ^[A-Za-z0-9._:-]+$ ]]; then
         INPUT="$_existing"
     fi
-    if _existing="$(read_existing_feed_env_value INPUT_TYPE "$FEED_ENV")"; then
+    if _existing="$(read_existing_feed_env_value INPUT_TYPE "$FEED_ENV")" \
+        && [[ "$_existing" =~ ^[A-Za-z0-9_]+$ ]]; then
         INPUT_TYPE="$_existing"
     fi
     local -A _prev_tracked=()

--- a/configure.sh
+++ b/configure.sh
@@ -300,6 +300,13 @@ write_feed_env() {
 # readsb tuning, the local RESULTS output bundle, REDUCE_INTERVAL) live
 # in the daemon scripts; add overrides here only if you run a custom
 # airplanes.live backend or non-default decoder hardware.
+#
+# Format contract: one KEY=value or KEY="value" per line, plain scalar
+# values only — no shell expansion or escapes, no 'export' prefix, no
+# comment on a value's line, no line continuations. This file has
+# several consumers (shell, systemd, the apl-feed CLI); other shapes
+# parse differently between them and may be dropped on rewrite. Read
+# values with 'apl-feed config show' instead of parsing this file.
 
 LATITUDE="$RECEIVERLATITUDE"
 LONGITUDE="$RECEIVERLONGITUDE"

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -102,7 +102,7 @@ Commands:
   mlat          Configure MLAT (enable/disable/setup/user/geo/private)
   978           Configure 978 MHz UAT (enable/disable/setup/status)
   diagnostics   Enable or disable diagnostics push (enable/disable)
-  config        Remote config sync (sync/enable/disable)
+  config        Show config and remote sync (show/sync/enable/disable)
   import        Import configuration (legacy-config)
   apply         Apply config keys from a JSON payload on stdin
   schema        Print the feed.env config schema as JSON

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -956,12 +956,88 @@ usage_config() {
 Usage: apl-feed config <subcommand> [options]
 
 Subcommands:
+  show [--json]                     Print the effective feeder configuration
   sync [--dry-run] [--no-restart]   Run a one-shot remote config sync
   enable                            Enable remote config sync (opt-in)
   disable                           Disable remote config sync
 
 Run 'apl-feed config <subcommand> --help' for details.
 USAGE
+}
+
+usage_config_show() {
+    cat <<'USAGE'
+Usage: apl-feed config show [--json]
+
+Prints the effective feeder configuration: the readable feed.env keys
+with the values the daemons resolve, read from the same files the
+daemons read (a not-yet-migrated legacy image falls back to its boot
+config). Values are parsed with the same strict reader 'apl-feed apply'
+uses — this command is the supported way for other software to read the
+feeder configuration instead of parsing feed.env itself.
+
+Default output is one KEY=value line per present key. --json emits
+{"schema_version":1,"values":{...}} with one entry per readable key:
+a string when the key is present (empty string for an explicitly empty
+value), null when absent.
+USAGE
+}
+
+apl_feed_config_show() {
+    local as_json=0 opt_rc
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help) usage_config_show; exit 0 ;;
+            --json) as_json=1; shift; continue ;;
+        esac
+        if parse_common_option "$@"; then opt_rc=0; else opt_rc=$?; fi
+        case "$opt_rc" in
+            1) shift ;;
+            2) shift 2 ;;
+            0) die "unknown flag for config show: $1" ;;
+        esac
+    done
+
+    # The strict reader lives in feed-env-apply.sh, sourced defensively by
+    # the CLI entrypoint; a partial install only stubs apl_feed_apply.
+    declare -F _apl_feed_apply_read >/dev/null 2>&1 \
+        || die "feed-env-apply.sh missing; reinstall feed"
+
+    # Effective values: every file the daemons read, in feed_env_paths
+    # order with later files overriding earlier ones, parsed with the
+    # strict reader so this command and `apply` share one parser.
+    local -A _show_values=()
+    local _show_path _show_k
+    while IFS= read -r _show_path; do
+        [[ -n "$_show_path" && -f "$_show_path" ]] || continue
+        local -A _show_file=()
+        _apl_feed_apply_read "$_show_path" _show_file
+        for _show_k in "${!_show_file[@]}"; do
+            _show_values[$_show_k]="${_show_file[$_show_k]}"
+        done
+    done < <(feed_env_paths)
+
+    local key
+    if (( as_json )); then
+        require_jq
+        local jq_args=() filter='{schema_version: 1, values: {}}' i=0
+        for key in "${APL_FEED_READABLE_KEYS[@]}"; do
+            if [[ -n "${_show_values[$key]+set}" ]]; then
+                jq_args+=(--arg "k${i}" "$key" --arg "v${i}" "${_show_values[$key]}")
+                filter+=" | .values[\$k${i}] = \$v${i}"
+            else
+                jq_args+=(--arg "k${i}" "$key")
+                filter+=" | .values[\$k${i}] = null"
+            fi
+            i=$((i + 1))
+        done
+        jq -nc "${jq_args[@]}" "$filter"
+    else
+        for key in "${APL_FEED_READABLE_KEYS[@]}"; do
+            [[ -n "${_show_values[$key]+set}" ]] || continue
+            printf '%s=%s\n' "$key" "${_show_values[$key]}"
+        done
+    fi
 }
 
 usage_config_sync() {
@@ -1002,6 +1078,7 @@ dispatch_config() {
     fi
     shift || true
     case "$sub" in
+        show)    apl_feed_config_show    "$@" ;;
         enable)  apl_feed_config_enable  "$@" ;;
         disable) apl_feed_config_disable "$@" ;;
         sync)    apl_feed_config_sync    "$@" ;;

--- a/test/test_apl_feed_config.bats
+++ b/test/test_apl_feed_config.bats
@@ -261,3 +261,98 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"opt_in_required"* ]]
 }
+
+## `apl-feed config show` — effective-config read surface.
+
+@test "config show prints present readable keys as KEY=value lines" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+LONGITUDE="13.40"
+MLAT_ENABLED="true"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+EOF
+    run apl_feed_config_show
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"LATITUDE=52.52"* ]]
+    [[ "$output" == *"MLAT_ENABLED=true"* ]]
+    # Non-readable keys (backend overrides) are not part of the surface.
+    [[ "$output" != *"TARGET"* ]]
+    # Absent readable keys produce no line in the human format.
+    [[ "$output" != *"GAIN"* ]]
+}
+
+@test "config show --json emits null for absent and empty string for empty" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+UAT_INPUT=""
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.schema_version' <<< "$output")" = "1" ]
+    [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "52.52" ]
+    # Explicitly empty value round-trips as "" — distinct from absent.
+    [ "$(jq -r '.values.UAT_INPUT | type' <<< "$output")" = "string" ]
+    [ "$(jq -r '.values.UAT_INPUT' <<< "$output")" = "" ]
+    [ "$(jq -r '.values.GAIN' <<< "$output")" = "null" ]
+    # Every readable key appears, even when feed.env is sparse.
+    [ "$(jq -r '.values | length' <<< "$output")" = "${#APL_FEED_READABLE_KEYS[@]}" ]
+}
+
+@test "config show --json works against an absent feed.env (all null)" {
+    rm -f "$ROOT_DIR/etc/airplanes/feed.env"
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '[.values[] | select(. != null)] | length' <<< "$output")" = "0" ]
+}
+
+@test "config show falls back to the legacy boot config like the daemons do" {
+    rm -f "$ROOT_DIR/etc/airplanes/feed.env"
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
+    printf '#!/bin/true\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
+LATITUDE="50.00"
+MLAT_ENABLED="true"
+EOF
+    cat > "$ROOT_DIR/boot/airplanes-env" <<'EOF'
+LATITUDE="51.00"
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    # airplanes-env overrides airplanes-config.txt (feed_env_paths order).
+    [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "51.00" ]
+    [ "$(jq -r '.values.MLAT_ENABLED' <<< "$output")" = "true" ]
+}
+
+@test "config show uses the strict reader: contract-violating lines are absent" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+MLAT_ENABLED="true" # trailing comment makes this line malformed
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "52.52" ]
+    [ "$(jq -r '.values.MLAT_ENABLED' <<< "$output")" = "null" ]
+}
+
+@test "config show rejects unknown flags via die" {
+    run apl_feed_config_show --bogus
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unknown flag for config show"* ]]
+}
+
+@test "dispatch_config routes show" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+EOF
+    run dispatch_config show
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"LATITUDE=52.52"* ]]
+}

--- a/test/test_apl_feed_config.bats
+++ b/test/test_apl_feed_config.bats
@@ -356,3 +356,46 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"LATITUDE=52.52"* ]]
 }
+
+@test "config show --json escapes shell-hostile value content correctly" {
+    # Single-quoted on disk so the strict reader takes it verbatim; the
+    # JSON path must round-trip the raw bytes through jq --arg.
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+GAIN='a"b$c\d'
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.GAIN' <<< "$output")" = 'a"b$c\d' ]
+}
+
+@test "config show resolves feed.env through --root in either flag order" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+EOF
+    local saved_root="$ROOT"
+    ROOT="/nonexistent-root"
+    run apl_feed_config_show --root "$saved_root" --json
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "52.52" ]
+
+    ROOT="/nonexistent-root"
+    run apl_feed_config_show --json --root "$saved_root"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "52.52" ]
+    ROOT="$saved_root"
+}
+
+@test "config show legacy fallback works when airplanes-env is absent" {
+    rm -f "$ROOT_DIR/etc/airplanes/feed.env"
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
+    printf '#!/bin/true\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
+LATITUDE="50.00"
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "50.00" ]
+}

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -388,3 +388,317 @@ run_configure_env() {
     [[ "$output" =~ "Missing required non-interactive configure value: AIRPLANES_LATITUDE" ]]
     [ ! -e "$WHIPTAIL_LOG" ]
 }
+
+## Preservation on re-run (feed#131): write_feed_env must not clobber
+## operator data it doesn't own.
+
+seed_feed_env() {
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    cat > "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+rerun_coords_only() {
+    run_configure_env \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+}
+
+@test "configure.sh re-run carries unowned keys over verbatim" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.00000"
+LONGITUDE="8.00000"
+ALTITUDE="100"
+MLAT_USER="alice"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+MLATSERVER="feed.airplanes.test:31090"
+APL_FEED_WEBSITE_URL="https://airplanes.test"
+REPORT_STATUS="false"
+GAIN="auto"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    local env_file="$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$env_file"
+    grep -qx 'MLATSERVER="feed.airplanes.test:31090"' "$env_file"
+    grep -qx 'APL_FEED_WEBSITE_URL="https://airplanes.test"' "$env_file"
+    grep -qx 'REPORT_STATUS="false"' "$env_file"
+    grep -qx 'GAIN="auto"' "$env_file"
+    grep -q 'Carried over from the previous feed.env' "$env_file"
+    # New coordinates landed; owned keys are not duplicated by carry-over.
+    grep -q 'LATITUDE="52.52000"' "$env_file"
+    [ "$(grep -c '^LATITUDE=' "$env_file")" -eq 1 ]
+    [ "$(grep -c '^MLAT_USER=' "$env_file")" -eq 1 ]
+}
+
+@test "configure.sh re-run keeps duplicate unowned lines in order" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+GAIN="auto"
+GAIN="42"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    # Both occurrences survive, original order (source last-write-wins).
+    [ "$(grep -c '^GAIN=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 2 ]
+    grep -A1 '^GAIN="auto"' "$ROOT_DIR/etc/airplanes/feed.env" | grep -qx 'GAIN="42"'
+}
+
+@test "configure.sh re-run does not carry comments or non-KEY= lines" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+# operator note about the override below
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+export SHELLISH=1
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q 'operator note about the override' "$ROOT_DIR/etc/airplanes/feed.env"
+    ! grep -q 'SHELLISH' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run twice is idempotent (byte-identical file)" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+REPORT_STATUS="false"
+EOF
+    rerun_coords_only
+    [ "$status" -eq 0 ]
+    cp "$ROOT_DIR/etc/airplanes/feed.env" "$ROOT_DIR/first-pass"
+
+    rerun_coords_only
+    [ "$status" -eq 0 ]
+    cmp "$ROOT_DIR/first-pass" "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh fresh install writes no carried-over section" {
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'Carried over from the previous feed.env' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run preserves MLAT_ENABLED=false and MLAT_PRIVATE=true" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false"
+MLAT_PRIVATE=true
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh interactive re-run preserves MLAT toggles and name on blank input" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_USER="keepme"
+MLAT_ENABLED="false"
+MLAT_PRIVATE=true
+EOF
+    run_configure $'\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="keepme"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'MLAT_PRIVATE=true' "$ROOT_DIR/etc/airplanes/feed.env"
+    # The name prompt advertises keep-current semantics on a re-run.
+    grep -q 'keep the current name "keepme"' "$WHIPTAIL_LOG"
+}
+
+@test "configure.sh interactive re-run: explicit name input still wins" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_USER="keepme"
+EOF
+    run_configure $'newname\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="newname"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh explicit AIRPLANES_MLAT_ENABLED=true overrides preserved false" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false"
+EOF
+    run_configure_env \
+        AIRPLANES_MLAT_ENABLED="true" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh empty AIRPLANES_MLAT_ENABLED preserves the existing value" {
+    # Set-but-empty means "no explicit choice" — same as unset.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false"
+EOF
+    run_configure_env \
+        AIRPLANES_MLAT_ENABLED="" \
+        AIRPLANES_LATITUDE="52.52000" \
+        AIRPLANES_LONGITUDE="13.40500" \
+        AIRPLANES_ALTITUDE="35m"
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run: invalid existing toggle falls back to default" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="banana"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run: quoted toggle with trailing comment falls back to default" {
+    # `MLAT_ENABLED="false" # note` doesn't match any strict read form
+    # (the bare rule captures the opening quote), so preservation
+    # refuses it and the default applies. Pinned: this is the parser
+    # behavior that makes same-line comments a forbidden shape.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_ENABLED="false" # operator note
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="true"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run preserves a custom INPUT/INPUT_TYPE" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+INPUT="192.168.1.10:30005"
+INPUT_TYPE="dump1090"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -qx 'INPUT="192.168.1.10:30005"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'INPUT_TYPE="dump1090"' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ "$(grep -c '^INPUT=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 1 ]
+}
+
+@test "configure.sh re-run preserves MLAT_USER when no name is supplied" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+MLAT_USER="keepme"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_USER="keepme"' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh build mode with pre-existing overrides preserves them, no sidecar" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+EOF
+    run_configure_env \
+        AIRPLANES_BUILD_MODE=1 \
+        AIRPLANES_LATITUDE="0" \
+        AIRPLANES_LONGITUDE="0" \
+        AIRPLANES_ALTITUDE=""
+
+    [ "$status" -eq 0 ]
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Build mode is not an operator edit — no metadata stamps.
+    [ ! -e "$ROOT_DIR/etc/airplanes/feed.meta.json" ]
+}
+
+@test "configure.sh stamps sidecar metadata for changed tracked keys only" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.00000"
+LONGITUDE="8.00000"
+ALTITUDE="35"
+MLAT_USER="alice"
+MLAT_ENABLED="false"
+MLAT_PRIVATE=false
+EOF
+    cat > "$ROOT_DIR/etc/airplanes/feed.meta.json" <<'EOF'
+{"schema_version":1,"fields":{"MLAT_USER":{"edited_at":"2026-01-01T00:00:00.000000Z","edited_by":"website"}}}
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    local meta="$ROOT_DIR/etc/airplanes/feed.meta.json"
+    # Coordinates changed → fresh feeder stamps.
+    [ "$(jq -r '.fields.LATITUDE.edited_by' "$meta")" = "feeder" ]
+    [ "$(jq -r '.fields.LATITUDE.edited_at' "$meta")" != "2026-01-01T00:00:00.000000Z" ]
+    # MLAT_USER unchanged (preserved) → existing website tuple kept.
+    [ "$(jq -r '.fields.MLAT_USER.edited_by' "$meta")" = "website" ]
+    [ "$(jq -r '.fields.MLAT_USER.edited_at' "$meta")" = "2026-01-01T00:00:00.000000Z" ]
+    # MLAT_ENABLED preserved unchanged → no stamp materializes.
+    [ "$(jq -r '.fields.MLAT_ENABLED' "$meta")" = "null" ]
+}
+
+@test "configure.sh carried keys survive a subsequent apl_feed_apply write" {
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"
+EOF
+    rerun_coords_only
+    [ "$status" -eq 0 ]
+
+    # Run the canonical key-level writer over the rewritten file the way
+    # apl-feed diagnostics/config would; the carried TARGET value must
+    # survive (apply normalizes formatting but keeps the value).
+    mkdir -p "$ROOT_DIR/run/airplanes"
+    run bash -c '
+        source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/configure-validators.sh"
+        source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-keys.sh"
+        source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-apply.sh"
+        apl_feed_apply --no-restart --no-audit \
+            --feed-env "'"$ROOT_DIR"'/etc/airplanes/feed.env" \
+            --lock-file "'"$ROOT_DIR"'/run/airplanes/feed-env.lock" \
+            REPORT_STATUS=false
+    '
+    [ "$status" -eq 0 ]
+    grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
+    grep -qx 'REPORT_STATUS="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+}

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -702,3 +702,39 @@ EOF
     grep -qx 'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"' "$ROOT_DIR/etc/airplanes/feed.env"
     grep -qx 'REPORT_STATUS="false"' "$ROOT_DIR/etc/airplanes/feed.env"
 }
+
+@test "configure.sh re-run: unsafe existing INPUT falls back to detection" {
+    # A single-quoted command substitution is inert when sourced; the
+    # template re-emits preserved values double-quoted, which would make
+    # it live. The charset guard must refuse to preserve it.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+INPUT='$(reboot)'
+INPUT_TYPE="dump1090"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'reboot' "$ROOT_DIR/etc/airplanes/feed.env"
+    # Detection yields the defaults, so no INPUT block is emitted at all.
+    ! grep -q '^INPUT=' "$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+@test "configure.sh re-run preserves an indented owned key's value" {
+    # An indented MLAT_ENABLED is valid for `source`; the harvest treats
+    # it as owned (not carried), so the preservation reader must see it
+    # too — otherwise the value would be silently reset.
+    seed_feed_env <<'EOF'
+LATITUDE="50.0"
+LONGITUDE="8.0"
+ALTITUDE="100"
+  MLAT_ENABLED="false"
+EOF
+    rerun_coords_only
+
+    [ "$status" -eq 0 ]
+    grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
+    [ "$(grep -c 'MLAT_ENABLED=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 1 ]
+}

--- a/test/test_feed_env_value_contract.bats
+++ b/test/test_feed_env_value_contract.bats
@@ -127,11 +127,14 @@ KEY="x" \tx'
 }
 
 @test "divergence: dollar expansion is live under source, literal in the CLI readers" {
-    printf 'KEY="$HOME"\n' > "$FEED_ENV"
+    # Purpose-built sentinel instead of an inherited variable like HOME,
+    # so the expected expansion is fully under the test's control.
+    export APL_CONTRACT_SENTINEL="expanded-by-source"
+    printf 'KEY="$APL_CONTRACT_SENTINEL"\n' > "$FEED_ENV"
 
-    [ "$(read_via_source KEY)" = "$HOME" ]
-    [ "$(read_via_get KEY)" = '$HOME' ]
-    [ "$(read_via_strict KEY)" = '$HOME' ]
+    [ "$(read_via_source KEY)" = "expanded-by-source" ]
+    [ "$(read_via_get KEY)" = '$APL_CONTRACT_SENTINEL' ]
+    [ "$(read_via_strict KEY)" = '$APL_CONTRACT_SENTINEL' ]
 }
 
 @test "divergence: unterminated quote breaks source entirely" {

--- a/test/test_feed_env_value_contract.bats
+++ b/test/test_feed_env_value_contract.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Executable record of the feed.env value contract (one KEY=value or
+# KEY="value" per line, plain scalars, no expansion/escapes, no same-line
+# comments — see the header configure.sh writes).
+#
+# feed.env is consumed by several parsers: bash `source` (the daemons),
+# systemd EnvironmentFile= (image units), and the CLI's readers —
+# feed_env_get (sed, apl-feed/common.sh) and _apl_feed_apply_read (the
+# strict reader behind `apl-feed apply` and `apl-feed config show`).
+# Conforming values must parse identically in the ones executable here;
+# the divergence tests pin exactly how the forbidden shapes fall apart,
+# so a parser change that shifts the boundary is visible in CI.
+
+setup() {
+    LIB="$BATS_TEST_DIRNAME/../scripts/lib"
+    APL="$BATS_TEST_DIRNAME/../scripts/apl-feed"
+    ROOT_DIR="$(mktemp -d)"
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+
+    bats_exit_trap="$(trap -p EXIT)"
+    # shellcheck source=../scripts/lib/configure-validators.sh
+    source "$LIB/configure-validators.sh"
+    # shellcheck source=../scripts/lib/feed-env-keys.sh
+    source "$LIB/feed-env-keys.sh"
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$LIB/feed-env-apply.sh"
+    # shellcheck source=../scripts/apl-feed/common.sh
+    source "$APL/common.sh"
+    eval "$bats_exit_trap"
+    ROOT="$ROOT_DIR"
+
+    FEED_ENV="$ROOT_DIR/etc/airplanes/feed.env"
+}
+
+teardown() {
+    rm -rf "$ROOT_DIR"
+}
+
+# Reader 1: bash `source`, the daemons' parser. Runs in a throwaway bash
+# so vector content can't leak state into the test shell. Prints the
+# value, __UNSET__ when the key never materialized, or fails when the
+# file itself doesn't parse.
+read_via_source() {
+    local key="$1"
+    bash -c 'source "$1" 2>/dev/null || exit 99; printf "%s" "${'"$key"'-__UNSET__}"' _ "$FEED_ENV"
+}
+
+# Reader 2: feed_env_get, the sed-based CLI reader.
+read_via_get() {
+    feed_env_get "$1" || printf '__UNSET__'
+}
+
+# Reader 3: _apl_feed_apply_read, the strict reader behind apply and
+# config show.
+read_via_strict() {
+    local key="$1"
+    local -A m=()
+    _apl_feed_apply_read "$FEED_ENV" m
+    if [[ -n "${m[$key]+set}" ]]; then
+        printf '%s' "${m[$key]}"
+    else
+        printf '__UNSET__'
+    fi
+}
+
+@test "contract: conforming shapes parse identically across all three readers" {
+    # LINE<TAB>EXPECTED vector table. Conforming = double-quoted or bare
+    # plain scalar, exactly what configure.sh and apl-feed apply write.
+    local vectors=$'KEY=hello\thello
+KEY="hello world"\thello world
+KEY="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"\t--net-connector feed.airplanes.test,30004,beast_reduce_plus_out
+KEY="https://airplanes.test"\thttps://airplanes.test
+KEY=true\ttrue
+KEY="-12.5"\t-12.5
+KEY="x" \tx'
+
+    local line expected got_source got_get got_strict
+    while IFS=$'\t' read -r line expected; do
+        printf '%s\n' "$line" > "$FEED_ENV"
+        got_source="$(read_via_source KEY)"
+        got_get="$(read_via_get KEY)"
+        got_strict="$(read_via_strict KEY)"
+        [ "$got_source" = "$expected" ] || { echo "source: [$line] -> [$got_source] != [$expected]"; return 1; }
+        [ "$got_get" = "$expected" ]    || { echo "feed_env_get: [$line] -> [$got_get] != [$expected]"; return 1; }
+        [ "$got_strict" = "$expected" ] || { echo "strict: [$line] -> [$got_strict] != [$expected]"; return 1; }
+    done <<< "$vectors"
+}
+
+@test "contract: duplicate keys resolve last-write-wins in all three readers" {
+    printf 'KEY=first\nKEY="second"\n' > "$FEED_ENV"
+
+    [ "$(read_via_source KEY)" = "second" ]
+    [ "$(read_via_get KEY)" = "second" ]
+    [ "$(read_via_strict KEY)" = "second" ]
+}
+
+@test "divergence: explicitly empty value is invisible to feed_env_get" {
+    # source and the strict reader represent KEY="" as an empty string;
+    # feed_env_get conflates it with absent (rc 1). Callers that treat
+    # empty as meaningful (UAT_INPUT) must use the strict reader.
+    printf 'KEY=""\n' > "$FEED_ENV"
+
+    [ "$(read_via_source KEY)" = "" ]
+    [ "$(read_via_strict KEY)" = "" ]
+    run feed_env_get KEY
+    [ "$status" -eq 1 ]
+}
+
+@test "divergence: quoted value with trailing comment splits three ways" {
+    # Forbidden by the contract precisely because of this split: source
+    # reads the clean value, the strict reader drops the line, and
+    # feed_env_get's bare rule captures the opening quote.
+    printf 'KEY="false" # note\n' > "$FEED_ENV"
+
+    [ "$(read_via_source KEY)" = "false" ]
+    [ "$(read_via_strict KEY)" = "__UNSET__" ]
+    [ "$(read_via_get KEY)" = '"false"' ]
+}
+
+@test "divergence: bare value with trailing comment is dropped by the strict reader" {
+    printf 'KEY=auto # note\n' > "$FEED_ENV"
+
+    [ "$(read_via_source KEY)" = "auto" ]
+    [ "$(read_via_get KEY)" = "auto" ]
+    [ "$(read_via_strict KEY)" = "__UNSET__" ]
+}
+
+@test "divergence: dollar expansion is live under source, literal in the CLI readers" {
+    printf 'KEY="$HOME"\n' > "$FEED_ENV"
+
+    [ "$(read_via_source KEY)" = "$HOME" ]
+    [ "$(read_via_get KEY)" = '$HOME' ]
+    [ "$(read_via_strict KEY)" = '$HOME' ]
+}
+
+@test "divergence: unterminated quote breaks source entirely" {
+    printf 'KEY="abc\nOTHER="fine"\n' > "$FEED_ENV"
+
+    # The whole file stops being sourceable — the worst failure mode the
+    # contract exists to prevent.
+    run read_via_source KEY
+    [ "$status" -eq 99 ]
+    # The strict reader drops the malformed line and keeps going.
+    [ "$(read_via_strict KEY)" = "__UNSET__" ]
+}
+
+@test "informational: single-quoted values agree across the bash readers" {
+    # Works today in all bash-side parsers, but stays outside the
+    # documented contract: supported writers only emit double-quoted or
+    # bare values.
+    printf "KEY='a b'\n" > "$FEED_ENV"
+
+    [ "$(read_via_source KEY)" = "a b" ]
+    [ "$(read_via_get KEY)" = "a b" ]
+    [ "$(read_via_strict KEY)" = "a b" ]
+}
+
+@test "writer: universal-reject blocks every non-conforming byte" {
+    # The canonical writer can only ever produce conforming values —
+    # that, not reader leniency, is what keeps the parsers agreeing.
+    local bad_values=('a"b' 'a\b' 'a$b' 'a`b' 'a;b' 'a&b' 'a|b' 'a<b' 'a>b' 'a#b' "a'b" $'a\nb' $'a\rb')
+    local v
+    for v in "${bad_values[@]}"; do
+        if _apl_feed_apply_universal_reject "$v"; then
+            echo "universal-reject accepted forbidden value: [$v]"
+            return 1
+        fi
+    done
+    _apl_feed_apply_universal_reject 'plain-scalar value 1.5, ok'
+}


### PR DESCRIPTION
`feed.env` is parsed by several independent readers — the daemons `source` it, systemd units read it via `EnvironmentFile=`, the CLI has its own parsers, and the on-device webconfig currently ships a Go parser as well. Values written by the supported tooling are simple quoted scalars so the readers agree today, but nothing pinned that, and a hand-edited value using shell-only syntax parses differently in each consumer and surfaces as a hard-to-trace config bug.

This adds `apl-feed config show [--json]`: the effective feeder configuration read from the same files the daemons use, parsed with the same strict reader as `apl-feed apply`. It completes the CLI's read/write surface (`apply` and `schema` already exist) so other software can stop parsing `feed.env` itself — the webconfig will migrate to it next. The header that setup writes into `feed.env` now documents the value contract, and a new vector test pins how every parser handles both conforming and forbidden shapes, so a future parser change that shifts the boundary fails CI instead of shipping silently.

Addresses #132.
