### PR TITLE
Unify the CLI on one feed.env parser

### DIFF
--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -571,6 +571,20 @@ main() {
     # timer cadence until the server acks.
     local report_status_raw
     report_status_raw="$(feed_env_get REPORT_STATUS 2>/dev/null || true)"
+    # A REPORT_STATUS line the strict reader refuses (same-line comment,
+    # broken quoting) must not fail open to the enabled default: a key
+    # that is present but unreadable gets the same bad-config exit as a
+    # parseable-but-invalid value. Privacy toggles fail closed.
+    if [[ -z "$report_status_raw" ]]; then
+        local _rs_path
+        while IFS= read -r _rs_path; do
+            [[ -f "$_rs_path" ]] || continue
+            if grep -q '^[[:space:]]*REPORT_STATUS=.' "$_rs_path"; then
+                log error "status=bad_config key=REPORT_STATUS value=unreadable"
+                exit "$EXIT_BAD_CONFIG"
+            fi
+        done < <(feed_env_paths)
+    fi
     local toggle
     toggle="$(parse_report_status "$report_status_raw")"
     case "$toggle" in

--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -37,23 +37,30 @@ _INSTALL_DIR="$(_resolve_install_dir)"
 # Source helpers from apl-feed/. In production these live at
 # /usr/local/share/airplanes/apl-feed/. In the source tree they're at
 # feed/scripts/apl-feed/. Both resolutions land at the same directory
-# relative to this script.
+# relative to this script. feed-env-apply.sh sits next to them in the
+# sibling lib/ directory (production $_INSTALL_DIR/lib/, source tree
+# scripts/lib/) and is required: common.sh's feed_env_get delegates to
+# its strict reader.
 for _candidate in \
     "$_INSTALL_DIR/apl-feed/common.sh" \
     "$_INSTALL_DIR/../scripts/apl-feed/common.sh"; do
     if [[ -r "$_candidate" ]]; then
         _COMMON_SH="$_candidate"
         _HTTP_SH="$(dirname "$_candidate")/http.sh"
+        _FEED_ENV_APPLY_SH="$(dirname "$_candidate")/../lib/feed-env-apply.sh"
         break
     fi
 done
 
-if [[ -z "${_COMMON_SH:-}" ]] || [[ ! -r "${_HTTP_SH:-}" ]]; then
+if [[ -z "${_COMMON_SH:-}" ]] || [[ ! -r "${_HTTP_SH:-}" ]] \
+    || [[ ! -r "${_FEED_ENV_APPLY_SH:-}" ]]; then
     printf '%s level=error status=fatal reason=helpers_missing install_dir=%s\n' \
         "$SCRIPT_NAME" "$_INSTALL_DIR" >&2
     exit "$EXIT_BAD_CONFIG"
 fi
 
+# shellcheck source=lib/feed-env-apply.sh
+source "$_FEED_ENV_APPLY_SH"
 # shellcheck source=apl-feed/common.sh
 source "$_COMMON_SH"
 # shellcheck source=apl-feed/http.sh

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -382,21 +382,32 @@ read_version_file() {
     printf '%s' "$version"
 }
 
+# Single-key read over the effective config files (feed_env_paths order,
+# later files override). Delegates to the strict reader from
+# feed-env-apply.sh — the same parser behind `apply` and `config show` —
+# so the CLI has one feed.env parser. Contract: rc 0 + value when the
+# key is present and non-empty; rc 1 when absent, explicitly empty, or
+# on a contract-violating line the strict reader drops (callers treat
+# absent and empty identically, e.g. UAT_INPUT's disabled state).
 feed_env_get() {
     local key="$1"
-    local path output
-    output="$(
-        while IFS= read -r path; do
-            [[ -f "$path" ]] || continue
-            sed -n \
-                -e "s/^${key}=\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
-                -e "s/^${key}='\\(.*\\)'[[:space:]]*$/\\1/p" \
-                -e "s/^${key}=\\([^#[:space:]]*\\).*$/\\1/p" \
-                "$path"
-        done < <(feed_env_paths)
-    )"
-    [[ -n "$output" ]] || return 1
-    printf '%s\n' "$output" | tail -n 1
+    local path value="" found=0
+    if ! declare -F _apl_feed_apply_read >/dev/null 2>&1; then
+        echo "feed_env_get: feed-env-apply.sh not in scope; reinstall feed" >&2
+        return 1
+    fi
+    while IFS= read -r path; do
+        [[ -f "$path" ]] || continue
+        local -A _feg_file=()
+        _apl_feed_apply_read "$path" _feg_file
+        if [[ -n "${_feg_file[$key]+set}" ]]; then
+            value="${_feg_file[$key]}"
+            found=1
+        fi
+    done < <(feed_env_paths)
+    (( found )) || return 1
+    [[ -n "$value" ]] || return 1
+    printf '%s\n' "$value"
 }
 
 apl_auth_token() {

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -1038,3 +1038,15 @@ SH
     run jq '.services[] | select(.name=="airplanes-mlat") | .state // empty' "$BODY_LOG"
     [ -z "$output" ]
 }
