### PR TITLE
Expose APL_FEED_WEBSITE_URL through schema and config show

### DIFF
--- a/scripts/lib/feed-env-keys.sh
+++ b/scripts/lib/feed-env-keys.sh
@@ -49,6 +49,11 @@ declare -ga APL_FEED_READABLE_KEYS=(
     DUMP978_GAIN
     REPORT_STATUS
     REMOTE_CONFIG_ENABLED
+    # Read-only backend pointer (like INPUT/INPUT_TYPE it has no writer
+    # here): consumers such as the webconfig claim page need the website
+    # host a custom-backend feeder registered against, and `config show`
+    # is the supported way to read it without parsing feed.env.
+    APL_FEED_WEBSITE_URL
 )
 
 declare -gA APL_FEED_KEY_TYPE=(

--- a/test/test_apl_feed_apply.bats
+++ b/test/test_apl_feed_apply.bats
@@ -59,7 +59,9 @@ run_apply() {
     [ "$(jq -r '.writable_keys | type' <<<"$OUT")" = "array" ]
     [ "$(jq -r '.readable_keys | type' <<<"$OUT")" = "array" ]
     [ "$(jq -r '.writable_keys | contains(["LATITUDE","LONGITUDE","MLAT_ENABLED","READSB_SDR_SERIAL"])' <<<"$OUT")" = "true" ]
-    [ "$(jq -r '.readable_keys | contains(["INPUT","INPUT_TYPE","READSB_SDR_SERIAL"])' <<<"$OUT")" = "true" ]
+    [ "$(jq -r '.readable_keys | contains(["INPUT","INPUT_TYPE","READSB_SDR_SERIAL","APL_FEED_WEBSITE_URL"])' <<<"$OUT")" = "true" ]
+    # Read-only backend pointer: readable, never writable.
+    [ "$(jq -r '.writable_keys | contains(["APL_FEED_WEBSITE_URL"])' <<<"$OUT")" = "false" ]
 }
 
 @test "apply with empty payload returns no_change" {

--- a/test/test_apl_feed_config.bats
+++ b/test/test_apl_feed_config.bats
@@ -399,3 +399,24 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(jq -r '.values.LATITUDE' <<< "$output")" = "50.00" ]
 }
+
+@test "config show --json surfaces APL_FEED_WEBSITE_URL when overridden" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+APL_FEED_WEBSITE_URL="https://airplanes.test"
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.APL_FEED_WEBSITE_URL' <<< "$output")" = "https://airplanes.test" ]
+}
+
+@test "config show --json reports APL_FEED_WEBSITE_URL null on a default feeder" {
+    cat > "$ROOT_DIR/etc/airplanes/feed.env" <<'EOF'
+LATITUDE="52.52"
+EOF
+    run apl_feed_config_show --json
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.values.APL_FEED_WEBSITE_URL' <<< "$output")" = "null" ]
+}


### PR DESCRIPTION
Software that needs the website host a feeder is pointed at (for example the on-device webconfig building its claim-page link) currently has to parse feed.env for APL_FEED_WEBSITE_URL. The key is now part of the readable registry, so 'apl-feed schema' lists it and 'apl-feed config show' returns it — read-only, it remains non-writable.

Refs #132.
