### PR TITLE
Keep the documented feed.env header across apl-feed saves

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -294,65 +294,40 @@ write_feed_env() {
     # must never observe a truncated half-written file.
     local _tmp
     _tmp="$(mktemp "${FEED_ENV}.XXXXXX")"
-    cat > "$_tmp" <<EOF
-# /etc/airplanes/feed.env — operator-supplied configuration for the
-# airplanes.live feeder daemons. Product-side defaults (brand endpoints,
-# readsb tuning, the local RESULTS output bundle, REDUCE_INTERVAL) live
-# in the daemon scripts; add overrides here only if you run a custom
-# airplanes.live backend or non-default decoder hardware.
-#
-# Format contract: one KEY=value or KEY="value" per line, plain scalar
-# values only — no shell expansion or escapes, no 'export' prefix, no
-# comment on a value's line, no line continuations. This file has
-# several consumers (shell, systemd, the apl-feed CLI); other shapes
-# parse differently between them and may be dropped on rewrite. Read
-# values with 'apl-feed config show' instead of parsing this file.
-
-LATITUDE="$RECEIVERLATITUDE"
-LONGITUDE="$RECEIVERLONGITUDE"
-ALTITUDE="$RECEIVERALTITUDE"
-# Explicit "user has provided real coordinates" flag. The daemon refuses
-# to start MLAT until this is true; the legacy "LATITUDE=0 means unset"
-# sentinel is retired. Image freeze writes false; configure.sh writes
-# true when both coords are non-zero (Atlantic 0,0 placeholders stay
-# false). The webconfig UI writes this explicitly when the user saves.
-GEO_CONFIGURED=$GEO_CONFIGURED
-
-# Display name shown on the MLAT map. Used as mlat-client's --user.
-MLAT_USER="$MLAT_USER"
-# Explicit on/off toggle. When false, airplanes-mlat exits early.
-MLAT_ENABLED="$MLAT_ENABLED"
-# Hide the feed name on the public MLAT map. true|false. Position is
-# never shown accurately no matter the setting. Toggle with:
-#   sudo apl-feed mlat private enable
-#   sudo apl-feed mlat private disable
-MLAT_PRIVATE=$MLAT_PRIVATE
-
-# Diagnostics push: every 10 minutes the feeder reports anonymized CPU,
-# temperature, disk, memory, uptime, service health, and version info to
-# airplanes.live. Visible only on your own logged-in dashboard. The
-# schema excludes hostname, MAC, LAN IP, SSID, and Pi serial number.
-#
-# Default: enabled. Toggle via the CLI (the canonical writer, which also
-# runs through validation + the apply lock):
-#   sudo apl-feed diagnostics enable
-#   sudo apl-feed diagnostics disable
-# Don't hand-edit REPORT_STATUS below — direct edits bypass validation
-# and the lock that webconfig holds during concurrent writes.
-#REPORT_STATUS=true
-EOF
+    {
+        # Shared documented header (operator preamble, format contract,
+        # diagnostics/REPORT_STATUS warning) and per-key comments come from
+        # feed-env-keys.sh — the same source the apl-feed apply writer uses,
+        # so a later webconfig/CLI save reproduces this documented file
+        # rather than stripping it to bare keys.
+        _apl_feed_render_header
+        printf '\n'
+        printf 'LATITUDE="%s"\n' "$RECEIVERLATITUDE"
+        printf 'LONGITUDE="%s"\n' "$RECEIVERLONGITUDE"
+        printf 'ALTITUDE="%s"\n' "$RECEIVERALTITUDE"
+        printf '\n'
+        _apl_feed_render_key_doc GEO_CONFIGURED
+        printf 'GEO_CONFIGURED=%s\n' "$GEO_CONFIGURED"
+        printf '\n'
+        _apl_feed_render_key_doc MLAT_USER
+        printf 'MLAT_USER="%s"\n' "$MLAT_USER"
+        _apl_feed_render_key_doc MLAT_ENABLED
+        printf 'MLAT_ENABLED="%s"\n' "$MLAT_ENABLED"
+        _apl_feed_render_key_doc MLAT_PRIVATE
+        printf 'MLAT_PRIVATE=%s\n' "$MLAT_PRIVATE"
+    } > "$_tmp"
 
     # Write INPUT + INPUT_TYPE only when they differ from the daemon
     # defaults (127.0.0.1:30005 / dump1090). detect_receiver_input sets
     # both together (Radarcape uses 127.0.0.1:10003 / radarcape_gps),
     # so emit them as a pair to keep the override consistent.
     if [[ "$INPUT" != "127.0.0.1:30005" ]] || [[ "$INPUT_TYPE" != "dump1090" ]]; then
-        cat >> "$_tmp" <<EOF
-
-# Non-default receiver decoder. Defaults are 127.0.0.1:30005 / dump1090.
-INPUT="$INPUT"
-INPUT_TYPE="$INPUT_TYPE"
-EOF
+        {
+            printf '\n'
+            _apl_feed_render_key_doc INPUT
+            printf 'INPUT="%s"\n' "$INPUT"
+            printf 'INPUT_TYPE="%s"\n' "$INPUT_TYPE"
+        } >> "$_tmp"
     fi
 
     if (( ${#CARRIED_FEED_ENV_LINES[@]} > 0 )); then

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -353,17 +353,38 @@ _apl_feed_apply_write() {
     local feed_env="$1"
     local -n merged_ref="$2"
 
+    # The doc renderers live in feed-env-keys.sh (same lib that defines
+    # APL_FEED_WRITABLE_KEYS, which this function already needs). Fail loudly
+    # on a skewed install rather than silently writing a header-less file:
+    # the redirected `{ … } > tmp` group below is on the left of `||`, so
+    # errexit is suppressed inside it and a missing renderer would otherwise
+    # print "command not found" and still return success.
+    if ! declare -F _apl_feed_render_header >/dev/null 2>&1 \
+        || ! declare -F _apl_feed_render_key_doc >/dev/null 2>&1; then
+        echo "_apl_feed_apply_write: feed-env-keys.sh not in scope; reinstall feed" >&2
+        return 1
+    fi
+
     local dir tmp
     dir="$(dirname "$feed_env")"
     mkdir -p "$dir" || return 1
     tmp="$(mktemp "${feed_env}.XXXXXX")" || return 1
 
     {
-        local key escaped
-        # Emit in source order first.
+        local key escaped doc
+        # Documented header first (shared with configure.sh via
+        # feed-env-keys.sh) so a webconfig/CLI save reproduces the
+        # self-documented file instead of stripping it to bare keys.
+        _apl_feed_render_header
+        printf '\n'
+        # Emit in source order first. Each key is preceded by its shared
+        # doc comment (blank-line separated); unowned keys render no doc
+        # (`case` returns 0 — safe under set -u) and print bare.
         local -A emitted=()
         for key in "${APL_APPLY_KEY_ORDER[@]}"; do
             if [[ -n "${merged_ref[$key]+set}" ]]; then
+                doc="$(_apl_feed_render_key_doc "$key")"
+                [[ -n "$doc" ]] && printf '\n%s\n' "$doc"
                 escaped="${merged_ref[$key]//\\/\\\\}"
                 escaped="${escaped//\$/\\\$}"
                 escaped="${escaped//\`/\\\`}"
@@ -376,6 +397,8 @@ _apl_feed_apply_write() {
         for key in "${APL_FEED_WRITABLE_KEYS[@]}"; do
             [[ -n "${emitted[$key]+x}" ]] && continue
             [[ -z "${merged_ref[$key]+set}" ]] && continue
+            doc="$(_apl_feed_render_key_doc "$key")"
+            [[ -n "$doc" ]] && printf '\n%s\n' "$doc"
             escaped="${merged_ref[$key]//\\/\\\\}"
             escaped="${escaped//\$/\\\$}"
             escaped="${escaped//\`/\\\`}"

--- a/scripts/lib/feed-env-keys.sh
+++ b/scripts/lib/feed-env-keys.sh
@@ -13,7 +13,11 @@
 #   APL_FEED_KEY_TYPE         associative; type tag per key, drives validators
 #   APL_FEED_KEY_RESTART      associative; space-separated service list per key
 #
-# Pure-data file. Safe to re-source.
+# Also provides the feed.env documentation renderers (_apl_feed_render_header,
+# _apl_feed_render_key_doc) so both writers — configure.sh and
+# feed-env-apply.sh's _apl_feed_apply_write — emit the same header and per-key
+# comments from one source. Safe to re-source; no side effects beyond the
+# global definitions above.
 
 declare -ga APL_FEED_WRITABLE_KEYS=(
     LATITUDE
@@ -109,4 +113,96 @@ apl_feed_is_readable_key() {
         [[ "$k" == "$needle" ]] && return 0
     done
     return 1
+}
+
+# Top comment block for feed.env. Emitted first by every writer so the
+# operator-config preamble, the format contract, and the diagnostics /
+# REPORT_STATUS hand-edit warning survive every rewrite (a webconfig save
+# goes through _apl_feed_apply_write, which would otherwise strip them).
+# Single-quoted heredoc: the text contains no expansions and must never be
+# subject to any. All lines are full-line `#` comments — safe for shell
+# `source`, systemd EnvironmentFile, and the strict apl-feed reader.
+_apl_feed_render_header() {
+    cat <<'EOF'
+# /etc/airplanes/feed.env — operator-supplied configuration for the
+# airplanes.live feeder daemons. Product-side defaults (brand endpoints,
+# readsb tuning, the local RESULTS output bundle, REDUCE_INTERVAL) live
+# in the daemon scripts; add overrides here only if you run a custom
+# airplanes.live backend or non-default decoder hardware.
+#
+# Format contract: one KEY=value or KEY="value" per line, plain scalar
+# values only — no shell expansion or escapes, no 'export' prefix, no
+# comment on a value's line, no line continuations. This file has
+# several consumers (shell, systemd, the apl-feed CLI); other shapes
+# parse differently between them and may be dropped on rewrite. Read
+# values with 'apl-feed config show' instead of parsing this file.
+#
+# Diagnostics push: every 10 minutes the feeder reports anonymized CPU,
+# temperature, disk, memory, uptime, service health, and version info to
+# airplanes.live. Visible only on your own logged-in dashboard. The
+# schema excludes hostname, MAC, LAN IP, SSID, and Pi serial number.
+#
+# Default: enabled. Toggle via the CLI (the canonical writer, which also
+# runs through validation + the apply lock):
+#   sudo apl-feed diagnostics enable
+#   sudo apl-feed diagnostics disable
+# Don't hand-edit REPORT_STATUS below — direct edits bypass validation
+# and the lock that webconfig holds during concurrent writes.
+#REPORT_STATUS=true
+EOF
+}
+
+# Per-key documentation comment, printed immediately above the key's value
+# line. Documented set mirrors what configure.sh historically emitted;
+# every other key (LATITUDE/LONGITUDE/ALTITUDE covered by the header,
+# REPORT_STATUS explained in the header, and the SDR/UAT tuning keys)
+# returns nothing. `case` (not an associative-array lookup) keeps this
+# safe under `set -u` when called for unowned keys like APL_FEED_WEBSITE_URL.
+# Single-quoted heredocs: comment text must never expand. INPUT_TYPE has no
+# entry — INPUT carries the shared decoder note for the pair so the apply
+# writer (which emits the keys consecutively) prints it once.
+_apl_feed_render_key_doc() {
+    case "$1" in
+        GEO_CONFIGURED)
+            cat <<'EOF'
+# Explicit "user has provided real coordinates" flag. The daemon refuses
+# to start MLAT until this is true; the legacy "LATITUDE=0 means unset"
+# sentinel is retired. Image freeze writes false; configure.sh writes
+# true when both coords are non-zero (Atlantic 0,0 placeholders stay
+# false). The webconfig UI writes this explicitly when the user saves.
+EOF
+            ;;
+        MLAT_USER)
+            cat <<'EOF'
+# Display name shown on the MLAT map. Used as mlat-client's --user.
+EOF
+            ;;
+        MLAT_ENABLED)
+            cat <<'EOF'
+# Explicit on/off toggle. When false, airplanes-mlat exits early.
+EOF
+            ;;
+        MLAT_PRIVATE)
+            cat <<'EOF'
+# Hide the feed name on the public MLAT map. true|false. Position is
+# never shown accurately no matter the setting. Toggle with:
+#   sudo apl-feed mlat private enable
+#   sudo apl-feed mlat private disable
+EOF
+            ;;
+        INPUT)
+            cat <<'EOF'
+# Non-default receiver decoder. Defaults are 127.0.0.1:30005 / dump1090.
+EOF
+            ;;
+        REPORT_STATUS)
+            cat <<'EOF'
+# Diagnostics push toggle; see the header. Set via apl-feed diagnostics
+# enable/disable, never by hand.
+EOF
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }

--- a/test/test_apl_feed_apply.bats
+++ b/test/test_apl_feed_apply.bats
@@ -80,6 +80,17 @@ run_apply() {
     grep -q '^MLAT_PRIVATE="true"$' "$FEED_ENV"
 }
 
+@test "apply through the CLI binary writes the documented header" {
+    # End-to-end via apl-feed.sh (runs under set -euo pipefail), proving the
+    # shared renderer is in scope on the real dispatch path — a webconfig
+    # save reproduces the self-documented file instead of stripping it.
+    run_apply '{"updates":{"MLAT_PRIVATE":"true"}}' --no-restart
+    [ "$APPLY_RC" -eq 0 ]
+    grep -q 'operator-supplied configuration for the' "$FEED_ENV"
+    grep -q "Don't hand-edit REPORT_STATUS below" "$FEED_ENV"
+    grep -q 'Hide the feed name on the public MLAT map' "$FEED_ENV"
+}
+
 @test "apply with invalid LATITUDE returns rejected + per-key errors" {
     run_apply '{"updates":{"LATITUDE":"200"}}' --no-restart
     [ "$APPLY_RC" -eq 2 ]

--- a/test/test_configure_script.bats
+++ b/test/test_configure_script.bats
@@ -738,3 +738,18 @@ EOF
     grep -q 'MLAT_ENABLED="false"' "$ROOT_DIR/etc/airplanes/feed.env"
     [ "$(grep -c 'MLAT_ENABLED=' "$ROOT_DIR/etc/airplanes/feed.env")" -eq 1 ]
 }
+
+@test "configure.sh emits the shared documented header" {
+    # The header + per-key comments come from feed-env-keys.sh, the same
+    # source the apl-feed apply writer uses, so setup and webconfig saves
+    # produce the same self-documented file.
+    run_configure $'ci-feeder\n52.52000\n13.40500\n35m'
+
+    [ "$status" -eq 0 ]
+    local fe="$ROOT_DIR/etc/airplanes/feed.env"
+    grep -q 'operator-supplied configuration for the' "$fe"
+    grep -q "Format contract: one KEY=value" "$fe"
+    grep -q "Don't hand-edit REPORT_STATUS below" "$fe"
+    grep -q '^#REPORT_STATUS=true$' "$fe"
+    grep -q 'Hide the feed name on the public MLAT map' "$fe"
+}

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -477,7 +477,11 @@ EOF
     [ -n "${APL_APPLY_ERRORS[BOGUS]}" ]
 }
 
-@test "comments and blank lines in feed.env preserved across rewrite" {
+@test "arbitrary comments dropped on rewrite; standard documented header emitted" {
+    # The writer is map-based: it re-emits keys plus the shared documented
+    # header/per-key comments, and does NOT preserve operator-added comment
+    # lines. (This test was historically mis-named "comments preserved" but
+    # only ever asserted the key lines survived.)
     cat > "$FEED_ENV" <<EOF
 # A user comment
 LATITUDE="10"
@@ -488,6 +492,10 @@ EOF
     [ "$APL_APPLY_RC" -eq 0 ]
     grep -q '^LATITUDE="11"$' "$FEED_ENV"
     grep -q '^LONGITUDE="20"$' "$FEED_ENV"
+    # Arbitrary operator comment is gone.
+    ! grep -q 'A user comment' "$FEED_ENV"
+    # Standard header is present.
+    grep -q 'operator-supplied configuration for the' "$FEED_ENV"
 }
 
 @test "APL_FEED_WEBSITE_URL is preserved through config-sync rewrite" {
@@ -909,4 +917,155 @@ EOF
     [ "$(jq -r '.fields.MLAT_USER.edited_by' "$ROOT_DIR/etc/airplanes/feed.meta.json")" = "website" ]
     APL_APPLY_INCOMING_META_EDITED_AT=()
     APL_APPLY_INCOMING_META_EDITED_BY=()
+}
+
+## Shared documented header / per-key comments (feed-env-keys.sh renderers)
+
+@test "apply save emits the documented header and per-key doc comments" {
+    seed_feed_env
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "applied" ]
+    # Header block (incl. the REPORT_STATUS hand-edit warning that a save
+    # used to strip — this is the regression observed live on feeder3).
+    grep -q 'operator-supplied configuration for the' "$FEED_ENV"
+    grep -q "Format contract: one KEY=value" "$FEED_ENV"
+    grep -q "Don't hand-edit REPORT_STATUS below" "$FEED_ENV"
+    grep -q '^#REPORT_STATUS=true$' "$FEED_ENV"
+    # Per-key doc comments for the documented keys.
+    grep -q 'Display name shown on the MLAT map' "$FEED_ENV"
+    grep -q 'Hide the feed name on the public MLAT map' "$FEED_ENV"
+    grep -q 'user has provided real coordinates' "$FEED_ENV"
+    # Value still written.
+    grep -q '^MLAT_PRIVATE="true"$' "$FEED_ENV"
+}
+
+@test "apply header is byte-identical to the shared renderer (single source)" {
+    seed_feed_env
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    local exp n got
+    exp="$(_apl_feed_render_header)"
+    n="$(printf '%s\n' "$exp" | wc -l)"
+    got="$(head -n "$n" "$FEED_ENV")"
+    [ "$exp" = "$got" ]
+}
+
+@test "non-default INPUT renders its decoder doc comment" {
+    cat > "$FEED_ENV" <<EOF
+LATITUDE="52.5"
+LONGITUDE="13.4"
+ALTITUDE="120"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=false
+MLAT_PRIVATE=false
+INPUT="127.0.0.1:10003"
+INPUT_TYPE=radarcape_gps
+EOF
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    grep -q 'Non-default receiver decoder' "$FEED_ENV"
+    grep -q '^INPUT="127.0.0.1:10003"$' "$FEED_ENV"
+    grep -q '^INPUT_TYPE="radarcape_gps"$' "$FEED_ENV"
+    # The shared note is emitted once (only for INPUT, not INPUT_TYPE).
+    [ "$(grep -c 'Non-default receiver decoder' "$FEED_ENV")" -eq 1 ]
+}
+
+@test "malformed REPORT_STATUS line is dropped on an unrelated save (guard intact)" {
+    # The realistic webconfig-save path: an operator hand-edited a bad
+    # REPORT_STATUS line, then changed something else in the UI. The strict
+    # reader refuses the malformed line, so it must not be re-emitted —
+    # otherwise the feed#137 diagnostics fail-closed guard would keep firing.
+    cat > "$FEED_ENV" <<EOF
+LATITUDE="52.5"
+LONGITUDE="13.4"
+ALTITUDE="120"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=false
+MLAT_PRIVATE=false
+REPORT_STATUS=false # opted out
+EOF
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    grep -q '^MLAT_PRIVATE="true"$' "$FEED_ENV"
+    ! grep -q 'opted out' "$FEED_ENV"
+    # No active REPORT_STATUS key line survives (the commented header
+    # example #REPORT_STATUS=true does not count).
+    ! grep -q '^[[:space:]]*REPORT_STATUS=' "$FEED_ENV"
+}
+
+@test "unowned key preserved with header and no set -u crash" {
+    cat > "$FEED_ENV" <<EOF
+APL_FEED_WEBSITE_URL="https://web.dev.airplanes.live"
+LATITUDE="52.5"
+LONGITUDE="13.4"
+GEO_CONFIGURED=true
+MLAT_USER="alice"
+MLAT_ENABLED=false
+MLAT_PRIVATE=false
+EOF
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    grep -q '^APL_FEED_WEBSITE_URL="https://web.dev.airplanes.live"$' "$FEED_ENV"
+    grep -q 'operator-supplied configuration for the' "$FEED_ENV"
+}
+
+@test "no-op save leaves a stripped file stripped (lazy header healing)" {
+    # A file already stripped by a pre-fix save is only re-documented on the
+    # next value-changing write; a no_change save must not rewrite it (no
+    # mtime churn, no daemon config-watch re-trigger).
+    cat > "$FEED_ENV" <<EOF
+LATITUDE="52.5"
+LONGITUDE="13.4"
+ALTITUDE="120"
+GEO_CONFIGURED="true"
+MLAT_USER="alice"
+MLAT_ENABLED="false"
+MLAT_PRIVATE="false"
+EOF
+    cp "$FEED_ENV" "$FEED_ENV.before"
+    do_apply --no-restart MLAT_PRIVATE=false
+    [ "$APL_APPLY_RC" -eq 0 ]
+    [ "$APL_APPLY_STATUS" = "no_change" ]
+    diff -u "$FEED_ENV.before" "$FEED_ENV"
+    ! grep -q 'operator-supplied configuration for the' "$FEED_ENV"
+}
+
+@test "documented output round-trips through the strict reader unchanged" {
+    seed_feed_env
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    # Read the now-documented file back: the header + per-key comments must
+    # not leak into the parsed map, and values must be exactly what we wrote.
+    declare -A back=()
+    APL_APPLY_KEY_ORDER=()
+    _apl_feed_apply_read "$FEED_ENV" back
+    [ "${back[LATITUDE]}" = "52.52" ]
+    [ "${back[MLAT_USER]}" = "alice" ]
+    [ "${back[MLAT_PRIVATE]}" = "true" ]
+    [ "${back[GAIN]}" = "auto" ]
+    [ "${back[INPUT]}" = "127.0.0.1:30005" ]
+    # No comment/header artifact became a key.
+    [ -z "${back['#']+set}" ]
+    [ -z "${back[REPORT_STATUS]+set}" ]
+}
+
+@test "INPUT_TYPE before INPUT in source still documents the pair once" {
+    # Pathological hand-written order. The decoder doc attaches to INPUT
+    # wherever it appears (accepted cosmetic-ordering caveat); it must still
+    # appear exactly once and both values must survive.
+    cat > "$FEED_ENV" <<EOF
+LATITUDE="52.5"
+LONGITUDE="13.4"
+MLAT_ENABLED=false
+INPUT_TYPE=radarcape_gps
+INPUT="127.0.0.1:10003"
+EOF
+    do_apply --no-restart MLAT_PRIVATE=true
+    [ "$APL_APPLY_RC" -eq 0 ]
+    grep -q '^INPUT="127.0.0.1:10003"$' "$FEED_ENV"
+    grep -q '^INPUT_TYPE="radarcape_gps"$' "$FEED_ENV"
+    [ "$(grep -c 'Non-default receiver decoder' "$FEED_ENV")" -eq 1 ]
 }


### PR DESCRIPTION
A webconfig or `apl-feed` CLI save rewrote `feed.env` down to bare `KEY=value` lines, dropping the documented header — including the warning not to hand-edit `REPORT_STATUS`. The header and per-key comments now live in one shared source that both the setup writer and the apply writer emit, so a save reproduces the documented file instead of stripping it.

Operator overrides and the value contract are unchanged, and the strict parser still drops malformed lines, so the diagnostics fail-closed behavior is unaffected. Already-stripped feeders are re-documented on their next config change.

Refs #132.