+
+@test "REPORT_STATUS=false with same-line comment exits 64 (fail closed, not fail open)" {
+    # The strict reader refuses the line, so the value reads as absent —
+    # but an unreadable present key must not fall through to the enabled
+    # default. Same bad-config posture as a garbage value.
+    printf 'REPORT_STATUS=false # opted out\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run_script
+    [ "$status" -eq 64 ]
+    [[ "$output" == *"status=bad_config"* ]]
+    [[ "$output" == *"REPORT_STATUS"* ]]
+    [ ! -f "$COMMAND_LOG" ]
+}

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -29,6 +29,11 @@ setup() {
     # sourcing — without this, `skip` from inside a test silently
     # marks the test "not run".
     bats_exit_trap="$(trap -p EXIT)"
+    # feed_env_get delegates to the strict reader; both production
+    # consumers (apl-feed.sh, airplanes-diagnostics.sh) source the apply
+    # lib before common.sh, so the harness mirrors that.
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
     # shellcheck source=../scripts/apl-feed/common.sh
     source "$LIB_DIR/common.sh"
     eval "$bats_exit_trap"
@@ -154,8 +159,23 @@ run_strict() {
     [ "$output" = '127.0.0.1:30005' ]
 }
 
-@test "feed_env_get: strips trailing comment from unquoted value" {
+@test "feed_env_get: drops a bare value with a same-line comment (contract violation)" {
+    # The strict reader refuses `KEY=value # note` rather than guessing
+    # where the value ends — same-line comments are outside the feed.env
+    # value contract and parse differently across consumers.
     printf 'GAIN=42 # autogain\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get GAIN
+    [ "$status" -eq 1 ]
+}
+
+@test "feed_env_get: explicitly empty value reports rc 1 like absent" {
+    printf 'UAT_INPUT=""\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    run feed_env_get UAT_INPUT
+    [ "$status" -eq 1 ]
+}
+
+@test "feed_env_get: reads an indented key (source-visible lines stay visible)" {
+    printf '  GAIN="42"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
     run feed_env_get GAIN
     [ "$status" -eq 0 ]
     [ "$output" = '42' ]

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -21,6 +21,10 @@ setup() {
     export APL_FEED_SECRET_OWNER APL_FEED_SECRET_GROUP
 
     bats_exit_trap="$(trap -p EXIT)"
+    # feed_env_get delegates to the strict reader from feed-env-apply.sh;
+    # the production sourcers load it before common.sh.
+    # shellcheck source=../scripts/lib/feed-env-apply.sh
+    source "$BATS_TEST_DIRNAME/../scripts/lib/feed-env-apply.sh"
     # shellcheck source=../scripts/apl-feed/common.sh
     source "$LIB_DIR/common.sh"
     # shellcheck source=../scripts/apl-feed/http.sh

--- a/test/test_feed_env_value_contract.bats
+++ b/test/test_feed_env_value_contract.bats
@@ -5,9 +5,9 @@
 # comments — see the header configure.sh writes).
 #
 # feed.env is consumed by several parsers: bash `source` (the daemons),
-# systemd EnvironmentFile= (image units), and the CLI's readers —
-# feed_env_get (sed, apl-feed/common.sh) and _apl_feed_apply_read (the
-# strict reader behind `apl-feed apply` and `apl-feed config show`).
+# systemd EnvironmentFile= (image units), and the CLI's single reader —
+# _apl_feed_apply_read (the strict reader behind `apl-feed apply`,
+# `apl-feed config show`, and feed_env_get, which delegates to it).
 # Conforming values must parse identically in the ones executable here;
 # the divergence tests pin exactly how the forbidden shapes fall apart,
 # so a parser change that shifts the boundary is visible in CI.
@@ -107,22 +107,23 @@ KEY="x" \tx'
     [ "$status" -eq 1 ]
 }
 
-@test "divergence: quoted value with trailing comment splits three ways" {
-    # Forbidden by the contract precisely because of this split: source
-    # reads the clean value, the strict reader drops the line, and
-    # feed_env_get's bare rule captures the opening quote.
+@test "divergence: quoted value with trailing comment is dropped by both CLI readers" {
+    # Forbidden by the contract: source reads the clean value, but both
+    # CLI readers (feed_env_get delegates to the strict reader) refuse
+    # the line rather than guessing — historically feed_env_get's bare
+    # rule captured the opening quote here.
     printf 'KEY="false" # note\n' > "$FEED_ENV"
 
     [ "$(read_via_source KEY)" = "false" ]
     [ "$(read_via_strict KEY)" = "__UNSET__" ]
-    [ "$(read_via_get KEY)" = '"false"' ]
+    [ "$(read_via_get KEY)" = "__UNSET__" ]
 }
 
-@test "divergence: bare value with trailing comment is dropped by the strict reader" {
+@test "divergence: bare value with trailing comment is dropped by both CLI readers" {
     printf 'KEY=auto # note\n' > "$FEED_ENV"
 
     [ "$(read_via_source KEY)" = "auto" ]
-    [ "$(read_via_get KEY)" = "auto" ]
+    [ "$(read_via_get KEY)" = "__UNSET__" ]
     [ "$(read_via_strict KEY)" = "__UNSET__" ]
 }
 


### PR DESCRIPTION
The apl-feed CLI carried two feed.env parsers: the strict reader behind `apply` and `config show`, and `feed_env_get`'s older sed patterns used by the status, claim, MLAT, UAT, and diagnostics paths. The sed patterns could return mangled values for malformed lines — a quoted value with a trailing comment came back with the quote character included.

`feed_env_get` now delegates to the strict reader, so the CLI has exactly one feed.env parser. Its contract is unchanged for well-formed files (rc 1 for absent or empty keys, last occurrence wins, legacy boot-config fallback intact — the deployed legacy templates use plain `KEY=value` lines and parse identically). Lines outside the documented value contract, like same-line comments, are now refused instead of half-parsed; the parser-divergence test pins the new boundary.

Refs #132.
