### PR TITLE
Post feeder reception stats to /api/feeders/reception

### DIFF
--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -502,6 +502,83 @@ build_pi_throttle_json() {
     printf 'null'
 }
 
+# Build the feeder-attested reception block from the forwarder's readsb JSON
+# (aircraft.json + stats.json under /run/airplanes-feed, written by
+# airplanes-feed.sh's --write-json). Prints "null" — pruned from the payload —
+# when those files are absent/unreadable, jq is missing, or the data is stale.
+# aircraft.json is rewritten continuously, so a stale `now` means the forwarder
+# is down; we don't report its last gasp. max_range_nmi is gated on a real,
+# non-zero lat/lon (range from null island is meaningless); counts and signal
+# are reported regardless of location.
+build_reception_json() {
+    local json_dir aircraft_file stats_file now_epoch lat lon have_geo out
+    json_dir="$(root_path /run/airplanes-feed)"
+    aircraft_file="$json_dir/aircraft.json"
+    stats_file="$json_dir/stats.json"
+    [[ -r "$aircraft_file" && -r "$stats_file" ]] || { printf 'null'; return; }
+    command -v jq >/dev/null 2>&1 || { printf 'null'; return; }
+
+    now_epoch="$(date +%s 2>/dev/null)"
+    [[ "$now_epoch" =~ ^[0-9]+$ ]] || { printf 'null'; return; }
+
+    lat="$(feed_env_get LATITUDE 2>/dev/null || true)"
+    lon="$(feed_env_get LONGITUDE 2>/dev/null || true)"
+    # Geo gate: report range only with a valid, non-zero lat/lon. Both
+    # coordinates zero (0, +0, -0, 0.0, …) is the unconfigured "null island"
+    # default; a single zero is legitimate (equator / prime meridian). A value
+    # that isn't a plain decimal number is treated as no-geo — we won't trust
+    # range derived from a coordinate we can't parse.
+    have_geo=false
+    if [[ "$lat" =~ ^[+-]?[0-9]+(\.[0-9]+)?$ && "$lon" =~ ^[+-]?[0-9]+(\.[0-9]+)?$ ]]; then
+        if [[ "$lat" =~ ^[+-]?0+(\.0*)?$ && "$lon" =~ ^[+-]?0+(\.0*)?$ ]]; then
+            have_geo=false
+        else
+            have_geo=true
+        fi
+    fi
+
+    # timeout: a pathological aircraft.json must never hang the diagnostics
+    # run. An empty file slurps to [] → $a is null → null result; a malformed
+    # file makes jq exit nonzero, caught by the `if` and reported as null.
+    # `num` coerces non-number fields to null so a wrong-typed value can't
+    # produce string concatenation or a phantom zero. rssi: drop readsb's
+    # ~-49.5 dBFS no-signal floor before averaging.
+    if out="$(timeout 3s jq -nc \
+        --argjson now_epoch "$now_epoch" \
+        --argjson have_geo "$have_geo" \
+        --slurpfile ac "$aircraft_file" \
+        --slurpfile st "$stats_file" \
+        '
+        def num: if type == "number" then . else null end;
+        ($ac[0]) as $a | ($st[0]) as $s
+        | if ($a | type) != "object" or ($s | type) != "object" then null
+          elif ($a.now | num) == null
+               or (($now_epoch - $a.now) > 120) or (($a.now - $now_epoch) > 120) then null
+          else
+            ([ $a.aircraft[]? | .rssi? | select(type == "number" and . > -49.4) ]) as $rssi
+            | ($s.aircraft_with_pos | num) as $wp
+            | ($s.aircraft_without_pos | num) as $wo
+            | ($s.total.max_distance | num) as $md
+            | {
+                aircraft_total: (if $wp != null and $wo != null then $wp + $wo else null end),
+                aircraft_with_pos: $wp,
+                max_range_nmi: (if $have_geo and $md != null
+                    then (($md / 1852.0) | (. * 10 | round) / 10)
+                    else null end),
+                rssi_avg_dbfs: (if ($rssi | length) > 0
+                    then (($rssi | add) / ($rssi | length) | (. * 10 | round) / 10)
+                    else null end),
+                rssi_max_dbfs: (if ($rssi | length) > 0 then ($rssi | max) else null end)
+              }
+            | with_entries(select(.value != null))
+          end
+        ' 2>/dev/null)" && [[ -n "$out" ]]; then
+        printf '%s' "$out"
+    else
+        printf 'null'
+    fi
+}
+
 # nullable_num VALUE — echoes the value if non-empty, otherwise "null".
 # Used with `jq --argjson` so missing numerics become JSON null and the
 # `del(.. | nulls?)` pass strips them from the payload.
