### PR TITLE
Fix restore failing on a piped backup

### DIFF
--- a/scripts/apl-feed/backup.sh
+++ b/scripts/apl-feed/backup.sh
@@ -26,6 +26,10 @@ USAGE
 }
 
 read_backup_file() {
+    # Expects a seekable file path: jq reopens "$infile" once per field
+    # below, so a single-read stream (a pipe / FIFO such as /dev/stdin)
+    # would drain on the first call and present EOF to the rest. The
+    # caller is responsible for materialising non-seekable input first.
     local infile="$1"
     BACKUP_SCHEMA="$(jq -r '.schema_version // empty' < "$infile")"
     [[ "$BACKUP_SCHEMA" == "1" ]] || die "unsupported backup schema_version: ${BACKUP_SCHEMA:-<missing>}"
@@ -205,7 +209,27 @@ config_restore() {
     fi
 
     if [[ -n "$infile" ]]; then
-        [[ -f "$infile" ]] || die "$infile does not exist"
+        if [[ -f "$infile" ]]; then
+            : # regular file (incl. /dev/stdin backed by a redirected
+              # file): seekable, read_backup_file can reopen it directly.
+        elif [[ "$infile" == /dev/stdin || "$infile" == /dev/fd/0 \
+                || "$infile" == /proc/self/fd/0 || -p "$infile" ]]; then
+            # Non-seekable source — the webconfig identity-import path
+            # pipes the backup JSON in on /dev/stdin. read_backup_file
+            # reopens its argument once per field, so materialise the
+            # single-read stream into a temp file first. Cap the copy:
+            # backup envelopes are well under 1 MiB, and this runs under
+            # a privileged sudoers entry, so an unbounded stdin drain
+            # would be a trivial disk-fill lever.
+            local tmp
+            tmp="$(new_tmp_file)"
+            head -c "$((1024 * 1024 + 1))" "$infile" > "$tmp" \
+                || die "failed to read backup from $infile"
+            (( $(wc -c < "$tmp") > 1024 * 1024 )) && die "backup input too large"
+            infile="$tmp"
+        else
+            die "$infile does not exist"
+        fi
         require_jq
         read_backup_file "$infile"
     else

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -413,6 +413,49 @@ EOF
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")" = "4" ]
 }
 
+@test "restore reads a backup piped on /dev/stdin (webconfig identity-import path)" {
+    # The webconfig identity-import wrapper runs `apl-feed restore
+    # /dev/stdin --force` with the backup JSON on a pipe. read_backup_file
+    # reopens its argument once per field, so the stream must be
+    # materialised first — otherwise the first jq drains the pipe and the
+    # rest see EOF.
+    local backup_file="$ROOT_DIR/backup.json"
+    echo "ABCDEFGHIJKLMNOP" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
+    echo "4" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+    chmod 600 "$ROOT_DIR/etc/airplanes/feeder-claim-secret" "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+    run "$SCRIPT" backup "$backup_file" --root "$ROOT_DIR"
+    [ "$status" -eq 0 ]
+    rm "$ROOT_DIR/etc/airplanes/feeder-id"
+    rm "$ROOT_DIR/etc/airplanes/feeder-claim-secret" "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version"
+
+    run bash -c "cat '$backup_file' | '$SCRIPT' restore /dev/stdin --force --root '$ROOT_DIR'"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "11111111-2222-3333-4444-555555555555" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret")" = "ABCDEFGHIJKLMNOP" ]
+    [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-claim-secret.version")" = "4" ]
+}
+
+@test "restore /dev/stdin with an empty pipe fails on schema, not existence" {
+    # A relaxed source check must still surface a real validation error
+    # (empty input → missing schema_version), not the misleading
+    # "does not exist" that the old `[[ -f /dev/stdin ]]` test produced.
+    run bash -c ": | '$SCRIPT' restore /dev/stdin --force --root '$ROOT_DIR'"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "schema_version" ]]
+    [[ "$output" != *"does not exist"* ]]
+}
+
+@test "restore of a missing file path still reports does not exist" {
+    # The regular-file path keeps its existence error; relaxing the check
+    # for /dev/stdin must not turn a genuine typo into a jq error.
+    run "$SCRIPT" restore "$ROOT_DIR/no-such-backup.json" --force --root "$ROOT_DIR"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "does not exist" ]]
+}
+
 @test "backup rejects --force instead of overwriting" {
     local backup_file="$ROOT_DIR/backup.json"
     echo "ABCDEFGHIJKLMNOP" > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"


### PR DESCRIPTION
Restoring a feeder backup that is piped into `apl-feed restore /dev/stdin` failed with a misleading "does not exist" error. The source check only accepted regular files, so a pipe was rejected outright; and even past that, the parser reopens its input once per field, which a single-read pipe cannot satisfy.

A non-seekable source is now buffered into a bounded temporary file before parsing, so a piped backup restores correctly. Restores from a regular file path are unchanged and a genuinely missing path still reports that it does not exist.