@@ -713,6 +790,15 @@ main() {
         # separately at ingest.
         ntp_sync_json="$(collect_ntp_sync 2>/dev/null || printf 'null')"
 
+        # Feeder-attested reception stats from the forwarder's readsb JSON,
+        # POSTed separately to /api/feeders/reception below (its own lane, not
+        # folded into the diagnostics payload). "null" — and the reception POST
+        # is skipped — until the forwarder writes JSON, or when the data is
+        # stale / jq is unavailable.
+        local reception_json
+        reception_json="$(build_reception_json 2>/dev/null || true)"
+        [[ -n "$reception_json" ]] || reception_json='null'
+
         local feed_scripts_version os_pretty_name os_id os_version_id kernel architecture image_release
         feed_scripts_version="$(get_feed_scripts_version || true)"
         os_pretty_name="$(get_os_release_field PRETTY_NAME || true)"
@@ -860,6 +946,37 @@ main() {
     status="$(post_json_bearer "$token" '/api/feeders/diagnostics' "$payload" "$response_file")"
     curl_rc=$?
     set -e
+
+    # Feeder-attested reception stats go to their own endpoint — a separate
+    # lane from device-health diagnostics. Best-effort and independent: a
+    # failure here is logged but never changes the diagnostics result. Rides
+    # the same REPORT_STATUS consent (full mode only) and is sent only when the
+    # forwarder produced fresh data (reception_json != null). Flattened onto the
+    # envelope so the server's reception sanitizer reads scalars top-level.
+    # Skipped when the diagnostics POST hit a transport error — the same dead
+    # network would just stall another curl timeout for nothing.
+    if (( curl_rc == 0 )) \
+        && [[ "$mode" == "full" && "${reception_json:-null}" != "null" ]]; then
+        local reception_payload reception_response reception_status
+        reception_payload="$(jq -nc \
+            --arg ts "$ts" \
+            --arg uuid "$uuid" \
+            --argjson reception "$reception_json" \
+            '{schema_version: 1, ts: $ts, uuid: $uuid} + $reception')" \
+            || reception_payload=''
+        if [[ -n "$reception_payload" ]]; then
+            reception_response="$(new_tmp_file)"
+            set +e
+            reception_status="$(post_json_bearer "$token" '/api/feeders/reception' "$reception_payload" "$reception_response")"
+            set -e
+            if [[ "$reception_status" == 2* ]]; then
+                log info "status=reception_ok http=$reception_status"
+            else
+                log warn "status=reception_failed http=${reception_status:-none}"
+            fi
+        fi
+    fi
+
     # Wipe the token before any further work — it's no longer needed.
     token=''
 

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -11,6 +11,7 @@ setup() {
     STUB_DIR="$ROOT_DIR/bin"
     COMMAND_LOG="$ROOT_DIR/cmd.log"
     BODY_LOG="$ROOT_DIR/body.log"
+    RECEPTION_BODY_LOG="$ROOT_DIR/reception-body.log"
     HEADER_LOG="$ROOT_DIR/header.log"
     mkdir -p "$STUB_DIR" "$ROOT_DIR/var/lib"
 
@@ -32,8 +33,19 @@ for arg in "$@"; do
     fi
     prev="$arg"
 done
-# Drain stdin (the JSON body) so callers can inspect what was sent.
-cat > "$BODY_LOG"
+# Drain stdin (the JSON body) so callers can inspect what was sent. Route by
+# endpoint so the diagnostics and reception POST bodies stay separable.
+_recv_target=''
+for arg in "$@"; do
+    case "$arg" in
+        */api/feeders/reception) _recv_target="${RECEPTION_BODY_LOG:-}" ;;
+    esac
+done
+if [[ -n "$_recv_target" ]]; then
+    cat > "$_recv_target"
+else
+    cat > "$BODY_LOG"
+fi
 if [[ -n "$output_file" ]]; then
     printf '%s' "${CURL_RESPONSE:-{\"ok\":true\}}" > "$output_file"
 fi
@@ -177,6 +189,7 @@ run_script() {
         APL_FEED_WEBSITE_URL="${APL_FEED_WEBSITE_URL:-http://127.0.0.1:0}" \
         COMMAND_LOG="$COMMAND_LOG" \
         BODY_LOG="$BODY_LOG" \
+        RECEPTION_BODY_LOG="$RECEPTION_BODY_LOG" \
         HEADER_LOG="$HEADER_LOG" \
         CURL_STATUS="${CURL_STATUS:-200}" \
         CURL_RC="${CURL_RC:-0}" \
@@ -1049,4 +1062,158 @@ SH
     [[ "$output" == *"status=bad_config"* ]]
     [[ "$output" == *"REPORT_STATUS"* ]]
     [ ! -f "$COMMAND_LOG" ]
+}
+
+# ---- reception stats (forwarder readsb JSON) ----
+
+# Seed the forwarder's readsb JSON outputs under the rooted /run dir. Kept
+# rssi after the no-signal floor filter is {-10,-20,-6} → avg -12, max -6.
+_seed_forwarder_json() {
+    local now_val="$1"
+    local dir="$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$dir"
+    cat > "$dir/aircraft.json" <<EOF
+{"now": $now_val, "messages": 99, "aircraft": [
+  {"hex":"a1","rssi":-10.0,"lat":1.0,"lon":2.0},
+  {"hex":"a2","rssi":-20.0},
+  {"hex":"mlat","rssi":-49.5},
+  {"hex":"a3","rssi":-6.0,"lat":3.0,"lon":4.0}
+]}
+EOF
+    cat > "$dir/stats.json" <<EOF
+{"now": $now_val, "aircraft_with_pos": 7, "aircraft_without_pos": 3, "total": {"max_distance": 185200}}
+EOF
+}
+
+@test "reception: fresh forwarder JSON + geo → separate POST to /api/feeders/reception" {
+    printf 'REPORT_STATUS=true\nLATITUDE=52.52\nLONGITUDE=13.405\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    _seed_forwarder_json "$(date +%s)"
+    run_script
+    [ "$status" -eq 0 ]
+    # Both endpoints hit; reception travels in its own POST, not diagnostics.
+    grep -q -- '/api/feeders/diagnostics' "$COMMAND_LOG"
+    grep -q -- '/api/feeders/reception' "$COMMAND_LOG"
+    # Reception body is the envelope with scalars flattened to top level.
+    run jq -e '.schema_version == 1' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e '.aircraft_total == 10' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e '.aircraft_with_pos == 7' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    # 185200 m / 1852 = 100 nmi
+    run jq -e '.max_range_nmi == 100' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e '.rssi_max_dbfs == -6' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    # avg over kept rssi {-10,-20,-6} = -12; the -49.5 floor is excluded
+    run jq -e '.rssi_avg_dbfs == -12' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    # Diagnostics payload no longer carries reception.
+    run jq -e 'has("reception") | not' "$BODY_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "reception: stale forwarder JSON (old now) → no reception POST" {
+    printf 'REPORT_STATUS=true\nLATITUDE=52.52\nLONGITUDE=13.405\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    _seed_forwarder_json "$(( $(date +%s) - 9999 ))"
+    run_script
+    [ "$status" -eq 0 ]
+    grep -q -- '/api/feeders/diagnostics' "$COMMAND_LOG"
+    if grep -q -- '/api/feeders/reception' "$COMMAND_LOG"; then return 1; fi
+}
+
+@test "reception: absent forwarder JSON → no reception POST (diagnostics still sent)" {
+    # No _seed_forwarder_json — /run/airplanes-feed has no JSON files yet.
+    run_script
+    [ "$status" -eq 0 ]
+    grep -q -- '/api/feeders/diagnostics' "$COMMAND_LOG"
+    if grep -q -- '/api/feeders/reception' "$COMMAND_LOG"; then return 1; fi
+}
+
+@test "reception: 0/0 geo → reception POST omits max_range_nmi" {
+    printf 'REPORT_STATUS=true\nLATITUDE=0\nLONGITUDE=0\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    _seed_forwarder_json "$(date +%s)"
+    run_script
+    [ "$status" -eq 0 ]
+    grep -q -- '/api/feeders/reception' "$COMMAND_LOG"
+    run jq -e '.aircraft_total == 10' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e '.rssi_max_dbfs == -6' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e 'has("max_range_nmi") | not' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "reception: malformed forwarder JSON → no reception POST (diagnostics still sent)" {
+    printf 'REPORT_STATUS=true\nLATITUDE=52.52\nLONGITUDE=13.405\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    local dir="$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$dir"
+    printf '{ this is not json' > "$dir/aircraft.json"
+    printf '{"now": %s, "aircraft_with_pos": 1, "aircraft_without_pos": 0, "total": {"max_distance": 0}}\n' \
+        "$(date +%s)" > "$dir/stats.json"
+    run_script
+    [ "$status" -eq 0 ]
+    grep -q -- '/api/feeders/diagnostics' "$COMMAND_LOG"
+    if grep -q -- '/api/feeders/reception' "$COMMAND_LOG"; then return 1; fi
+}
+
+@test "reception: all RSSI at the no-signal floor → reception POST omits signal fields" {
+    printf 'REPORT_STATUS=true\nLATITUDE=52.52\nLONGITUDE=13.405\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    local dir="$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$dir"
+    cat > "$dir/aircraft.json" <<EOF
+{"now": $(date +%s), "aircraft": [{"hex":"x","rssi":-49.5},{"hex":"y","rssi":-50.0}]}
+EOF
+    printf '{"now": %s, "aircraft_with_pos": 0, "aircraft_without_pos": 2, "total": {"max_distance": 0}}\n' \
+        "$(date +%s)" > "$dir/stats.json"
+    run_script
+    [ "$status" -eq 0 ]
+    grep -q -- '/api/feeders/reception' "$COMMAND_LOG"
+    run jq -e '.aircraft_total == 2' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e 'has("rssi_avg_dbfs") | not' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e 'has("rssi_max_dbfs") | not' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "reception: missing stats count omits total; max_range rounds to 1 dp" {
+    printf 'REPORT_STATUS=true\nLATITUDE=52.52\nLONGITUDE=13.405\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    local dir="$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$dir"
+    cat > "$dir/aircraft.json" <<EOF
+{"now": $(date +%s), "aircraft": [{"hex":"x","rssi":-8.0}]}
+EOF
+    # No aircraft_without_pos → total can't be computed (omitted). Non-number
+    # types must not concatenate. 186000 m / 1852 = 100.43… → rounds to 100.4.
+    printf '{"now": %s, "aircraft_with_pos": 5, "total": {"max_distance": 186000}}\n' \
+        "$(date +%s)" > "$dir/stats.json"
+    run_script
+    [ "$status" -eq 0 ]
+    grep -q -- '/api/feeders/reception' "$COMMAND_LOG"
+    run jq -e '.aircraft_with_pos == 5' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e 'has("aircraft_total") | not' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+    run jq -e '.max_range_nmi == 100.4' "$RECEPTION_BODY_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "reception: REPORT_STATUS=false → no reception POST (rides diagnostics consent)" {
+    printf 'REPORT_STATUS=false\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    _seed_forwarder_json "$(date +%s)"
+    run_script
+    [ "$status" -eq 0 ]
+    # Opted out of telemetry → reception is not sent even with fresh data.
+    if grep -q -- '/api/feeders/reception' "$COMMAND_LOG"; then return 1; fi
+}
+
+@test "reception: skipped when the diagnostics POST has a transport error" {
+    printf 'REPORT_STATUS=true\nLATITUDE=52.52\nLONGITUDE=13.405\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+    _seed_forwarder_json "$(date +%s)"
+    # curl exits non-zero (e.g. couldn't connect) → don't stall another POST
+    # against the same dead network.
+    CURL_RC=7 run_script
+    [ "$status" -eq 0 ]
+    if grep -q -- '/api/feeders/reception' "$COMMAND_LOG"; then return 1; fi
 }


### PR DESCRIPTION
The feeder diagnostics push now also reports receiver-performance statistics — the aircraft a feeder is seeing, its maximum range, and a signal-strength summary — read from the forwarder's local readsb JSON.

These go out as a separate best-effort POST to the dedicated `/api/feeders/reception` endpoint rather than being folded into the device-health diagnostics payload, so the two telemetry lanes stay independent. The reception report rides the same `REPORT_STATUS` consent (an opted-out feeder sends neither), only fires when the forwarder has produced fresh data, and a failure never affects the diagnostics result.