### PR TITLE
refactor!: install the feeder under the /opt/airplanes FHS layout

### DIFF
--- a/create-uuid.sh
+++ b/create-uuid.sh
@@ -22,8 +22,14 @@ normalize_uuid() {
 }
 
 read_existing_uuid() {
-    local candidate raw
-    for candidate in "$FEEDER_ID_FILE" "$LEGACY_UUID_FILE" "$BOOT_UUID_FILE"; do
+    local candidate raw pre_fhs_uuid
+    # Pre-FHS installs kept the legacy UUID under the old $IPATH at
+    # /usr/local/share/airplanes/airplanes-uuid. LEGACY_UUID_FILE now points at
+    # the new $STATE location, so include the old path explicitly — otherwise an
+    # upgrade across the FHS layout move would lose feeder identity before it has
+    # been migrated into /etc/airplanes/feeder-id.
+    pre_fhs_uuid="$(airplanes_path /usr/local/share/airplanes/airplanes-uuid)"
+    for candidate in "$FEEDER_ID_FILE" "$LEGACY_UUID_FILE" "$pre_fhs_uuid" "$BOOT_UUID_FILE"; do
         [[ -f "$candidate" ]] || continue
         raw="$(normalize_uuid "$candidate")"
         if valid_uuid "$raw"; then

--- a/install.sh
+++ b/install.sh
@@ -43,8 +43,10 @@ else
     }
 
     airplanes_init_paths() {
-        IPATH="$(airplanes_path /usr/local/share/airplanes)"
-        GIT="$IPATH/git"
+        PREFIX="$(airplanes_path /opt/airplanes/current)"
+        IPATH="$PREFIX/share/airplanes"
+        STATE="$(airplanes_path /var/lib/airplanes/runtime)"
+        GIT="$STATE/git"
     }
 
     airplanes_is_build_mode() {

--- a/scripts/airplanes-config-sync.service
+++ b/scripts/airplanes-config-sync.service
@@ -20,6 +20,6 @@ PrivateTmp=yes
 # first. The first config-sync.timer tick used to fail namespace setup
 # ("/var/lib/airplanes: No such file or directory") when it fired before
 # diagnostics ever ran.
-StateDirectory=airplanes-config-sync
+StateDirectory=airplanes/config-sync
 StateDirectoryMode=0755
 ReadWritePaths=/etc/airplanes /run

--- a/scripts/airplanes-diagnostics.service
+++ b/scripts/airplanes-diagnostics.service
@@ -6,14 +6,14 @@ After=network-online.target airplanes-feed.service
 [Service]
 Type=oneshot
 User=airplanes-feed
-StateDirectory=airplanes-diagnostics
+StateDirectory=airplanes/diagnostics
 # 0755 so `apl-feed status` run as a non-airplanes-feed-group user can
 # stat the last-success sentinel inside this dir. The file is non-secret
 # (mtime only), and the only thing inside is the `touch`-created marker.
 StateDirectoryMode=0755
-RuntimeDirectory=airplanes-diagnostics
+RuntimeDirectory=airplanes/diagnostics
 RuntimeDirectoryMode=0700
-ExecStart=/usr/local/share/airplanes/airplanes-diagnostics.sh
+ExecStart=/opt/airplanes/current/share/airplanes/airplanes-diagnostics.sh
 TimeoutStartSec=90s
 SyslogIdentifier=airplanes-diagnostics
 NoNewPrivileges=yes

--- a/scripts/airplanes-diagnostics.sh
+++ b/scripts/airplanes-diagnostics.sh
@@ -18,8 +18,8 @@ SCRIPT_NAME="airplanes-diagnostics"
 EXIT_OK=0
 EXIT_BAD_CONFIG=64
 
-LAST_SUCCESS_FILE="${AIRPLANES_DIAGNOSTICS_LAST_SUCCESS:-${STATE_DIRECTORY:-/var/lib/airplanes-diagnostics}/diagnostics-last-success}"
-INTENT_ACK_FILE="${AIRPLANES_DIAGNOSTICS_INTENT_ACK_FILE:-${STATE_DIRECTORY:-/var/lib/airplanes-diagnostics}/diagnostics-intent-acked}"
+LAST_SUCCESS_FILE="${AIRPLANES_DIAGNOSTICS_LAST_SUCCESS:-${STATE_DIRECTORY:-/var/lib/airplanes/diagnostics}/diagnostics-last-success}"
+INTENT_ACK_FILE="${AIRPLANES_DIAGNOSTICS_INTENT_ACK_FILE:-${STATE_DIRECTORY:-/var/lib/airplanes/diagnostics}/diagnostics-intent-acked}"
 INSTALL_DIR="${AIRPLANES_DIAGNOSTICS_INSTALL_DIR:-}"
 
 _resolve_install_dir() {
@@ -35,7 +35,7 @@ _resolve_install_dir() {
 _INSTALL_DIR="$(_resolve_install_dir)"
 
 # Source helpers from apl-feed/. In production these live at
-# /usr/local/share/airplanes/apl-feed/. In the source tree they're at
+# /opt/airplanes/current/share/airplanes/apl-feed/. In the source tree they're at
 # feed/scripts/apl-feed/. Both resolutions land at the same directory
 # relative to this script. feed-env-apply.sh sits next to them in the
 # sibling lib/ directory (production $_INSTALL_DIR/lib/, source tree
@@ -312,19 +312,21 @@ collect_ntp_sync() {
 }
 
 # Resolve a service's version. Priority:
-#   1. Install-time file at $IPATH/<file>_version (written by update-builds.sh)
+#   1. Install-time file at $STATE/<file>_version (written by update-builds.sh)
 #   2. Best-effort `<binary> --version | head -1` (3s timeout)
 # Returns empty on failure.
 get_service_version() {
     local service="$1"
-    local ipath
-    ipath="$(root_path /usr/local/share/airplanes)"
+    local state_dir
+    # Build-time version stamps live in the mutable runtime state dir
+    # (written by update-builds.sh as $STATE/{readsb,mlat}_version).
+    state_dir="$(root_path /var/lib/airplanes/runtime)"
     local version_file=''
     case "$service" in
         # airplanes-feed, readsb, and airplanes-978 all run a readsb-derived
         # binary; they share the same install-time version file.
-        airplanes-feed|readsb|airplanes-978) version_file="$ipath/readsb_version" ;;
-        airplanes-mlat) version_file="$ipath/mlat_version" ;;
+        airplanes-feed|readsb|airplanes-978) version_file="$state_dir/readsb_version" ;;
+        airplanes-mlat) version_file="$state_dir/mlat_version" ;;
     esac
     if [[ -n "$version_file" && -r "$version_file" ]]; then
         local v
@@ -512,7 +514,7 @@ get_os_release_field() {
 
 get_feed_scripts_version() {
     local file
-    file="$(root_path /usr/local/share/airplanes/.version)"
+    file="$(root_path /opt/airplanes/current/share/airplanes/.version)"
     [[ -r "$file" ]] || return 1
     local raw
     raw="$(head -n 1 "$file" 2>/dev/null | tr -d '[:cntrl:]' | cut -c1-128)"
@@ -658,7 +660,7 @@ main() {
         # file would always say enabled/ok — no value in plumbing it.
         # readsb has no state file at all.
         svc_feed="$(build_service_json airplanes-feed)"
-        svc_mlat="$(build_service_json airplanes-mlat "$(root_path /run/airplanes-mlat/state)")"
+        svc_mlat="$(build_service_json airplanes-mlat "$(root_path /run/airplanes/mlat/state)")"
         svc_readsb="$(build_service_json readsb)"
         # dump978-fa and airplanes-978 are both UAT-only — relevant only
         # when the user has actually configured UAT. Without this gate,
@@ -671,8 +673,8 @@ main() {
         svc_dump978='null'
         svc_978='null'
         if [[ -n "$uat_input" ]]; then
-            svc_dump978="$(build_service_json dump978-fa "$(root_path /run/dump978-fa/state)")"
-            svc_978="$(build_service_json airplanes-978 "$(root_path /run/airplanes-978/state)")"
+            svc_dump978="$(build_service_json dump978-fa "$(root_path /run/airplanes/dump978-fa/state)")"
+            svc_978="$(build_service_json airplanes-978 "$(root_path /run/airplanes/978/state)")"
         fi
 
         local pi_throttle_json ntp_sync_json

--- a/scripts/airplanes-feed.service
+++ b/scripts/airplanes-feed.service
@@ -6,9 +6,9 @@ After=network-online.target airplanes-first-run.service
 
 [Service]
 User=airplanes-feed
-RuntimeDirectory=airplanes-feed
+RuntimeDirectory=airplanes/feed
 RuntimeDirectoryPreserve=yes
-ExecStart=/usr/local/share/airplanes/airplanes-feed.sh
+ExecStart=/opt/airplanes/current/share/airplanes/airplanes-feed.sh
 Type=simple
 Restart=always
 RestartSec=30

--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -16,11 +16,12 @@ FEED_ENV="$(airplanes_path /etc/airplanes/feed.env)"
 FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
 IMAGE_INSTALL_MARKER="$(airplanes_path /etc/airplanes/image-install)"
 
-# The feed binary now lands at the same consolidated path for both image
-# and standalone installs, so it no longer discriminates install type;
-# the /etc/airplanes/image-install marker is the sole signal.
+# An image install is signalled by the /etc/airplanes/image-install marker
+# (new overlay image) or the baked /usr/bin/airplanes-feeder binary (a legacy
+# image, which predates the marker). The flag lets the feeder fall back to its
+# /boot config when no feed.env is present and selects the image decoder tuning.
 IMAGE_INSTALL=0
-if [[ -f "$IMAGE_INSTALL_MARKER" ]]; then
+if [[ -f "$IMAGE_INSTALL_MARKER" || -x "$(airplanes_path /usr/bin/airplanes-feeder)" ]]; then
     IMAGE_INSTALL=1
 fi
 
@@ -62,7 +63,13 @@ if [[ "${MODEAC:-}" == "yes" ]]; then
     MODEAC_OPTION="--modeac"
 fi
 
+# Prefer the consolidated /opt feed binary; fall back to a legacy image's
+# baked /usr/bin/airplanes-feeder when /opt has no binary. AIRPLANES_FEED_BIN
+# overrides both. Mirrors airplanes_image_feed_bin_default in the installer.
 DEFAULT_FEED_BIN="$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
+if [[ ! -x "$DEFAULT_FEED_BIN" && -x "$(airplanes_path /usr/bin/airplanes-feeder)" ]]; then
+    DEFAULT_FEED_BIN="$(airplanes_path /usr/bin/airplanes-feeder)"
+fi
 FEED_BIN="${AIRPLANES_FEED_BIN:-$DEFAULT_FEED_BIN}"
 
 # Brand endpoint + readsb tuning defaults. Apply outside the image

--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -14,11 +14,13 @@ BOOT_CONFIG="$(airplanes_path /boot/airplanes-config.txt)"
 BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
 FEED_ENV="$(airplanes_path /etc/airplanes/feed.env)"
 FEEDER_ID_FILE="$(airplanes_path /etc/airplanes/feeder-id)"
-IMAGE_FEED_BIN="$(airplanes_path /usr/bin/airplanes-feeder)"
 IMAGE_INSTALL_MARKER="$(airplanes_path /etc/airplanes/image-install)"
 
+# The feed binary now lands at the same consolidated path for both image
+# and standalone installs, so it no longer discriminates install type;
+# the /etc/airplanes/image-install marker is the sole signal.
 IMAGE_INSTALL=0
-if [[ -x "$IMAGE_FEED_BIN" || -f "$IMAGE_INSTALL_MARKER" ]]; then
+if [[ -f "$IMAGE_INSTALL_MARKER" ]]; then
     IMAGE_INSTALL=1
 fi
 
@@ -60,11 +62,7 @@ if [[ "${MODEAC:-}" == "yes" ]]; then
     MODEAC_OPTION="--modeac"
 fi
 
-if [[ -x "$IMAGE_FEED_BIN" ]]; then
-    DEFAULT_FEED_BIN="$IMAGE_FEED_BIN"
-else
-    DEFAULT_FEED_BIN="$(airplanes_path /usr/local/share/airplanes/feed-airplanes)"
-fi
+DEFAULT_FEED_BIN="$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
 FEED_BIN="${AIRPLANES_FEED_BIN:-$DEFAULT_FEED_BIN}"
 
 # Brand endpoint + readsb tuning defaults. Apply outside the image
@@ -122,7 +120,7 @@ unset _target_rest
 
 # State writer (defensive: a partial install where this script is in
 # place but the lib isn't yet must not take down the daemon).
-STATE_WRITER="$(airplanes_path /usr/local/share/airplanes/lib/state-writer.sh)"
+STATE_WRITER="$(airplanes_path /opt/airplanes/current/share/airplanes/lib/state-writer.sh)"
 if [[ -r "$STATE_WRITER" ]]; then
     # shellcheck source=lib/state-writer.sh
     source "$STATE_WRITER"
@@ -135,7 +133,7 @@ fi
 # (effective config + binary path) for consumers. Forward-compatible
 # with future signals (e.g. an explicit FEED_ENABLED=false toggle
 # would add a reason token without bumping schema_version).
-STATE_FILE="$(airplanes_path /run/airplanes-feed/state)"
+STATE_FILE="$(airplanes_path /run/airplanes/feed/state)"
 mkdir -p "$(dirname "$STATE_FILE")"
 airplanes_write_state "$STATE_FILE" \
     "service=airplanes-feed" \

--- a/scripts/airplanes-mlat.service
+++ b/scripts/airplanes-mlat.service
@@ -6,9 +6,9 @@ After=network-online.target airplanes-first-run.service
 
 [Service]
 User=airplanes-feed
-RuntimeDirectory=airplanes-mlat
+RuntimeDirectory=airplanes/mlat
 RuntimeDirectoryPreserve=yes
-ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh
+ExecStart=/opt/airplanes/current/share/airplanes/airplanes-mlat.sh
 Type=simple
 Restart=always
 RestartSec=30

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -31,7 +31,7 @@ unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER GEO_CONFIGURE
 if [[ -f "$FEED_ENV" ]]; then
     source "$FEED_ENV"
     _mlat_config_sources=("$FEED_ENV")
-elif [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && -f "$BOOT_CONFIG" ]]; then
+elif [[ -f "$(airplanes_path /etc/airplanes/image-install)" && -f "$BOOT_CONFIG" ]]; then
     source "$BOOT_CONFIG"
     [[ -f "$BOOT_ENV" ]] && source "$BOOT_ENV"
     _mlat_config_sources=("$FEED_ENV" "$BOOT_CONFIG" "$BOOT_ENV")
@@ -90,7 +90,7 @@ fi
 # state-writer source below). Unrecognised values leave MLAT_PRIVATE
 # unset so MLAT_MARKER can fall through, and ultimately the default
 # false applies.
-LEGACY_MLAT_TR="$(airplanes_path /usr/local/share/airplanes/lib/legacy-mlat-translation.sh)"
+LEGACY_MLAT_TR="$(airplanes_path /opt/airplanes/current/share/airplanes/lib/legacy-mlat-translation.sh)"
 if [[ -r "$LEGACY_MLAT_TR" ]]; then
     # shellcheck source=lib/legacy-mlat-translation.sh
     source "$LEGACY_MLAT_TR"
@@ -181,7 +181,7 @@ UUID_FILE="--uuid-file $FEEDER_ID_FILE"
 
 # State writer (defensive: a partial install where this script is in
 # place but the lib isn't yet must not take down the daemon).
-STATE_WRITER="$(airplanes_path /usr/local/share/airplanes/lib/state-writer.sh)"
+STATE_WRITER="$(airplanes_path /opt/airplanes/current/share/airplanes/lib/state-writer.sh)"
 if [[ -r "$STATE_WRITER" ]]; then
     # shellcheck source=lib/state-writer.sh
     source "$STATE_WRITER"
@@ -248,7 +248,7 @@ _mlat_config_fingerprint() {
 }
 
 read -r STATE REASON < <(_mlat_classify)
-STATE_FILE="$(airplanes_path /run/airplanes-mlat/state)"
+STATE_FILE="$(airplanes_path /run/airplanes/mlat/state)"
 mkdir -p "$(dirname "$STATE_FILE")"
 airplanes_write_state "$STATE_FILE" \
     "service=airplanes-mlat" \
@@ -326,7 +326,7 @@ while command -v nc &>/dev/null && ! nc -z "$INPUT_IP" "$INPUT_PORT"; do
     sleep 10
 done
 
-exec "$(airplanes_path /usr/local/share/airplanes/venv/bin/mlat-client)" \
+exec "$(airplanes_path /opt/airplanes/current/share/airplanes/venv/bin/mlat-client)" \
     --input-type "$INPUT_TYPE" --no-udp \
     --input-connect "$INPUT" \
     --server "$MLATSERVER" \

--- a/scripts/airplanes-mlat.sh
+++ b/scripts/airplanes-mlat.sh
@@ -31,7 +31,7 @@ unset USER MLAT_USER MLAT_ENABLED MLAT_PRIVATE PRIVACY MLAT_MARKER GEO_CONFIGURE
 if [[ -f "$FEED_ENV" ]]; then
     source "$FEED_ENV"
     _mlat_config_sources=("$FEED_ENV")
-elif [[ -f "$(airplanes_path /etc/airplanes/image-install)" && -f "$BOOT_CONFIG" ]]; then
+elif [[ ( -f "$(airplanes_path /etc/airplanes/image-install)" || -x "$(airplanes_path /usr/bin/airplanes-feeder)" ) && -f "$BOOT_CONFIG" ]]; then
     source "$BOOT_CONFIG"
     [[ -f "$BOOT_ENV" ]] && source "$BOOT_ENV"
     _mlat_config_sources=("$FEED_ENV" "$BOOT_CONFIG" "$BOOT_ENV")

--- a/scripts/airplanes-stats.service
+++ b/scripts/airplanes-stats.service
@@ -6,12 +6,12 @@ After=network-online.target airplanes-feed.service
 [Service]
 Type=oneshot
 # Runs as the forwarder's user so it can read the 0640 airplanes-feed:airplanes-feed
-# claim secret and the forwarder's readsb JSON under /run/airplanes-feed. It needs
-# no directory of its own: it only READS /run/airplanes-feed (owned by
+# claim secret and the forwarder's readsb JSON under /run/airplanes/feed. It needs
+# no directory of its own: it only READS /run/airplanes/feed (owned by
 # airplanes-feed.service) and writes scratch files to its private /tmp. Declaring
-# RuntimeDirectory=airplanes-feed would clobber the forwarder's dir, so none is set.
+# RuntimeDirectory=airplanes/feed would clobber the forwarder's dir, so none is set.
 User=airplanes-feed
-ExecStart=/usr/local/share/airplanes/airplanes-stats.sh
+ExecStart=/opt/airplanes/current/share/airplanes/airplanes-stats.sh
 TimeoutStartSec=60s
 SyslogIdentifier=airplanes-stats
 NoNewPrivileges=yes

--- a/scripts/airplanes-stats.sh
+++ b/scripts/airplanes-stats.sh
@@ -54,7 +54,7 @@ _resolve_install_dir() {
 
 _INSTALL_DIR="$(_resolve_install_dir)"
 
-# Source helpers from apl-feed/ (production /usr/local/share/airplanes/apl-feed/,
+# Source helpers from apl-feed/ (production /opt/airplanes/current/share/airplanes/apl-feed/,
 # source tree feed/scripts/apl-feed/). feed-env-apply.sh sits in the sibling lib/
 # dir and is required: common.sh's feed_env_get delegates to its strict reader.
 # Mirrors airplanes-diagnostics.sh's bootstrap.
@@ -182,7 +182,7 @@ main() {
     # envelope); outline is optional (omitted if absent/invalid, e.g. a quiet
     # receiver with no range ring).
     local json_dir aircraft_file stats_file outline_file
-    json_dir="$(root_path /run/airplanes-feed)"
+    json_dir="$(root_path /run/airplanes/feed)"
     aircraft_file="$json_dir/aircraft.json"
     stats_file="$json_dir/stats.json"
     outline_file="$json_dir/outline.json"

--- a/scripts/apl-feed.sh
+++ b/scripts/apl-feed.sh
@@ -9,7 +9,7 @@ resolve_lib_dir() {
     if [[ -d "$script_dir/apl-feed" ]]; then
         printf '%s\n' "$script_dir/apl-feed"
     else
-        printf '%s\n' '/usr/local/share/airplanes/apl-feed'
+        printf '%s\n' '/opt/airplanes/current/share/airplanes/apl-feed'
     fi
 }
 
@@ -24,7 +24,7 @@ resolve_daemon_lib_dir() {
     if [[ -d "$script_dir/lib" ]]; then
         printf '%s\n' "$script_dir/lib"
     else
-        printf '%s\n' '/usr/local/share/airplanes/lib'
+        printf '%s\n' '/opt/airplanes/current/share/airplanes/lib'
     fi
 }
 APL_FEED_DAEMON_LIB_DIR="${APL_FEED_DAEMON_LIB_DIR:-$(resolve_daemon_lib_dir)}"

--- a/scripts/apl-feed/apply.sh
+++ b/scripts/apl-feed/apply.sh
@@ -209,7 +209,7 @@ apl_feed_apply_cli() {
     done <<< "$meta_blob"
 
     # Auto-bootstrap canonical feed.env from /boot/airplanes-config.txt
-    # when running on a bridged-legacy box (airplanes-feeder installed,
+    # when running on a bridged-legacy box (image-install marker present,
     # no canonical feed.env yet). The new Go webconfig is the only
     # consumer of this CLI in production today and ships only on the new
     # image (which has feed.env at build time), so this is defensive

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -160,7 +160,7 @@ uuid_file_primary() {
 }
 
 uuid_file_legacy() {
-    root_path '/usr/local/share/airplanes/airplanes-uuid'
+    root_path '/var/lib/airplanes/runtime/airplanes-uuid'
 }
 
 uuid_file_boot() {
@@ -184,7 +184,7 @@ feed_env_path() {
         root_path '/etc/airplanes/feed.env'
         return
     fi
-    if [[ -x "$(root_path '/usr/bin/airplanes-feeder')" && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
+    if [[ -f "$(root_path '/etc/airplanes/image-install')" && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
         root_path '/boot/airplanes-config.txt'
         return
     fi
@@ -205,8 +205,8 @@ feed_env_write_path() {
 
 # Bootstrap the canonical feed.env from a bridged-legacy boot config when
 # canonical is missing. Idempotent: no-op when canonical already exists.
-# Detection mirrors feed_env_path()'s legacy fallback: airplanes-feeder
-# binary installed (bridge ran) + /boot/airplanes-config.txt present.
+# Detection mirrors feed_env_path()'s legacy fallback: the image-install
+# marker is present + /boot/airplanes-config.txt present.
 #
 # Without this, every apl-feed writer (mlat, uat, eventually configure
 # wrappers) would error out with "feed.env not found" on a bridged-legacy
@@ -226,10 +226,10 @@ feed_env_ensure_canonical_for_write() {
     canonical="$(feed_env_write_path)"
     [[ -f "$canonical" ]] && return 0
 
-    local boot_config feeder_binary
+    local boot_config image_marker
     boot_config="$(root_path '/boot/airplanes-config.txt')"
-    feeder_binary="$(root_path '/usr/bin/airplanes-feeder')"
-    if [[ ! -x "$feeder_binary" || ! -f "$boot_config" ]]; then
+    image_marker="$(root_path '/etc/airplanes/image-install')"
+    if [[ ! -f "$image_marker" || ! -f "$boot_config" ]]; then
         return 0
     fi
 
@@ -253,7 +253,7 @@ feed_env_paths() {
         printf '\n'
         return
     fi
-    if [[ -x "$(root_path '/usr/bin/airplanes-feeder')" && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
+    if [[ -f "$(root_path '/etc/airplanes/image-install')" && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
         root_path '/boot/airplanes-config.txt'
         printf '\n'
         root_path '/boot/airplanes-env'

--- a/scripts/apl-feed/common.sh
+++ b/scripts/apl-feed/common.sh
@@ -184,7 +184,8 @@ feed_env_path() {
         root_path '/etc/airplanes/feed.env'
         return
     fi
-    if [[ -f "$(root_path '/etc/airplanes/image-install')" && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
+    # Legacy images (baked /usr/bin/airplanes-feeder, no marker) read /boot too.
+    if [[ ( -f "$(root_path '/etc/airplanes/image-install')" || -x "$(root_path '/usr/bin/airplanes-feeder')" ) && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
         root_path '/boot/airplanes-config.txt'
         return
     fi
@@ -205,8 +206,15 @@ feed_env_write_path() {
 
 # Bootstrap the canonical feed.env from a bridged-legacy boot config when
 # canonical is missing. Idempotent: no-op when canonical already exists.
-# Detection mirrors feed_env_path()'s legacy fallback: the image-install
-# marker is present + /boot/airplanes-config.txt present.
+#
+# Gating is image-install-marker-only ON PURPOSE — deliberately narrower than
+# feed_env_path()'s read fallback, which ALSO accepts a true legacy ROM's
+# baked /usr/bin/airplanes-feeder. A legacy ROM keeps its config in /boot,
+# owned by the legacy PHP webconfig that keeps writing there; bootstrapping a
+# canonical feed.env on such a box would make the daemons source feed.env and
+# silently ignore the operator's ongoing /boot edits. So writes only bootstrap
+# on a bridged feeder carrying the marker + a /boot config, never on a legacy
+# ROM (which has no marker).
 #
 # Without this, every apl-feed writer (mlat, uat, eventually configure
 # wrappers) would error out with "feed.env not found" on a bridged-legacy
@@ -253,7 +261,7 @@ feed_env_paths() {
         printf '\n'
         return
     fi
-    if [[ -f "$(root_path '/etc/airplanes/image-install')" && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
+    if [[ ( -f "$(root_path '/etc/airplanes/image-install')" || -x "$(root_path '/usr/bin/airplanes-feeder')" ) && -f "$(root_path '/boot/airplanes-config.txt')" ]]; then
         root_path '/boot/airplanes-config.txt'
         printf '\n'
         root_path '/boot/airplanes-env'

--- a/scripts/apl-feed/config.sh
+++ b/scripts/apl-feed/config.sh
@@ -80,13 +80,13 @@ _config_sync_parse_opt_in() {
 # which systemd exports as $STATE_DIRECTORY at runtime so the path tracks the
 # unit without drift; the literal fallback covers manual / chroot invocations
 # where the unit env isn't present.
-CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-${STATE_DIRECTORY:-/var/lib/airplanes-config-sync}/config-sync-last-success}"
+CONFIG_SYNC_LAST_SUCCESS_FILE="${AIRPLANES_CONFIG_SYNC_LAST_SUCCESS:-${STATE_DIRECTORY:-/var/lib/airplanes/config-sync}/config-sync-last-success}"
 
 # Owned-state file (same StateDirectory, same override discipline as the
 # sentinel). Holds the server's last ownership verdict so the unowned→owned
 # claim edge can be detected across ticks. Persistent (not /run) so the edge
 # fires only on an actual claim, not on every reboot.
-CONFIG_SYNC_STATE_FILE="${AIRPLANES_CONFIG_SYNC_STATE:-${STATE_DIRECTORY:-/var/lib/airplanes-config-sync}/state}"
+CONFIG_SYNC_STATE_FILE="${AIRPLANES_CONFIG_SYNC_STATE:-${STATE_DIRECTORY:-/var/lib/airplanes/config-sync}/state}"
 
 # Structured logger. Mirrors airplanes-diagnostics.sh's `log` so the two
 # timers produce a uniform journal stream.

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -4,8 +4,8 @@
 # fall back to a stub that always returns 1 so the MLAT path degrades to
 # systemd-only rendering. The path is BASH_SOURCE-relative so it
 # resolves identically in source tree (scripts/apl-feed/.. -> scripts/lib)
-# and production install (/usr/local/share/airplanes/apl-feed/.. ->
-# /usr/local/share/airplanes/lib).
+# and production install (/opt/airplanes/current/share/airplanes/apl-feed/.. ->
+# /opt/airplanes/current/share/airplanes/lib).
 _status_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 _state_reader="$_status_dir/../lib/state-reader.sh"
 if [[ -r "$_state_reader" ]]; then
@@ -228,7 +228,7 @@ status_finish() {
 # bracket).
 _derive_backend_endpoints() {
     local state_file value
-    state_file="$(root_path /run/airplanes-feed/state)"
+    state_file="$(root_path /run/airplanes/feed/state)"
     if value="$(airplanes_read_state "$state_file" target_host)"; then
         STATUS_FEED_TARGET_PRESENT=1
         STATUS_FEED_TARGET_HOST="$value"
@@ -242,7 +242,7 @@ _derive_backend_endpoints() {
             STATUS_FEED_TARGET_INVALID='false'
         fi
     fi
-    state_file="$(root_path /run/airplanes-mlat/state)"
+    state_file="$(root_path /run/airplanes/mlat/state)"
     if value="$(airplanes_read_state "$state_file" mlat_server)"; then
         STATUS_MLAT_SERVER_PRESENT=1
         STATUS_MLAT_SERVER="$value"
@@ -352,7 +352,7 @@ _render_systemd_state() {
 
 # mlat_status_line — replaces the old mlat_disabled_by_config + the
 # matching service_status_line call in feed_status. Reads the daemon's
-# published decision from /run/airplanes-mlat/state when the unit is
+# published decision from /run/airplanes/mlat/state when the unit is
 # active or transitioning; falls through to systemd-derived rendering
 # otherwise. Special-cases failed-with-exit-64 (the strict misconfig
 # fail from airplanes-mlat.sh — today only fires for an invalid
@@ -368,7 +368,7 @@ mlat_status_line() {
     local active_state
     active_state="$(systemctl show --property=ActiveState --value "$unit" 2>/dev/null || true)"
     local state_file
-    state_file="$(root_path /run/airplanes-mlat/state)"
+    state_file="$(root_path /run/airplanes/mlat/state)"
 
     case "$active_state" in
         active|activating|reloading)
@@ -410,14 +410,14 @@ mlat_status_line() {
 }
 
 # _mlat_privacy_suffix — read the daemon's published privacy posture
-# from /run/airplanes-mlat/state and render the inline suffix appended
+# from /run/airplanes/mlat/state and render the inline suffix appended
 # to a "running" MLAT line. Empty string when the state file is
 # unreadable, the value is missing, or the value is unrecognised (an
 # unknown value is surfaced separately via _mlat_privacy_unknown_value
 # so forward-schema visibility isn't lost when the suffix is folded in).
 _mlat_privacy_suffix() {
     local state_file mlat_private
-    state_file="$(root_path /run/airplanes-mlat/state)"
+    state_file="$(root_path /run/airplanes/mlat/state)"
     if ! mlat_private="$(airplanes_read_state "$state_file" mlat_private 2>/dev/null)"; then
         return 0
     fi
@@ -432,7 +432,7 @@ _mlat_privacy_suffix() {
 # surface as a warn line. Empty when absent or recognised.
 _mlat_privacy_unknown_value() {
     local state_file mlat_private
-    state_file="$(root_path /run/airplanes-mlat/state)"
+    state_file="$(root_path /run/airplanes/mlat/state)"
     if ! mlat_private="$(airplanes_read_state "$state_file" mlat_private 2>/dev/null)"; then
         return 0
     fi
@@ -749,12 +749,12 @@ claim_registration_status_line() {
 # diagnostics_status_line — render the airplanes-diagnostics push state.
 # Reads the REPORT_STATUS toggle from feed.env, then consults the systemd
 # unit (if a bad config caused an exit-64 failure on the last run) and
-# the mtime of /var/lib/airplanes-diagnostics/diagnostics-last-success.
+# the mtime of /var/lib/airplanes/diagnostics/diagnostics-last-success.
 diagnostics_status_line() {
     local label="Diagnostics push"
     local unit="airplanes-diagnostics.service"
     local last_success_file
-    last_success_file="$(root_path /var/lib/airplanes-diagnostics/diagnostics-last-success)"
+    last_success_file="$(root_path /var/lib/airplanes/diagnostics/diagnostics-last-success)"
 
     local raw lower
     raw="$(feed_env_get REPORT_STATUS 2>/dev/null || true)"
@@ -835,14 +835,14 @@ diagnostics_status_line() {
 # config_sync_status_line — render the airplanes-config-sync remote-config
 # state. Reads the REMOTE_CONFIG_ENABLED opt-in from feed.env, then consults
 # the systemd unit (exit-64 hard-config failures) and the mtime of
-# /var/lib/airplanes-config-sync/config-sync-last-success. The sentinel is
+# /var/lib/airplanes/config-sync/config-sync-last-success. The sentinel is
 # touched on every successful sync (owned or unowned heartbeat), so it tracks
 # liveness regardless of whether the feeder is account-claimed.
 config_sync_status_line() {
     local label="Remote config"
     local unit="airplanes-config-sync.service"
     local last_success_file
-    last_success_file="$(root_path /var/lib/airplanes-config-sync/config-sync-last-success)"
+    last_success_file="$(root_path /var/lib/airplanes/config-sync/config-sync-last-success)"
 
     local raw lower
     raw="$(feed_env_get REMOTE_CONFIG_ENABLED 2>/dev/null || true)"

--- a/scripts/lib/feed-env-apply.sh
+++ b/scripts/lib/feed-env-apply.sh
@@ -453,7 +453,7 @@ _apl_feed_apply_restart_set() {
 # and a foreign unit doesn't read feed.env, so the restart could never
 # apply the change anyway. Ownership test: every unit installed by the
 # feed scripts or the image runtime overlay ExecStarts a wrapper under
-# /usr/local/share/airplanes/.
+# /opt/airplanes/current/share/airplanes/.
 _apl_feed_apply_unit_is_ours() {
     local unit="$1" unit_def
     # `systemctl cat` returns 0 iff the unit (or a generator-emitted
@@ -462,7 +462,7 @@ _apl_feed_apply_unit_is_ours() {
     # exiting at first match can SIGPIPE systemctl and fail the whole
     # pipeline — skipping the restart of a unit we do own.
     unit_def="$(systemctl cat "$unit" 2>/dev/null)" || return 1
-    [[ "$unit_def" == *'/usr/local/share/airplanes/'* ]]
+    [[ "$unit_def" == *'/opt/airplanes/current/share/airplanes/'* ]]
 }
 
 _apl_feed_apply_restart_services() {

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -137,8 +137,15 @@ airplanes_init_paths() {
     SYSTEMD_DIR="$(airplanes_path /etc/systemd/system)"
 }
 
+# An image install is either the new overlay image (which lays the
+# /etc/airplanes/image-install marker) or a legacy image (which ships the baked
+# /usr/bin/airplanes-feeder binary but predates the marker). Detecting the
+# legacy binary is a READ of a file the legacy rootfs already carries — it does
+# not write into /usr/bin, so it does not conflict with the FHS de-squat. Both
+# require a config source so a bare rootfs isn't mistaken for a configured image.
 airplanes_is_image_install() {
-    [[ -f "$(airplanes_path /etc/airplanes/image-install)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
+    [[ -f "$(airplanes_path /etc/airplanes/image-install)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]] \
+        || [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
 }
 
 airplanes_image_feed_bin_default() {

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -119,34 +119,30 @@ airplanes_path() {
 }
 
 airplanes_init_paths() {
-    IPATH="$(airplanes_path /usr/local/share/airplanes)"
-    GIT="$IPATH/git"
-    LOGFILE="$IPATH/lastlog"
+    PREFIX="$(airplanes_path /opt/airplanes/current)"
+    IPATH="$PREFIX/share/airplanes"
+    BIN="$PREFIX/bin"
+    STATE="$(airplanes_path /var/lib/airplanes/runtime)"
+    GIT="$STATE/git"
+    LOGFILE="$STATE/lastlog"
     BOOT_CONFIG="$(airplanes_path /boot/airplanes-config.txt)"
     BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
     ETC_AIRPLANES="$(airplanes_path /etc/airplanes)"
     FEED_ENV="$ETC_AIRPLANES/feed.env"
     FEEDER_ID_FILE="$ETC_AIRPLANES/feeder-id"
-    LEGACY_UUID_FILE="$IPATH/airplanes-uuid"
+    LEGACY_UUID_FILE="$STATE/airplanes-uuid"
     BOOT_UUID_FILE="$(airplanes_path /boot/airplanes-uuid)"
     LEGACY_FEED_ENV="$(airplanes_path /etc/default/airplanes)"
     LOCAL_BIN="$(airplanes_path /usr/local/bin)"
-    SYSTEMD_DIR="$(airplanes_path /lib/systemd/system)"
+    SYSTEMD_DIR="$(airplanes_path /etc/systemd/system)"
 }
 
 airplanes_is_image_install() {
-    [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]] \
-        || [[ -f "$(airplanes_path /etc/airplanes/image-install)" && -f "$FEED_ENV" ]]
+    [[ -f "$(airplanes_path /etc/airplanes/image-install)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
 }
 
 airplanes_image_feed_bin_default() {
-    local legacy
-    legacy="$(airplanes_path /usr/bin/airplanes-feeder)"
-    if [[ -x "$legacy" ]]; then
-        printf '%s' "$legacy"
-    else
-        printf '%s' "$(airplanes_path /usr/local/share/airplanes/feed-airplanes)"
-    fi
+    printf '%s' "$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
 }
 
 airplanes_image_target_default() {

--- a/scripts/lib/install-update-common.sh
+++ b/scripts/lib/install-update-common.sh
@@ -149,7 +149,21 @@ airplanes_is_image_install() {
 }
 
 airplanes_image_feed_bin_default() {
-    printf '%s' "$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
+    # Prefer the consolidated /opt feed binary (new overlay image + standalone
+    # builds both land here). Fall back to a legacy image's baked
+    # /usr/bin/airplanes-feeder, which predates the /opt layout and cannot be
+    # rebuilt on an image. The /opt path is the canonical "missing" target so
+    # the caller's error message points at where the binary should be.
+    local opt_bin legacy_bin
+    opt_bin="$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
+    legacy_bin="$(airplanes_path /usr/bin/airplanes-feeder)"
+    if [[ -x "$opt_bin" ]]; then
+        printf '%s' "$opt_bin"
+    elif [[ -x "$legacy_bin" ]]; then
+        printf '%s' "$legacy_bin"
+    else
+        printf '%s' "$opt_bin"
+    fi
 }
 
 airplanes_image_target_default() {

--- a/scripts/lib/state-reader.sh
+++ b/scripts/lib/state-reader.sh
@@ -11,7 +11,7 @@
 # contain shell metacharacters. Parse line-by-line.
 #
 # Usage:
-#   if reason="$(airplanes_read_state /run/airplanes-mlat/state reason)"; then
+#   if reason="$(airplanes_read_state /run/airplanes/mlat/state reason)"; then
 #       printf 'reason=%s\n' "$reason"
 #   else
 #       printf 'state file unavailable or unparseable\n'

--- a/scripts/lib/state-writer.sh
+++ b/scripts/lib/state-writer.sh
@@ -36,7 +36,7 @@
 # metacharacters. Parse line-by-line with KEY=VALUE split on first `=`.
 #
 # Usage:
-#   airplanes_write_state /run/airplanes-mlat/state \
+#   airplanes_write_state /run/airplanes/mlat/state \
 #       service=airplanes-mlat \
 #       state=disabled \
 #       reason=mlat_enabled_false \

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -564,17 +564,33 @@ remove_pre_fhs_layout() {
     local legacy_systemd="$2"
     local logfile="${3:-/dev/null}"
 
-    if [[ ! -e "$legacy_ipath" && ! -e "$legacy_systemd/airplanes-feed.service" ]]; then
-        return 0
+    local legacy_units=(
+        airplanes-feed.service airplanes-mlat.service
+        airplanes-diagnostics.service airplanes-diagnostics.timer
+        airplanes-stats.service airplanes-stats.timer
+        airplanes-config-sync.service airplanes-config-sync.timer
+    )
+
+    # Skip (and avoid the daemon-reload) only when there is genuinely nothing
+    # left to clean: no legacy IPATH and none of the legacy units. Checking the
+    # full unit list — not just airplanes-feed.service — so a partial earlier
+    # cleanup that left a stale mlat/diagnostics/stats/config-sync unit behind
+    # still gets finished.
+    local unit have_legacy=0
+    [[ -e "$legacy_ipath" ]] && have_legacy=1
+    if (( ! have_legacy )); then
+        for unit in "${legacy_units[@]}"; do
+            if [[ -e "$legacy_systemd/$unit" ]]; then
+                have_legacy=1
+                break
+            fi
+        done
     fi
+    (( have_legacy )) || return 0
 
     echo "Removing pre-FHS install layout ($legacy_ipath + $legacy_systemd units)" >> "$logfile" 2>&1
 
-    local unit
-    for unit in airplanes-feed.service airplanes-mlat.service \
-                airplanes-diagnostics.service airplanes-diagnostics.timer \
-                airplanes-stats.service airplanes-stats.timer \
-                airplanes-config-sync.service airplanes-config-sync.timer; do
+    for unit in "${legacy_units[@]}"; do
         rm -f "$legacy_systemd/$unit"
     done
 

--- a/scripts/lib/update-migrations.sh
+++ b/scripts/lib/update-migrations.sh
@@ -539,6 +539,57 @@ migrate_disable_legacy_mlat_client() {
     fi
 }
 
+# ---------------------------------------------------------------------------
+# Pre-FHS install-layout migration
+# ---------------------------------------------------------------------------
+
+# Sweep the pre-FHS install layout after a successful upgrade to the /opt
+# layout. Before the FHS move the standalone installer wrote payload and
+# mutable state into /usr/local/share/airplanes (the old $IPATH) and units
+# into /lib/systemd/system. The new install lays everything under
+# /opt/airplanes/current, /var/lib/airplanes/runtime, and /etc/systemd/system,
+# so the old tree is orphaned. /etc/airplanes (feeder identity + config) is
+# never touched, and create-uuid.sh has already migrated any legacy UUID into
+# /etc/airplanes/feeder-id by the time this runs — so this only removes stale
+# files, it does not move data. Re-running on an already-migrated feeder is a
+# no-op (idempotent). File removal always runs so a chroot/build rootfs stays
+# clean; the daemon-reload that drops the now-stale /lib unit definitions is
+# gated on the real system.
+#
+# Args: $1 legacy IPATH (/usr/local/share/airplanes)
+#       $2 legacy systemd dir (/lib/systemd/system)
+#       $3 logfile
+remove_pre_fhs_layout() {
+    local legacy_ipath="$1"
+    local legacy_systemd="$2"
+    local logfile="${3:-/dev/null}"
+
+    if [[ ! -e "$legacy_ipath" && ! -e "$legacy_systemd/airplanes-feed.service" ]]; then
+        return 0
+    fi
+
+    echo "Removing pre-FHS install layout ($legacy_ipath + $legacy_systemd units)" >> "$logfile" 2>&1
+
+    local unit
+    for unit in airplanes-feed.service airplanes-mlat.service \
+                airplanes-diagnostics.service airplanes-diagnostics.timer \
+                airplanes-stats.service airplanes-stats.timer \
+                airplanes-config-sync.service airplanes-config-sync.timer; do
+        rm -f "$legacy_systemd/$unit"
+    done
+
+    # Defensive: only ever rm -rf a path that ends in the known legacy IPATH
+    # suffix, so a mis-passed argument can't widen the deletion.
+    if [[ -n "$legacy_ipath" && "$legacy_ipath" == */usr/local/share/airplanes ]]; then
+        rm -rf "$legacy_ipath"
+    fi
+
+    if ! airplanes_is_build_mode && [[ "${AIRPLANES_ROOT:-/}" == "/" ]] \
+        && command -v systemctl >/dev/null 2>&1; then
+        systemctl daemon-reload >> "$logfile" 2>&1 || true
+    fi
+}
+
 run_post_update_legacy_cleanup() {
     local rc_local="$1"
     local mlat_client_default="$2"

--- a/setup.sh
+++ b/setup.sh
@@ -54,13 +54,13 @@ if ! airplanes_is_build_mode && airplanes_is_image_install; then
     exit 1
 fi
 
-bash "$IPATH/git/configure.sh" "$@"
+bash "$GIT/configure.sh" "$@"
 
 BACKTITLETEXT="${BACKTITLETEXT:-airplanes.live Setup Script}"
 if ! airplanes_is_build_mode; then
     whiptail --backtitle "$BACKTITLETEXT" --title "$BACKTITLETEXT" --yesno "We are now ready to begin setting up your receiver to feed airplanes.live.\n\nDo you wish to proceed?" 9 78 || exit 1
 fi
 
-bash "$IPATH/git/update.sh" "$@"
+bash "$GIT/update.sh" "$@"
 
 exit 0

--- a/test/Dockerfile.apl-feed-test
+++ b/test/Dockerfile.apl-feed-test
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY scripts/apl-feed.sh /usr/local/bin/apl-feed
 RUN chmod +x /usr/local/bin/apl-feed
-COPY scripts/apl-feed /usr/local/share/airplanes/apl-feed
+COPY scripts/apl-feed /opt/airplanes/current/share/airplanes/apl-feed
 
 # UUID is generated at container start (entrypoint.sh), not baked into the
 # image, so each `docker run` produces a fresh registration.

--- a/test/image-boot.sh
+++ b/test/image-boot.sh
@@ -711,7 +711,7 @@ GUEST
 cat > "$ROOT_MNT/opt/airplanes-boot-smoke/feed-daemon-stub" <<'GUEST'
 #!/usr/bin/env bash
 set -euo pipefail
-printf 'feed-daemon %s\n' "$*" >> /run/airplanes-feed/boot-smoke-feed-daemon.log 2>/dev/null || true
+printf 'feed-daemon %s\n' "$*" >> /run/airplanes/feed/boot-smoke-feed-daemon.log 2>/dev/null || true
 exec sleep infinity
 GUEST
     chmod 0755 "$ROOT_MNT/opt/airplanes-boot-smoke/feed-daemon-stub"
@@ -784,20 +784,20 @@ assert_image_contracts() {
         assert_file /etc/airplanes/feed.env
     fi
     assert_valid_uuid_file /etc/airplanes/feeder-id
-    # The /usr/local/share/airplanes/airplanes-uuid -> feeder-id compat symlink
-    # is required only on the legacy contract. create-uuid.sh lays it down on
-    # any install path that runs update.sh; the overlay-managed new image
-    # instead generates the canonical /etc/airplanes/feeder-id inline at first
-    # boot and deliberately does NOT ship the legacy symlink (the image's own
-    # overlay smoke asserts its absence). We assert presence only on legacy
-    # rather than asserting absence on new, because a hypothetical non-overlay
-    # new install would still run update.sh and create the symlink — the
-    # invariant that actually holds is "required on legacy", not "forbidden on
-    # new". apl-feed resolves feeder-id from the canonical path first
-    # (common.sh's resolver), so the symlink is a back-compat shim, not a
-    # functional dependency on the new contract.
+    # The airplanes-uuid -> feeder-id compat symlink (now under $STATE at
+    # /var/lib/airplanes/runtime/airplanes-uuid) is required only on the legacy
+    # contract. create-uuid.sh lays it down on any install path that runs
+    # update.sh; the overlay-managed new image instead generates the canonical
+    # /etc/airplanes/feeder-id inline at first boot and deliberately does NOT
+    # ship the legacy symlink (the image's own overlay smoke asserts its
+    # absence). We assert presence only on legacy rather than asserting absence
+    # on new, because a hypothetical non-overlay new install would still run
+    # update.sh and create the symlink — the invariant that actually holds is
+    # "required on legacy", not "forbidden on new". apl-feed resolves feeder-id
+    # from the canonical path first (common.sh's resolver), so the symlink is a
+    # back-compat shim, not a functional dependency on the new contract.
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
-        assert_symlink_target /usr/local/share/airplanes/airplanes-uuid '../../../../etc/airplanes/feeder-id'
+        assert_symlink_target /var/lib/airplanes/runtime/airplanes-uuid '../../../../etc/airplanes/feeder-id'
         assert_exec /usr/bin/airplanes-feeder
         # update.sh installs itself to IPATH on any install path that runs it.
         # The overlay-managed new image deliberately does NOT ship update.sh:
@@ -805,22 +805,22 @@ assert_image_contracts() {
         # and update.sh refuses to run there anyway (overlay guard, EX_CONFIG).
         # It is neither staged into the overlay tree nor a managed_paths entry.
         # Required only on the legacy contract.
-        assert_file /usr/local/share/airplanes/update.sh
+        assert_file /opt/airplanes/current/share/airplanes/update.sh
     else
-        assert_exec /usr/local/share/airplanes/feed-airplanes
+        assert_exec /opt/airplanes/current/bin/feed-airplanes
     fi
     assert_exec /usr/local/bin/apl-feed
-    assert_file /usr/local/share/airplanes/airplanes-feed.sh
-    assert_file /usr/local/share/airplanes/airplanes-mlat.sh
-    assert_file /usr/local/share/airplanes/apl-feed/common.sh
+    assert_file /opt/airplanes/current/share/airplanes/airplanes-feed.sh
+    assert_file /opt/airplanes/current/share/airplanes/airplanes-mlat.sh
+    assert_file /opt/airplanes/current/share/airplanes/apl-feed/common.sh
     assert_file /etc/systemd/system/airplanes-feed.service
     assert_file /etc/systemd/system/airplanes-mlat.service
     assert_file /etc/systemd/system/airplanes-first-run.service
-    assert_contains /etc/systemd/system/airplanes-feed.service 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh'
+    assert_contains /etc/systemd/system/airplanes-feed.service 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-feed.sh'
     assert_regex /etc/systemd/system/airplanes-feed.service '^After=.*airplanes-first-run.service'
-    assert_contains /etc/systemd/system/airplanes-mlat.service 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh'
+    assert_contains /etc/systemd/system/airplanes-mlat.service 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-mlat.sh'
     assert_regex /etc/systemd/system/airplanes-mlat.service '^After=.*airplanes-first-run.service'
-    assert_contains /usr/local/share/airplanes/airplanes-feed.sh 'feed2.airplanes.live,64004'
+    assert_contains /opt/airplanes/current/share/airplanes/airplanes-feed.sh 'feed2.airplanes.live,64004'
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
         assert_not_exists /etc/airplanes/feed.env
         [[ -L /etc/default/airplanes ]] || fail "/etc/default/airplanes is not a symlink"
@@ -857,30 +857,37 @@ disable_mlat_for_boot_smoke() {
 prepare_mlat_fixture() {
     local mlat_version
     disable_mlat_for_boot_smoke
-    install -d -m 0755 /usr/local/share/airplanes/venv/bin
-    if [[ ! -x /usr/local/share/airplanes/venv/bin/mlat-client ]]; then
-        cat > /usr/local/share/airplanes/venv/bin/mlat-client <<'SH'
+    # The venv lives at $IPATH/venv under the /opt payload prefix; the
+    # mlat_version stamp is mutable build state under $STATE. Seed both so
+    # update.sh's version-match fast path skips the rebuild.
+    install -d -m 0755 /opt/airplanes/current/share/airplanes/venv/bin
+    install -d -m 0755 /var/lib/airplanes/runtime
+    if [[ ! -x /opt/airplanes/current/share/airplanes/venv/bin/mlat-client ]]; then
+        cat > /opt/airplanes/current/share/airplanes/venv/bin/mlat-client <<'SH'
 #!/usr/bin/env bash
 sleep 3600
 SH
-        chmod 0755 /usr/local/share/airplanes/venv/bin/mlat-client
+        chmod 0755 /opt/airplanes/current/share/airplanes/venv/bin/mlat-client
     fi
     mlat_version="$(git --git-dir=/opt/airplanes-boot-smoke/mlat.git rev-parse refs/heads/master)"
-    printf '%s\n' "$mlat_version" > /usr/local/share/airplanes/mlat_version
+    printf '%s\n' "$mlat_version" > /var/lib/airplanes/runtime/mlat_version
 }
 
 prepare_readsb_fixture() {
     local readsb_version
-    install -d -m 0755 /usr/local/share/airplanes
-    if [[ ! -x /usr/bin/airplanes-feeder && ! -x /usr/local/share/airplanes/feed-airplanes ]]; then
-        cat > /usr/local/share/airplanes/feed-airplanes <<'SH'
+    # A built feed binary lands in the /opt payload bin/; the readsb_version
+    # stamp is mutable build state under $STATE.
+    install -d -m 0755 /opt/airplanes/current/bin
+    install -d -m 0755 /var/lib/airplanes/runtime
+    if [[ ! -x /usr/bin/airplanes-feeder && ! -x /opt/airplanes/current/bin/feed-airplanes ]]; then
+        cat > /opt/airplanes/current/bin/feed-airplanes <<'SH'
 #!/usr/bin/env bash
 exit 0
 SH
-        chmod 0755 /usr/local/share/airplanes/feed-airplanes
+        chmod 0755 /opt/airplanes/current/bin/feed-airplanes
     fi
     readsb_version="$(git --git-dir=/opt/airplanes-boot-smoke/readsb.git rev-parse refs/heads/dev)"
-    printf '%s\n' "$readsb_version" > /usr/local/share/airplanes/readsb_version
+    printf '%s\n' "$readsb_version" > /var/lib/airplanes/runtime/readsb_version
 }
 
 run_feed_update() {
@@ -901,12 +908,12 @@ run_feed_update() {
 feed_binary_path() {
     # The feed binary lives in different places per contract: legacy images
     # ship an image-baked binary at /usr/bin/airplanes-feeder; new-contract
-    # installs build the binary into /usr/local/share/airplanes/feed-airplanes.
+    # installs build the binary into /opt/airplanes/current/bin/feed-airplanes.
     # Idempotency assertions need the right one.
     if [[ "$IMAGE_CONTRACT" == "legacy" ]]; then
         printf '%s\n' /usr/bin/airplanes-feeder
     else
-        printf '%s\n' /usr/local/share/airplanes/feed-airplanes
+        printf '%s\n' /opt/airplanes/current/bin/feed-airplanes
     fi
 }
 
@@ -916,7 +923,7 @@ snapshot_post_update_state() {
     #   - feeder-id content hash (UUID must survive reboot byte-stable)
     local feed_bin mlat_bin
     feed_bin="$(feed_binary_path)"
-    mlat_bin=/usr/local/share/airplanes/venv/bin/mlat-client
+    mlat_bin=/opt/airplanes/current/share/airplanes/venv/bin/mlat-client
     stat -c '%Y %n' "$feed_bin" "$mlat_bin" > "$STATE_DIR/snapshot-mtimes"
     sha256sum /etc/airplanes/feeder-id > "$STATE_DIR/snapshot-feeder-id"
 }
@@ -968,7 +975,7 @@ assert_binaries_unchanged() {
     post_snap="$STATE_DIR/snapshot-mtimes-post-rerun"
     local feed_bin mlat_bin
     feed_bin="$(feed_binary_path)"
-    mlat_bin=/usr/local/share/airplanes/venv/bin/mlat-client
+    mlat_bin=/opt/airplanes/current/share/airplanes/venv/bin/mlat-client
     stat -c '%Y %n' "$feed_bin" "$mlat_bin" > "$post_snap"
     if ! diff -q "$pre_snap" "$post_snap" >/dev/null; then
         echo "pre-rerun snapshot:" >&2
@@ -1023,8 +1030,8 @@ case "$phase" in
         # via sleep+exit per the daemon classifier in rules/architecture.md),
         # so is-active is a safe assertion across both branches.
         assert_service_healthy airplanes-mlat.service
-        assert_state_file_schema_v1 /run/airplanes-feed/state
-        assert_state_file_schema_v1 /run/airplanes-mlat/state
+        assert_state_file_schema_v1 /run/airplanes/feed/state
+        assert_state_file_schema_v1 /run/airplanes/mlat/state
         assert_uuid_stable_across_reboot
 
         if is_overlay_managed_image; then
@@ -1041,7 +1048,7 @@ case "$phase" in
             post_reboot_snap="$STATE_DIR/snapshot-mtimes-post-reboot"
             stat -c '%Y %n' \
                 "$(feed_binary_path)" \
-                /usr/local/share/airplanes/venv/bin/mlat-client \
+                /opt/airplanes/current/share/airplanes/venv/bin/mlat-client \
                 > "$post_reboot_snap"
             if ! diff -q "$STATE_DIR/snapshot-mtimes" "$post_reboot_snap" >/dev/null; then
                 echo "pre-reboot snapshot:" >&2

--- a/test/image-build-mode.sh
+++ b/test/image-build-mode.sh
@@ -56,7 +56,7 @@ printf '%s\n' "mlat fixture" > "$MLAT_REPO/README"
 make_repo "$MLAT_REPO" master
 
 cp -a "$UPDATE_DIR/skeleton/." "$ROOT_DIR/"
-mkdir -p "$ROOT_DIR/boot" "$ROOT_DIR/etc/default" "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/usr/bin"
+mkdir -p "$ROOT_DIR/boot" "$ROOT_DIR/etc/default" "$ROOT_DIR/etc/airplanes"
 cp "$UPDATE_DIR/boot-configs/airplanes-config.txt" "$ROOT_DIR/boot/airplanes-config.txt"
 cp "$UPDATE_DIR/boot-configs/airplanes-env" "$ROOT_DIR/boot/airplanes-env"
 if [[ -f "$UPDATE_DIR/boot-configs/airplanes-978env" ]]; then
@@ -83,7 +83,13 @@ sed -i \
 printf '%s\n' 'VERSION_ID="13"' > "$ROOT_DIR/etc/os-release"
 ln -sfn /boot/airplanes-config.txt "$ROOT_DIR/etc/default/airplanes"
 
-cat > "$ROOT_DIR/usr/bin/airplanes-feeder" <<'SH'
+# Image detection is via the /etc/airplanes/image-install marker; the baked
+# feed binary lives at /opt/airplanes/current/bin/feed-airplanes. update.sh's
+# build-mode image branch checks the marker for detection and requires the
+# binary to be executable before wiring the daemon.
+: > "$ROOT_DIR/etc/airplanes/image-install"
+mkdir -p "$ROOT_DIR/opt/airplanes/current/bin"
+cat > "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-V" ]]; then
     exit 0
@@ -91,7 +97,7 @@ fi
 printf '%s\n' "$*" > "${AIRPLANES_RUNTIME_ARG_LOG:?}"
 exit 0
 SH
-chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+chmod +x "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes"
 
 # Simulate an upgraded install where the legacy second-mlat.sh helper
 # (deleted in PR #30) has left an enabled airplanes-mlat2.service unit
@@ -110,8 +116,9 @@ SH
 ln -s ../../airplanes-mlat2.service \
     "$ROOT_DIR/etc/systemd/system/default.target.wants/airplanes-mlat2.service"
 
-IPATH="$ROOT_DIR/usr/local/share/airplanes"
-mkdir -p "$IPATH/venv/bin"
+IPATH="$ROOT_DIR/opt/airplanes/current/share/airplanes"
+STATE="$ROOT_DIR/var/lib/airplanes/runtime"
+mkdir -p "$IPATH/venv/bin" "$STATE"
 cp "$FEED_REPO/update.sh" "$IPATH/update.sh"
 # Simulate an upgraded install that still has the legacy second-mlat.sh
 # helper left over from an older feed release; update.sh must sweep it
@@ -129,7 +136,10 @@ cat > "$IPATH/venv/bin/mlat-client" <<'SH'
 exit 0
 SH
 chmod +x "$IPATH/venv/bin/mlat-client"
-git -C "$MLAT_REPO" rev-parse HEAD > "$IPATH/mlat_version"
+# The mlat_version stamp lives under mutable STATE (/var/lib/airplanes/runtime),
+# which is the ipath argument update.sh passes to install_mlat_client; the venv
+# itself stays under $IPATH. Seeding both lets the skip path short-circuit.
+git -C "$MLAT_REPO" rev-parse HEAD > "$STATE/mlat_version"
 
 cat > "$STUB_DIR/apt-get" <<'SH'
 #!/usr/bin/env bash
@@ -210,9 +220,9 @@ test -f "$ROOT_DIR/boot/airplanes-config.txt"
 test -f "$ROOT_DIR/boot/airplanes-env"
 test -f "$ROOT_DIR/etc/airplanes/feeder-id"
 grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' "$ROOT_DIR/etc/airplanes/feeder-id"
-test -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
-test "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id"
-test -x "$ROOT_DIR/usr/bin/airplanes-feeder"
+test -L "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
+test "$(readlink "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id"
+test -x "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes"
 test -x "$ROOT_DIR/usr/local/bin/apl-feed"
 test -f "$IPATH/apl-feed/common.sh"
 test -f "$IPATH/airplanes-feed.sh"
@@ -231,8 +241,8 @@ test ! -e "$ROOT_DIR/etc/airplanes/feed.env"
 test -L "$ROOT_DIR/etc/default/airplanes"
 test "$(readlink "$ROOT_DIR/etc/default/airplanes")" = "/boot/airplanes-config.txt"
 
-grep -q 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh' "$ROOT_DIR/etc/systemd/system/airplanes-feed.service"
-grep -q 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh' "$ROOT_DIR/etc/systemd/system/airplanes-mlat.service"
+grep -q 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-feed.sh' "$ROOT_DIR/etc/systemd/system/airplanes-feed.service"
+grep -q 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-mlat.sh' "$ROOT_DIR/etc/systemd/system/airplanes-mlat.service"
 grep -qE '^After=.*airplanes-first-run.service' "$ROOT_DIR/etc/systemd/system/airplanes-feed.service"
 grep -qE '^After=.*airplanes-first-run.service' "$ROOT_DIR/etc/systemd/system/airplanes-mlat.service"
 grep -qE '^User=airplanes-feed$' "$ROOT_DIR/etc/systemd/system/airplanes-feed.service"

--- a/test/mounted-image-upgrade.sh
+++ b/test/mounted-image-upgrade.sh
@@ -315,8 +315,9 @@ prepare_mounted_image() {
     # branch in main() that asserts feed/update.sh's overlay guard refuses
     # to run against a runtime-overlay-managed image; it does not need
     # any of the seeding below.
-    local ipath mlat_version
-    ipath="$ROOT_MNT/usr/local/share/airplanes"
+    local ipath state_dir mlat_version
+    ipath="$ROOT_MNT/opt/airplanes/current/share/airplanes"
+    state_dir="$ROOT_MNT/var/lib/airplanes/runtime"
 
     [[ -f "$ROOT_MNT/etc/systemd/system/airplanes-first-run.service" ]] \
         || fail "release image lacks airplanes-first-run.service"
@@ -341,8 +342,12 @@ prepare_mounted_image() {
 exit 0
 SH
     chmod +x "$ipath/venv/bin/mlat-client"
+    # The mlat_version stamp is mutable build state under $STATE, not alongside
+    # the read-only payload in the share/ prefix. Seed it there so update.sh's
+    # skip-build check matches and the chroot run doesn't rebuild the venv.
+    mkdir -p "$state_dir"
     mlat_version="$(git --git-dir="$MLAT_BARE" rev-parse refs/heads/master)"
-    printf '%s\n' "$mlat_version" > "$ipath/mlat_version"
+    printf '%s\n' "$mlat_version" > "$state_dir/mlat_version"
 }
 
 # Confirm the new image ships the runtime-overlay marker that feed's
@@ -416,7 +421,7 @@ run_runtime_probe() {
     AIRPLANES_ROOT="$ROOT_MNT" \
     AIRPLANES_FEED_BIN="$STUB_DIR/feed-bin-stub" \
     AIRPLANES_RUNTIME_ARG_LOG="$RUNTIME_ARG_LOG" \
-        bash "$ROOT_MNT/usr/local/share/airplanes/airplanes-feed.sh"
+        bash "$ROOT_MNT/opt/airplanes/current/share/airplanes/airplanes-feed.sh"
 }
 
 assert_contains() {
@@ -451,15 +456,18 @@ assert_updated_image_contracts() {
     # Legacy-contract post-update assertions only. New-contract bails on the
     # overlay guard before any update happens; there is no post-update state
     # to inspect there.
-    local ipath="$ROOT_MNT/usr/local/share/airplanes"
+    local ipath="$ROOT_MNT/opt/airplanes/current/share/airplanes"
 
     [[ -f "$FEED_BOOT_DIR/airplanes-config.txt" ]] || fail "missing boot config"
     [[ -f "$FEED_BOOT_DIR/airplanes-env" ]] || fail "missing boot env"
     assert_valid_uuid_file "$ROOT_MNT/etc/airplanes/feeder-id"
-    assert_symlink_target "$ipath/airplanes-uuid" '../../../../etc/airplanes/feeder-id'
+    # The legacy-UUID compat symlink lives under $STATE, not the payload prefix.
+    # The relative target still resolves to /etc/airplanes/feeder-id (both the
+    # old and new symlink locations sit four directories below /).
+    assert_symlink_target "$ROOT_MNT/var/lib/airplanes/runtime/airplanes-uuid" '../../../../etc/airplanes/feeder-id'
 
     [[ -x "$ROOT_MNT/usr/bin/airplanes-feeder" ]] || fail "missing image feed binary"
-    [[ ! -e "$ipath/feed-airplanes" ]] || fail "legacy image should use image feed binary"
+    [[ ! -e "$ROOT_MNT/opt/airplanes/current/bin/feed-airplanes" ]] || fail "legacy image should use image feed binary"
 
     [[ -x "$ROOT_MNT/usr/local/bin/apl-feed" ]] || fail "missing apl-feed command"
     [[ -f "$ipath/update.sh" ]] || fail "missing installed update.sh"
@@ -475,11 +483,11 @@ assert_updated_image_contracts() {
     [[ "$(readlink "$ROOT_MNT/etc/default/airplanes")" == "/boot/airplanes-config.txt" ]] \
         || fail "/etc/default/airplanes does not point at /boot/airplanes-config.txt"
 
-    assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh'
+    assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-feed.sh'
     grep -qE '^After=.*airplanes-first-run.service' "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" \
         || fail "airplanes-feed.service missing After=airplanes-first-run.service"
     assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-feed.service" 'User=airplanes-feed'
-    assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh'
+    assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-mlat.sh'
     grep -qE '^After=.*airplanes-first-run.service' "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" \
         || fail "airplanes-mlat.service missing After=airplanes-first-run.service"
     assert_contains "$ROOT_MNT/etc/systemd/system/airplanes-mlat.service" 'User=airplanes-feed'

--- a/test/script-install.sh
+++ b/test/script-install.sh
@@ -142,18 +142,18 @@ else
 fi
 
 # Post-install assertions (catch install-only regressions before update repairs them).
-test -d /usr/local/share/airplanes/git
+test -d /var/lib/airplanes/runtime/git
 test -x /usr/local/bin/apl-feed
 test -f /etc/airplanes/feed.env
 
-bash /usr/local/share/airplanes/git/update.sh
+bash /var/lib/airplanes/runtime/git/update.sh
 
 # Post-update assertions.
 test -f /etc/airplanes/feeder-id
-test -L /usr/local/share/airplanes/airplanes-uuid
-test -f /usr/local/share/airplanes/apl-feed/common.sh
-test -f /lib/systemd/system/airplanes-feed.service
-test -f /lib/systemd/system/airplanes-mlat.service
+test -L /var/lib/airplanes/runtime/airplanes-uuid
+test -f /opt/airplanes/current/share/airplanes/apl-feed/common.sh
+test -f /etc/systemd/system/airplanes-feed.service
+test -f /etc/systemd/system/airplanes-mlat.service
 test -f /etc/airplanes/feeder-claim-secret
 test "$(readlink /etc/default/airplanes)" = "/etc/airplanes/feed.env"
 grep -q 'systemctl restart airplanes-feed' /tmp/systemctl.log
@@ -162,4 +162,4 @@ grep -q 'systemctl restart airplanes-feed' /tmp/systemctl.log
 # opt in via `apl-feed 978 enable` (CLI) or webconfig (image), and a fresh
 # install leaves the connector unwired.
 ! grep -q 'UAT_INPUT="127.0.0.1:30978"' /etc/airplanes/feed.env
-! grep -q 'UAT_INPUT="127.0.0.1:30978"' /usr/local/share/airplanes/airplanes-feed.sh
+! grep -q 'UAT_INPUT="127.0.0.1:30978"' /opt/airplanes/current/share/airplanes/airplanes-feed.sh

--- a/test/script-upgrade.sh
+++ b/test/script-upgrade.sh
@@ -14,12 +14,12 @@ dump_diag() {
         cp -a /etc/default/airplanes "$DIAG_DIR/etc-default-airplanes" 2>/dev/null || true
     fi
     cp /tmp/systemctl.log "$DIAG_DIR/systemctl.log" 2>/dev/null || true
-    cp /usr/local/share/airplanes/lastlog "$DIAG_DIR/lastlog" 2>/dev/null || true
-    cp -a /run/airplanes-feed "$DIAG_DIR/run-airplanes-feed" 2>/dev/null || true
-    cp -a /run/airplanes-mlat "$DIAG_DIR/run-airplanes-mlat" 2>/dev/null || true
-    git -C /usr/local/share/airplanes/git remote -v > "$DIAG_DIR/git-remote.txt" 2>&1 || true
-    git -C /usr/local/share/airplanes/git rev-parse HEAD > "$DIAG_DIR/git-head.txt" 2>&1 || true
-    ls -la /lib/systemd/system/ > "$DIAG_DIR/systemd-units.txt" 2>&1 || true
+    cp /var/lib/airplanes/runtime/lastlog "$DIAG_DIR/lastlog" 2>/dev/null || true
+    cp -a /run/airplanes/feed "$DIAG_DIR/run-airplanes-feed" 2>/dev/null || true
+    cp -a /run/airplanes/mlat "$DIAG_DIR/run-airplanes-mlat" 2>/dev/null || true
+    git -C /var/lib/airplanes/runtime/git remote -v > "$DIAG_DIR/git-remote.txt" 2>&1 || true
+    git -C /var/lib/airplanes/runtime/git rev-parse HEAD > "$DIAG_DIR/git-head.txt" 2>&1 || true
+    ls -la /etc/systemd/system/ > "$DIAG_DIR/systemd-units.txt" 2>&1 || true
 }
 
 on_exit() {
@@ -163,20 +163,20 @@ export AIRPLANES_PACKAGE_MANAGER=apt
 # the mount, then redirect the in-update.sh re-fetch at the same mount so
 # the pin holds end-to-end.
 echo "=== Phase 1: install source from $AIRPLANES_SOURCE_REPO ==="
-mkdir -p /usr/local/share/airplanes
-git clone --branch main "$AIRPLANES_SOURCE_REPO" /usr/local/share/airplanes/git
+mkdir -p /var/lib/airplanes/runtime
+git clone --branch main "$AIRPLANES_SOURCE_REPO" /var/lib/airplanes/runtime/git
 
 sed -i \
     -e 's|^REPO=".*airplanes-live/feed\.git"$|REPO="'"$AIRPLANES_SOURCE_REPO"'"|' \
-    /usr/local/share/airplanes/git/update.sh
+    /var/lib/airplanes/runtime/git/update.sh
 
-bash /usr/local/share/airplanes/git/setup.sh
+bash /var/lib/airplanes/runtime/git/setup.sh
 
 # Post-install sanity. Only assert artifacts the source install is guaranteed
 # to produce — apl-feed CLI, feed.env-only layout, etc. are dev-branch
 # additions that predate this test. Phase 2's detect_source_env picks the
 # right config file regardless of which shape the source produced.
-test -d /usr/local/share/airplanes/git
+test -d /var/lib/airplanes/runtime/git
 
 # ---- Phase 2: seed USER= state ----
 # Force the migration code path: drop any MLAT_* keys the source install may
@@ -267,13 +267,13 @@ env -i bash -c '
 '
 
 grep -q 'feed\.airplanes\.live,30004,beast_reduce_plus_out,feed2\.airplanes\.live,64004' \
-    /usr/local/share/airplanes/airplanes-feed.sh \
+    /opt/airplanes/current/share/airplanes/airplanes-feed.sh \
     || { echo "FAIL: failover TARGET literal missing in installed airplanes-feed.sh default" >&2; exit 1; }
 
-grep -q 'feed\.airplanes\.live:31090' /usr/local/share/airplanes/airplanes-mlat.sh \
+grep -q 'feed\.airplanes\.live:31090' /opt/airplanes/current/share/airplanes/airplanes-mlat.sh \
     || { echo "FAIL: MLATSERVER literal missing in installed airplanes-mlat.sh default" >&2; exit 1; }
 
-grep -rq '/api/feeders/secret' /usr/local/share/airplanes/ \
+grep -rq '/api/feeders/secret' /opt/airplanes/current/share/airplanes/ \
     || { echo "FAIL: /api/feeders/secret reference missing" >&2; exit 1; }
 
 # 4C. Daemon state-file pattern
@@ -285,16 +285,16 @@ cp /etc/airplanes/feed.env /tmp/feed.env.snapshot
 # than passing inline env (which would be wiped by the unset).
 sed -i '/^MLAT_ENABLED=/d' /etc/airplanes/feed.env
 echo 'MLAT_ENABLED=false' >> /etc/airplanes/feed.env
-mkdir -p /run/airplanes-mlat
-timeout 3 bash /usr/local/share/airplanes/airplanes-mlat.sh || true
+mkdir -p /run/airplanes/mlat
+timeout 3 bash /opt/airplanes/current/share/airplanes/airplanes-mlat.sh || true
 
-[[ -f /run/airplanes-mlat/state ]] \
-    || { echo "FAIL: /run/airplanes-mlat/state not written" >&2; exit 1; }
-grep -q '^schema_version=1$'          /run/airplanes-mlat/state \
+[[ -f /run/airplanes/mlat/state ]] \
+    || { echo "FAIL: /run/airplanes/mlat/state not written" >&2; exit 1; }
+grep -q '^schema_version=1$'          /run/airplanes/mlat/state \
     || { echo "FAIL: airplanes-mlat state missing schema_version=1" >&2; exit 1; }
-grep -q '^state=disabled$'            /run/airplanes-mlat/state \
+grep -q '^state=disabled$'            /run/airplanes/mlat/state \
     || { echo "FAIL: airplanes-mlat state not 'disabled'" >&2; exit 1; }
-grep -q '^reason=mlat_enabled_false$' /run/airplanes-mlat/state \
+grep -q '^reason=mlat_enabled_false$' /run/airplanes/mlat/state \
     || { echo "FAIL: airplanes-mlat reason not 'mlat_enabled_false' (classifier order regression?)" >&2; exit 1; }
 
 # Restore for C.2
@@ -302,15 +302,15 @@ cp /tmp/feed.env.snapshot /etc/airplanes/feed.env
 
 # C.2 — airplanes-feed in enabled state. Stub the feed binary so exec succeeds
 # quickly and the script terminates (otherwise we'd block on a real binary).
-mkdir -p /run/airplanes-feed
+mkdir -p /run/airplanes/feed
 AIRPLANES_FEED_BIN=/bin/true \
-    timeout 3 bash /usr/local/share/airplanes/airplanes-feed.sh || true
+    timeout 3 bash /opt/airplanes/current/share/airplanes/airplanes-feed.sh || true
 
-[[ -f /run/airplanes-feed/state ]] \
-    || { echo "FAIL: /run/airplanes-feed/state not written" >&2; exit 1; }
-grep -q '^schema_version=1$' /run/airplanes-feed/state \
+[[ -f /run/airplanes/feed/state ]] \
+    || { echo "FAIL: /run/airplanes/feed/state not written" >&2; exit 1; }
+grep -q '^schema_version=1$' /run/airplanes/feed/state \
     || { echo "FAIL: airplanes-feed state missing schema_version=1" >&2; exit 1; }
-grep -q '^state=enabled$'    /run/airplanes-feed/state \
+grep -q '^state=enabled$'    /run/airplanes/feed/state \
     || { echo "FAIL: airplanes-feed state not 'enabled'" >&2; exit 1; }
 
 # ---- Phase 5: disabled-USER second subcase ----
@@ -330,7 +330,7 @@ echo 'USER=0' >> /etc/airplanes/feed.env
 # branch (which would self-replace away from candidate).
 AIRPLANES_FEED_REPO="$AIRPLANES_CANDIDATE_REPO" \
 AIRPLANES_FEED_BRANCH=dev \
-    bash /usr/local/share/airplanes/git/update.sh
+    bash /var/lib/airplanes/runtime/git/update.sh
 
 env -i bash -c '
     set -euo pipefail

--- a/test/script-upgrade.sh
+++ b/test/script-upgrade.sh
@@ -163,20 +163,23 @@ export AIRPLANES_PACKAGE_MANAGER=apt
 # the mount, then redirect the in-update.sh re-fetch at the same mount so
 # the pin holds end-to-end.
 echo "=== Phase 1: install source from $AIRPLANES_SOURCE_REPO ==="
-mkdir -p /var/lib/airplanes/runtime
-git clone --branch main "$AIRPLANES_SOURCE_REPO" /var/lib/airplanes/runtime/git
+# Phase 1 installs origin/main (the PRE-FHS layout), so it must use main's own
+# old paths: main's setup.sh/update.sh hardcode /usr/local/share/airplanes/git.
+# The candidate (Phase 3) installs the new /opt layout and migrates this away.
+mkdir -p /usr/local/share/airplanes
+git clone --branch main "$AIRPLANES_SOURCE_REPO" /usr/local/share/airplanes/git
 
 sed -i \
     -e 's|^REPO=".*airplanes-live/feed\.git"$|REPO="'"$AIRPLANES_SOURCE_REPO"'"|' \
-    /var/lib/airplanes/runtime/git/update.sh
+    /usr/local/share/airplanes/git/update.sh
 
-bash /var/lib/airplanes/runtime/git/setup.sh
+bash /usr/local/share/airplanes/git/setup.sh
 
 # Post-install sanity. Only assert artifacts the source install is guaranteed
 # to produce — apl-feed CLI, feed.env-only layout, etc. are dev-branch
 # additions that predate this test. Phase 2's detect_source_env picks the
 # right config file regardless of which shape the source produced.
-test -d /var/lib/airplanes/runtime/git
+test -d /usr/local/share/airplanes/git
 
 # ---- Phase 2: seed USER= state ----
 # Force the migration code path: drop any MLAT_* keys the source install may

--- a/test/test_airplanes_diagnostics.bats
+++ b/test/test_airplanes_diagnostics.bats
@@ -128,7 +128,8 @@ SH
     # routes /proc/uptime → $ROOT_DIR/proc/uptime, etc.
     mkdir -p "$ROOT_DIR/proc" "$ROOT_DIR/sys/class/net/eth0" \
              "$ROOT_DIR/sys/class/thermal/thermal_zone0" "$ROOT_DIR/etc/airplanes" \
-             "$ROOT_DIR/usr/local/share/airplanes"
+             "$ROOT_DIR/opt/airplanes/current/share/airplanes" \
+             "$ROOT_DIR/var/lib/airplanes/runtime"
     printf '12345.67 9999.99\n' > "$ROOT_DIR/proc/uptime"
     printf '0.42 0.38 0.41 1/100 12345\n' > "$ROOT_DIR/proc/loadavg"
     cat > "$ROOT_DIR/proc/meminfo" <<'MEM'
@@ -147,9 +148,9 @@ VERSION_ID="12"
 VERSION="12 (bookworm)"
 ID=debian
 OSR
-    printf '0.4.2\n' > "$ROOT_DIR/usr/local/share/airplanes/.version"
-    printf '0a1b2c3d4e5f6a7b8c9d\n' > "$ROOT_DIR/usr/local/share/airplanes/readsb_version"
-    printf 'feedcafe00112233\n' > "$ROOT_DIR/usr/local/share/airplanes/mlat_version"
+    printf '0.4.2\n' > "$ROOT_DIR/opt/airplanes/current/share/airplanes/.version"
+    printf '0a1b2c3d4e5f6a7b8c9d\n' > "$ROOT_DIR/var/lib/airplanes/runtime/readsb_version"
+    printf 'feedcafe00112233\n' > "$ROOT_DIR/var/lib/airplanes/runtime/mlat_version"
 
     # Claim state
     printf '11111111-2222-3333-4444-555555555555\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
@@ -158,9 +159,9 @@ OSR
     chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
     printf 'REPORT_STATUS=true\n' > "$ROOT_DIR/etc/airplanes/feed.env"
 
-    LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-last-success"
+    LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes/diagnostics/diagnostics-last-success"
     mkdir -p "$(dirname "$LAST_SUCCESS")"
-    INTENT_ACK="$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-intent-acked"
+    INTENT_ACK="$ROOT_DIR/var/lib/airplanes/diagnostics/diagnostics-intent-acked"
 }
 
 teardown() {
@@ -838,7 +839,7 @@ _write_state_file() {
 }
 
 @test "POST body service entry carries state=enabled,reason=ok from state file" {
-    _write_state_file /run/airplanes-mlat/state enabled ok
+    _write_state_file /run/airplanes/mlat/state enabled ok
     run_script
     [ "$status" -eq 0 ]
     run jq -er '.services[] | select(.name=="airplanes-mlat") | .state' "$BODY_LOG"
@@ -848,7 +849,7 @@ _write_state_file() {
 }
 
 @test "POST body service entry carries state=disabled,reason=mlat_enabled_false" {
-    _write_state_file /run/airplanes-mlat/state disabled mlat_enabled_false
+    _write_state_file /run/airplanes/mlat/state disabled mlat_enabled_false
     run_script
     [ "$status" -eq 0 ]
     run jq -er '.services[] | select(.name=="airplanes-mlat") | .state' "$BODY_LOG"
@@ -871,7 +872,7 @@ esac
 exit 0
 SH
     chmod +x "$STUB_DIR/systemctl"
-    _write_state_file /run/dump978-fa/state disabled no_hardware
+    _write_state_file /run/airplanes/dump978-fa/state disabled no_hardware
     run_script
     [ "$status" -eq 0 ]
     run jq -er '.services[] | select(.name=="dump978-fa") | .state' "$BODY_LOG"
@@ -915,7 +916,7 @@ SH
 }
 
 @test "POST body omits state/reason when schema_version is wrong" {
-    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    local rooted="$ROOT_DIR/run/airplanes/mlat/state"
     mkdir -p "$(dirname "$rooted")"
     {
         printf 'schema_version=2\n'
@@ -929,7 +930,7 @@ SH
 }
 
 @test "POST body omits state/reason on corrupt state file (no schema_version)" {
-    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    local rooted="$ROOT_DIR/run/airplanes/mlat/state"
     mkdir -p "$(dirname "$rooted")"
     {
         printf 'state=disabled\n'
@@ -968,7 +969,7 @@ esac
 exit 0
 SH
     chmod +x "$STUB_DIR/systemctl"
-    _write_state_file /run/airplanes-978/state enabled peer_no_hardware
+    _write_state_file /run/airplanes/978/state enabled peer_no_hardware
     run_script
     [ "$status" -eq 0 ]
     run jq -er '.services[] | select(.name=="airplanes-978") | .state' "$BODY_LOG"
@@ -981,7 +982,7 @@ SH
     # Regression guard against a future refactor that hardcodes /run/... —
     # the test seam roots everything under $ROOT_DIR, and the script must
     # route the state file path through root_path() so the seam works.
-    _write_state_file /run/airplanes-mlat/state disabled geo_not_configured
+    _write_state_file /run/airplanes/mlat/state disabled geo_not_configured
     run_script
     [ "$status" -eq 0 ]
     run jq -er '.services[] | select(.name=="airplanes-mlat") | .reason' "$BODY_LOG"
@@ -992,7 +993,7 @@ SH
     # Schema-valid but orphan: only `state=` present. The publisher must
     # refuse to send half a pair — that would let the dashboard see
     # ``state=disabled`` with no reason and fall through to the catchall.
-    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    local rooted="$ROOT_DIR/run/airplanes/mlat/state"
     mkdir -p "$(dirname "$rooted")"
     {
         printf 'schema_version=1\n'
@@ -1009,7 +1010,7 @@ SH
 @test "POST body omits state/reason when state file has reason but no state" {
     # Mirror of the above: orphan reason. All-or-nothing publish keeps the
     # server free of partial pairs even on schema-valid-but-corrupt files.
-    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    local rooted="$ROOT_DIR/run/airplanes/mlat/state"
     mkdir -p "$(dirname "$rooted")"
     {
         printf 'schema_version=1\n'
@@ -1026,7 +1027,7 @@ SH
 @test "POST body omits state/reason when state file value contains CR" {
     # state-writer.sh promises no CR in values; a CR in the on-disk file
     # is a corruption signal and must invalidate the whole record.
-    local rooted="$ROOT_DIR/run/airplanes-mlat/state"
+    local rooted="$ROOT_DIR/run/airplanes/mlat/state"
     mkdir -p "$(dirname "$rooted")"
     {
         printf 'schema_version=1\n'
@@ -1058,11 +1059,11 @@ SH
     # timer + the /api/feeders/stats endpoint). Diagnostics must POST only its
     # device-health payload, never the retired reception endpoint — even with
     # forwarder JSON present on disk.
-    mkdir -p "$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$ROOT_DIR/run/airplanes/feed"
     printf '{"now": %s, "aircraft": []}\n' "$(date +%s)" \
-        > "$ROOT_DIR/run/airplanes-feed/aircraft.json"
+        > "$ROOT_DIR/run/airplanes/feed/aircraft.json"
     printf '{"total": {"max_distance": 0}}\n' \
-        > "$ROOT_DIR/run/airplanes-feed/stats.json"
+        > "$ROOT_DIR/run/airplanes/feed/stats.json"
     run_script
     [ "$status" -eq 0 ]
     grep -q -- '/api/feeders/diagnostics' "$COMMAND_LOG"

--- a/test/test_airplanes_stats.bats
+++ b/test/test_airplanes_stats.bats
@@ -13,7 +13,7 @@ setup() {
     COMMAND_LOG="$ROOT_DIR/cmd.log"
     BODY_LOG="$ROOT_DIR/body.log"
     HEADER_LOG="$ROOT_DIR/header.log"
-    mkdir -p "$STUB_DIR" "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$STUB_DIR" "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/run/airplanes/feed"
 
     # curl stub: records argv, dumps the --config file (bearer header) to
     # HEADER_LOG, and GUNZIPS the uploaded body (post_gzip_bearer sends
@@ -59,7 +59,7 @@ teardown() {
 # Seed fresh, valid forwarder JSON (aircraft + stats). $1 overrides aircraft.now.
 _seed_forwarder() {
     local now="${1:-$(date +%s)}"
-    local dir="$ROOT_DIR/run/airplanes-feed"
+    local dir="$ROOT_DIR/run/airplanes/feed"
     cat > "$dir/aircraft.json" <<EOF
 {"now": $now, "messages": 1234, "aircraft": [{"hex":"abc123","rssi":-12.3,"lat":52.5,"lon":13.4}]}
 EOF
@@ -69,7 +69,7 @@ EOF
 }
 
 _seed_outline() {
-    cat > "$ROOT_DIR/run/airplanes-feed/outline.json" <<'EOF'
+    cat > "$ROOT_DIR/run/airplanes/feed/outline.json" <<'EOF'
 {"actualRange": {"last24h": {"points": [[52.5, 13.4], [52.6, 13.5], [52.4, 13.3]]}}}
 EOF
 }
@@ -130,7 +130,7 @@ _posted() { grep -q -- '/api/feeders/stats' "$COMMAND_LOG"; }
 
 @test "outline present but truncated → outline omitted, core still sent" {
     _seed_forwarder
-    printf '{ truncated outline' > "$ROOT_DIR/run/airplanes-feed/outline.json"
+    printf '{ truncated outline' > "$ROOT_DIR/run/airplanes/feed/outline.json"
     run_script
     [ "$status" -eq 0 ]
     _posted
@@ -140,7 +140,7 @@ _posted() { grep -q -- '/api/feeders/stats' "$COMMAND_LOG"; }
 
 @test "non-object core doc (array) → no POST, exit 0" {
     _seed_forwarder
-    printf '[1,2,3]\n' > "$ROOT_DIR/run/airplanes-feed/stats.json"
+    printf '[1,2,3]\n' > "$ROOT_DIR/run/airplanes/feed/stats.json"
     run_script
     [ "$status" -eq 0 ]
     if _posted; then return 1; fi
@@ -150,7 +150,7 @@ _posted() { grep -q -- '/api/feeders/stats' "$COMMAND_LOG"; }
     # A half-rewritten readsb file can concatenate two objects. validate_doc must
     # reject the stream rather than upload only the first object.
     _seed_forwarder
-    printf '{"a":1}{"b":2}\n' > "$ROOT_DIR/run/airplanes-feed/stats.json"
+    printf '{"a":1}{"b":2}\n' > "$ROOT_DIR/run/airplanes/feed/stats.json"
     run_script
     [ "$status" -eq 0 ]
     if _posted; then return 1; fi
@@ -167,10 +167,10 @@ _posted() { grep -q -- '/api/feeders/stats' "$COMMAND_LOG"; }
 }
 
 @test "missing aircraft.now → no POST, exit 0" {
-    cat > "$ROOT_DIR/run/airplanes-feed/aircraft.json" <<'EOF'
+    cat > "$ROOT_DIR/run/airplanes/feed/aircraft.json" <<'EOF'
 {"messages": 5, "aircraft": []}
 EOF
-    cat > "$ROOT_DIR/run/airplanes-feed/stats.json" <<'EOF'
+    cat > "$ROOT_DIR/run/airplanes/feed/stats.json" <<'EOF'
 {"total": {"max_distance": 0}}
 EOF
     run_script
@@ -180,10 +180,10 @@ EOF
 }
 
 @test "non-numeric aircraft.now → no POST, exit 0" {
-    cat > "$ROOT_DIR/run/airplanes-feed/aircraft.json" <<'EOF'
+    cat > "$ROOT_DIR/run/airplanes/feed/aircraft.json" <<'EOF'
 {"now": "soon", "aircraft": []}
 EOF
-    cat > "$ROOT_DIR/run/airplanes-feed/stats.json" <<'EOF'
+    cat > "$ROOT_DIR/run/airplanes/feed/stats.json" <<'EOF'
 {"total": {"max_distance": 0}}
 EOF
     run_script
@@ -229,7 +229,7 @@ EOF
 }
 
 @test "forwarder JSON entirely absent → no POST, exit 0" {
-    # No _seed_forwarder — /run/airplanes-feed is empty.
+    # No _seed_forwarder — /run/airplanes/feed is empty.
     run_script
     [ "$status" -eq 0 ]
     if _posted; then return 1; fi
@@ -242,7 +242,7 @@ EOF
     _seed_forwarder
     # A large outline pushes the raw envelope over the test cap; the core-only
     # envelope is well under it, so the uploader drops outline and still POSTs.
-    python3 - "$ROOT_DIR/run/airplanes-feed/outline.json" <<'PY'
+    python3 - "$ROOT_DIR/run/airplanes/feed/outline.json" <<'PY'
 import json, sys
 pts = [[round(52 + i*1e-4, 4), round(13 + i*1e-4, 4)] for i in range(400)]
 json.dump({"actualRange": {"last24h": {"points": pts}}}, open(sys.argv[1], "w"))

--- a/test/test_apl_feed_backup.bats
+++ b/test/test_apl_feed_backup.bats
@@ -14,7 +14,7 @@ setup() {
     TMPDIR="$ROOT_DIR/tmp"
     mkdir -p "$TMPDIR" \
         "$ROOT_DIR/etc/airplanes" \
-        "$ROOT_DIR/usr/local/share/airplanes" \
+        "$ROOT_DIR/var/lib/airplanes/runtime" \
         "$ROOT_DIR/boot"
     export TMPDIR
     APL_FEED_SECRET_OWNER="$(id -un)"

--- a/test/test_apl_feed_bridged_legacy_bootstrap.bats
+++ b/test/test_apl_feed_bridged_legacy_bootstrap.bats
@@ -2,8 +2,8 @@
 
 # End-to-end regression for the bridged-legacy bootstrap path:
 # `apl-feed mlat enable` / `apl-feed mlat disable` / `apl-feed 978 enable`
-# / `apl-feed 978 disable` on a box where /usr/bin/airplanes-feeder is
-# present, /boot/airplanes-config.txt is populated by the legacy PHP
+# / `apl-feed 978 disable` on a box where the /etc/airplanes/image-install
+# marker is present, /boot/airplanes-config.txt is populated by the legacy PHP
 # webconfig, and /etc/airplanes/feed.env does NOT yet exist. The writer
 # adapters call feed_env_ensure_canonical_for_write() before invoking
 # apl_feed_apply, which calls apl_feed_import_legacy_config to seed the
@@ -60,11 +60,10 @@ STUB
     PATH="$STUB_DIR:$PATH"
     export PATH
 
-    # Bridged-legacy shape: airplanes-feeder installed, no canonical
+    # Bridged-legacy shape: image-install marker present, no canonical
     # feed.env, legacy boot config carrying operational keys.
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot" "$ROOT_DIR/etc/airplanes"
-    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/boot" "$ROOT_DIR/etc/airplanes"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<EOF
 LATITUDE=52.5
 LONGITUDE=13.4
@@ -156,9 +155,8 @@ source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/configure-validators.sh"
 source "'"$BATS_TEST_DIRNAME"'/../scripts/lib/feed-env-keys.sh"
 source "'"$BATS_TEST_DIRNAME"'/../scripts/apl-feed/common.sh"
 ROOT='"$ROOT_DIR"'
-mkdir -p "$ROOT/usr/bin" "$ROOT/boot"
-: > "$ROOT/usr/bin/airplanes-feeder"
-chmod +x "$ROOT/usr/bin/airplanes-feeder"
+mkdir -p "$ROOT/etc/airplanes" "$ROOT/boot"
+: > "$ROOT/etc/airplanes/image-install"
 : > "$ROOT/boot/airplanes-config.txt"
 apl_feed_import_legacy_config() { return 1; }
 feed_env_ensure_canonical_for_write

--- a/test/test_apl_feed_cli.bats
+++ b/test/test_apl_feed_cli.bats
@@ -4,14 +4,14 @@ setup() {
     SCRIPT="$BATS_TEST_DIRNAME/../scripts/apl-feed.sh"
     CONTRACT="$BATS_TEST_DIRNAME/contracts/feeder-api-v1.json"
     ROOT_DIR="$(mktemp -d)"
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes" "$ROOT_DIR/etc/airplanes" \
-             "$ROOT_DIR/var/lib/airplanes-diagnostics"
+    mkdir -p "$ROOT_DIR/opt/airplanes/current/share/airplanes" "$ROOT_DIR/etc/airplanes" \
+             "$ROOT_DIR/var/lib/airplanes/diagnostics"
     echo "11111111-2222-3333-4444-555555555555" > "$ROOT_DIR/etc/airplanes/feeder-id"
     # Stage a fresh diagnostics-push timestamp so diagnostics_status_line
     # reads "ok" rather than the default "no successful push observed yet"
     # warn (the default-healthy fixture state assumes the timer has fired
     # at least once).
-    touch "$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-last-success"
+    touch "$ROOT_DIR/var/lib/airplanes/diagnostics/diagnostics-last-success"
     MOCK_PORT_FILE="$(mktemp)"
     MOCK_PID_FILE="$(mktemp)"
     # Mock servers append one "PATH<TAB>AUTH<TAB>BODY" line per POST here,
@@ -278,9 +278,8 @@ PY
 
 @test "top-level status reads image boot config and env" {
     rm -f "$ROOT_DIR/etc/airplanes/feeder-id"
-    mkdir -p "$ROOT_DIR/boot" "$ROOT_DIR/usr/bin"
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     echo "11111111-2222-3333-4444-555555555555" > "$ROOT_DIR/boot/airplanes-uuid"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
 USER="image-feeder"

--- a/test/test_apl_feed_common.bats
+++ b/test/test_apl_feed_common.bats
@@ -13,7 +13,7 @@ setup() {
     TMPDIR="$ROOT_DIR/tmp"
     mkdir -p "$TMPDIR" \
         "$ROOT_DIR/etc/airplanes" \
-        "$ROOT_DIR/usr/local/share/airplanes" \
+        "$ROOT_DIR/var/lib/airplanes/runtime" \
         "$ROOT_DIR/usr/bin" \
         "$ROOT_DIR/boot"
     export TMPDIR
@@ -94,7 +94,7 @@ run_strict() {
 
 @test "feed_env_path: returns boot config when image marker + boot config present" {
     : > "$ROOT_DIR/boot/airplanes-config.txt"
-    install -m 755 /dev/null "$ROOT_DIR/usr/bin/airplanes-feeder"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     run feed_env_path
     [ "$status" -eq 0 ]
     [ "$output" = "$ROOT_DIR/boot/airplanes-config.txt" ]
@@ -116,24 +116,11 @@ run_strict() {
 
 @test "feed_env_paths: two paths when image marker + boot config present" {
     : > "$ROOT_DIR/boot/airplanes-config.txt"
-    install -m 755 /dev/null "$ROOT_DIR/usr/bin/airplanes-feeder"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     run feed_env_paths
     [ "$status" -eq 0 ]
     [[ "$output" == *"$ROOT_DIR/boot/airplanes-config.txt"* ]]
     [[ "$output" == *"$ROOT_DIR/boot/airplanes-env"* ]]
-}
-
-# Documents drift with airplanes-feed.sh. airplanes-feed.sh treats
-# /etc/airplanes/image-install as an image marker (commit 269994c);
-# common.sh's feed_env_paths does not. With marker-only state (no
-# legacy /usr/bin/airplanes-feeder, no rootfs feed.env), feed_env_paths
-# falls through to the rootfs feed.env fallback.
-@test "feed_env_paths: image-install marker alone does NOT trigger image branch (drift)" {
-    : > "$ROOT_DIR/etc/airplanes/image-install"
-    : > "$ROOT_DIR/boot/airplanes-config.txt"
-    run feed_env_paths
-    [ "$status" -eq 0 ]
-    [ "$output" = "$ROOT_DIR/etc/airplanes/feed.env" ]
 }
 
 # --- feed_env_get ---
@@ -189,7 +176,7 @@ run_strict() {
 
 @test "feed_env_get: last value wins across multi-path output" {
     : > "$ROOT_DIR/boot/airplanes-config.txt"
-    install -m 755 /dev/null "$ROOT_DIR/usr/bin/airplanes-feeder"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     printf 'GAIN=42\n' > "$ROOT_DIR/boot/airplanes-config.txt"
     printf 'GAIN=99\n' > "$ROOT_DIR/boot/airplanes-env"
     run feed_env_get GAIN
@@ -341,14 +328,14 @@ run_strict() {
 
 @test "read_uuid: prefers /etc/airplanes/feeder-id" {
     printf '11111111-2222-3333-4444-555555555555\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
-    printf '99999999-2222-3333-4444-555555555555\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    printf '99999999-2222-3333-4444-555555555555\n' > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
     run read_uuid
     [ "$status" -eq 0 ]
     [ "$output" = '11111111-2222-3333-4444-555555555555' ]
 }
 
-@test "read_uuid: falls back to legacy /usr/local path" {
-    printf '22222222-2222-3333-4444-555555555555\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+@test "read_uuid: falls back to legacy /var/lib runtime path" {
+    printf '22222222-2222-3333-4444-555555555555\n' > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
     run read_uuid
     [ "$status" -eq 0 ]
     [ "$output" = '22222222-2222-3333-4444-555555555555' ]

--- a/test/test_apl_feed_config.bats
+++ b/test/test_apl_feed_config.bats
@@ -310,9 +310,8 @@ EOF
 
 @test "config show falls back to the legacy boot config like the daemons do" {
     rm -f "$ROOT_DIR/etc/airplanes/feed.env"
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
-    printf '#!/bin/true\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
 LATITUDE="50.00"
 MLAT_ENABLED="true"
@@ -388,9 +387,8 @@ EOF
 
 @test "config show legacy fallback works when airplanes-env is absent" {
     rm -f "$ROOT_DIR/etc/airplanes/feed.env"
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
-    printf '#!/bin/true\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
 LATITUDE="50.00"
 EOF

--- a/test/test_apl_feed_config_sync.bats
+++ b/test/test_apl_feed_config_sync.bats
@@ -69,10 +69,10 @@ STUB
         > "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
     chmod 0640 "$ROOT_DIR/etc/airplanes/feeder-claim-secret"
 
-    AIRPLANES_CONFIG_SYNC_LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes-config-sync/config-sync-last-success"
+    AIRPLANES_CONFIG_SYNC_LAST_SUCCESS="$ROOT_DIR/var/lib/airplanes/config-sync/config-sync-last-success"
     export AIRPLANES_CONFIG_SYNC_LAST_SUCCESS
 
-    AIRPLANES_CONFIG_SYNC_STATE="$ROOT_DIR/var/lib/airplanes-config-sync/state"
+    AIRPLANES_CONFIG_SYNC_STATE="$ROOT_DIR/var/lib/airplanes/config-sync/state"
     export AIRPLANES_CONFIG_SYNC_STATE
 }
 
@@ -728,7 +728,7 @@ EOF
     # ReadWritePaths= bind to a not-yet-existent /var/lib/airplanes fails
     # namespace setup (status=226/NAMESPACE) when config-sync.timer fires first.
     local unit="$REPO_ROOT/scripts/airplanes-config-sync.service"
-    run grep -qE '^StateDirectory=airplanes-config-sync$' "$unit"
+    run grep -qE '^StateDirectory=airplanes/config-sync$' "$unit"
     [ "$status" -eq 0 ]
     run grep -E '^ReadWritePaths=' "$unit"
     [ "$status" -eq 0 ]

--- a/test/test_apl_feed_id.bats
+++ b/test/test_apl_feed_id.bats
@@ -14,7 +14,7 @@ setup() {
     STUB_DIR="$ROOT_DIR/bin"
     mkdir -p "$TMPDIR" "$STUB_DIR" \
         "$ROOT_DIR/etc/airplanes" \
-        "$ROOT_DIR/usr/local/share/airplanes"
+        "$ROOT_DIR/var/lib/airplanes/runtime"
     export TMPDIR
     APL_FEED_SECRET_OWNER="$(id -un)"
     APL_FEED_SECRET_GROUP="$(id -gn)"

--- a/test/test_apl_feed_import.bats
+++ b/test/test_apl_feed_import.bats
@@ -234,16 +234,16 @@ EOF
 }
 
 @test "bridged-legacy box: writes canonical /etc/airplanes/feed.env, not boot config" {
-    # Reproduce the production shape that broke before: airplanes-feeder
-    # binary is present (bridge installed it), /etc/airplanes/feed.env
-    # does NOT exist yet, /boot/airplanes-config.txt does. feed_env_path()
+    # Reproduce the production shape that broke before: the
+    # /etc/airplanes/image-install marker is present (bridge laid it),
+    # /etc/airplanes/feed.env does NOT exist yet, /boot/airplanes-config.txt
+    # does. feed_env_path()
     # in this shape returns /boot/airplanes-config.txt as a status-reader
     # fallback — but the import writer must always target the canonical
     # path so the new daemons get a real feed.env to source.
     rm -rf "$ROOT_DIR/etc/airplanes"
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
-    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
 
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<EOF
 LATITUDE=52.5

--- a/test/test_apl_feed_mlat.bats
+++ b/test/test_apl_feed_mlat.bats
@@ -41,7 +41,7 @@ case "\$1" in
     is-active) echo active ;;
     # Ownership gate in the apply lib reads `systemctl cat` output and
     # only restarts units that ExecStart our wrappers.
-    cat) printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\${@: -1}" ;;
+    cat) printf 'ExecStart=/opt/airplanes/current/share/airplanes/%s.sh\n' "\${@: -1}" ;;
 esac
 exit 0
 STUB
@@ -670,15 +670,14 @@ EOF
 }
 
 @test "bridged-legacy: _mlat_apply targets canonical feed.env, not boot config" {
-    # Reproduce the bridged-legacy reader-fallback shape: airplanes-feeder
-    # is installed, /boot/airplanes-config.txt exists, /etc/airplanes/
-    # feed.env does not. Before feed_env_write_path() was introduced,
+    # Reproduce the bridged-legacy reader-fallback shape: the
+    # /etc/airplanes/image-install marker is present,
+    # /boot/airplanes-config.txt exists, /etc/airplanes/feed.env does not. Before feed_env_write_path() was introduced,
     # _mlat_apply called feed_env_path() and would have asked the apply
     # library to rewrite /boot/airplanes-config.txt itself.
     rm -rf "$ROOT_DIR/etc/airplanes"
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
-    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
 LATITUDE=52.5
 USER=alice

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -14,7 +14,7 @@ setup() {
     STUB_DIR="$ROOT_DIR/bin"
     mkdir -p "$TMPDIR" "$STUB_DIR" \
         "$ROOT_DIR/etc/airplanes" \
-        "$ROOT_DIR/usr/local/share/airplanes"
+        "$ROOT_DIR/opt/airplanes/current/share/airplanes"
     export TMPDIR
     APL_FEED_SECRET_OWNER="$(id -un)"
     APL_FEED_SECRET_GROUP="$(id -gn)"
@@ -233,7 +233,7 @@ write_mlat_state() {
     local decision="$1"
     local reason="$2"
     local mlat_private="${3:-}"
-    mkdir -p "$ROOT_DIR/run/airplanes-mlat"
+    mkdir -p "$ROOT_DIR/run/airplanes/mlat"
     {
         printf 'schema_version=1\n'
         printf 'service=airplanes-mlat\n'
@@ -242,7 +242,7 @@ write_mlat_state() {
         if [[ -n "$mlat_private" ]]; then
             printf 'mlat_private=%s\n' "$mlat_private"
         fi
-    } > "$ROOT_DIR/run/airplanes-mlat/state"
+    } > "$ROOT_DIR/run/airplanes/mlat/state"
 }
 
 # Helper: stub systemctl to return a chosen ActiveState / ExecMainStatus /
@@ -373,7 +373,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=failed + exit 64 + no state file → generic 'check feed.env MLAT config'" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state failed 64
     status_init
     STATUS_OUTPUT_JSON=0
@@ -383,7 +383,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=failed + exit other → 'failed (exit X)'" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state failed 1
     status_init
     STATUS_OUTPUT_JSON=0
@@ -393,7 +393,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=inactive + is-enabled=enabled → 'not running'" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state inactive 0 enabled
     status_init
     STATUS_OUTPUT_JSON=0
@@ -403,7 +403,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=inactive + is-enabled=masked → 'masked'" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state inactive 0 masked
     status_init
     STATUS_OUTPUT_JSON=0
@@ -413,7 +413,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=deactivating → 'not running'" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state deactivating
     status_init
     STATUS_OUTPUT_JSON=0
@@ -423,7 +423,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=active + no state file → degraded 'running' fallback" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
@@ -433,7 +433,7 @@ STUB
 }
 
 @test "mlat_status_line: ActiveState=activating + no state file → 'starting up'" {
-    rm -rf "$ROOT_DIR/run/airplanes-mlat"
+    rm -rf "$ROOT_DIR/run/airplanes/mlat"
     stub_systemctl_active_state activating
     status_init
     STATUS_OUTPUT_JSON=0
@@ -1222,7 +1222,7 @@ stop_python_mock() {
 
 _seed_config_sync_sentinel() {
     # $1 (optional): a `touch -d` time spec for the mtime (default: now).
-    local f="$ROOT_DIR/var/lib/airplanes-config-sync/config-sync-last-success"
+    local f="$ROOT_DIR/var/lib/airplanes/config-sync/config-sync-last-success"
     mkdir -p "$(dirname "$f")"
     if [[ -n "${1:-}" ]]; then
         touch -d "$1" "$f"
@@ -1317,7 +1317,7 @@ _seed_config_sync_sentinel() {
 # Helper: write a feed daemon state file carrying the published
 # effective-endpoint keys. write_feed_daemon_state <host> <port> <is_default>
 write_feed_daemon_state() {
-    mkdir -p "$ROOT_DIR/run/airplanes-feed"
+    mkdir -p "$ROOT_DIR/run/airplanes/feed"
     {
         printf 'schema_version=1\n'
         printf 'service=airplanes-feed\n'
@@ -1326,13 +1326,13 @@ write_feed_daemon_state() {
         printf 'target_host=%s\n' "$1"
         printf 'target_port=%s\n' "$2"
         printf 'target_is_default=%s\n' "$3"
-    } > "$ROOT_DIR/run/airplanes-feed/state"
+    } > "$ROOT_DIR/run/airplanes/feed/state"
 }
 
 # Helper: like write_mlat_state but with the endpoint keys.
 # write_mlat_state_with_server <decision> <reason> <server> <is_default>
 write_mlat_state_with_server() {
-    mkdir -p "$ROOT_DIR/run/airplanes-mlat"
+    mkdir -p "$ROOT_DIR/run/airplanes/mlat"
     {
         printf 'schema_version=1\n'
         printf 'service=airplanes-mlat\n'
@@ -1340,7 +1340,7 @@ write_mlat_state_with_server() {
         printf 'reason=%s\n' "$2"
         printf 'mlat_server=%s\n' "$3"
         printf 'mlat_server_is_default=%s\n' "$4"
-    } > "$ROOT_DIR/run/airplanes-mlat/state"
+    } > "$ROOT_DIR/run/airplanes/mlat/state"
 }
 
 @test "feed target suffix: non-default host renders bracket" {

--- a/test/test_apl_feed_uat.bats
+++ b/test/test_apl_feed_uat.bats
@@ -48,14 +48,14 @@ case "\$1" in
     cat)
         unit="\${@: -1}"
         # Foreign units (e.g. FlightAware's dump978-fa on a PiAware box)
-        # exist but ExecStart a path outside /usr/local/share/airplanes/,
+        # exist but ExecStart a path outside /opt/airplanes/current/share/airplanes/,
         # so the apply lib's ownership gate must skip them.
         if grep -Fxq "\$unit" "$FOREIGN_UNITS_FILE" 2>/dev/null; then
             printf 'ExecStart=/usr/bin/%s\n' "\$unit"
             exit 0
         fi
         if grep -Fxq "\$unit" "$INSTALLED_UNITS_FILE" 2>/dev/null; then
-            printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\$unit"
+            printf 'ExecStart=/opt/airplanes/current/share/airplanes/%s.sh\n' "\$unit"
             exit 0
         fi
         exit 1
@@ -101,7 +101,7 @@ mark_unit_installed() {
 }
 
 # A unit that exists on the host but belongs to a third-party package
-# (ExecStart outside /usr/local/share/airplanes/), e.g. FlightAware's
+# (ExecStart outside /opt/airplanes/current/share/airplanes/), e.g. FlightAware's
 # dump978-fa on a PiAware install.
 mark_unit_foreign() {
     printf '%s\n' "$1" >> "$FOREIGN_UNITS_FILE"
@@ -420,9 +420,8 @@ EOF
     # key (UAT_INPUT) that apl_feed_import_legacy_config understands so
     # this fixture is also a valid input to that command.
     rm -rf "$ROOT_DIR/etc/airplanes"
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/boot"
-    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     cat > "$ROOT_DIR/boot/airplanes-config.txt" <<'EOF'
 UAT_INPUT=127.0.0.1:30978
 EOF

--- a/test/test_claim_register.bats
+++ b/test/test_claim_register.bats
@@ -149,8 +149,8 @@ mock_url() {
 
 @test "reads UUID from legacy local path as fallback" {
     rm "$ROOT_DIR/etc/airplanes/feeder-id"
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
-    echo "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime"
+    echo "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
     run timeout 2 "$SCRIPT" claim register --root "$ROOT_DIR" \
         --website-url "http://127.0.0.1:1" --dry-run
     [ "$status" -eq 0 ]

--- a/test/test_feed_env_apply.bats
+++ b/test/test_feed_env_apply.bats
@@ -26,14 +26,14 @@ setup() {
     FEED_ENV="$ROOT_DIR/etc/airplanes/feed.env"
     LOCK_FILE="$ROOT_DIR/run/airplanes/feed-env.lock"
 
-    # `cat` answers with an ExecStart under /usr/local/share/airplanes/ so
+    # `cat` answers with an ExecStart under /opt/airplanes/current/share/airplanes/ so
     # the apply lib's unit-ownership gate treats every unit as ours by
     # default; the foreign-unit tests override this stub per-test.
     cat > "$STUB_DIR/systemctl" <<STUB
 #!/usr/bin/env bash
 printf 'systemctl %s\n' "\$*" >> "$SYSTEMCTL_LOG"
 if [ "\$1" = cat ]; then
-    printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\${@: -1}"
+    printf 'ExecStart=/opt/airplanes/current/share/airplanes/%s.sh\n' "\${@: -1}"
 fi
 exit 0
 STUB
@@ -368,7 +368,7 @@ if [ "\$1" = cat ]; then
     unit="\${@: -1}"
     case " $foreign " in
         *" \$unit "*) printf 'ExecStart=/usr/bin/%s\n' "\$unit" ;;
-        *) printf 'ExecStart=/usr/local/share/airplanes/%s.sh\n' "\$unit" ;;
+        *) printf 'ExecStart=/opt/airplanes/current/share/airplanes/%s.sh\n' "\$unit" ;;
     esac
 fi
 exit 0

--- a/test/test_image_runtime_scripts.bats
+++ b/test/test_image_runtime_scripts.bats
@@ -17,9 +17,15 @@ teardown() {
 
 write_image_config() {
     local root="$1"
-    mkdir -p "$root/boot" "$root/usr/bin"
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    mkdir -p "$root/boot" "$root/etc/airplanes" "$root/opt/airplanes/current/bin"
+    # Image install is signalled by the marker file, not the presence of a
+    # feed binary at a magic path. The feed binary now lands at the same
+    # consolidated /opt path for both image and standalone installs; tests
+    # that need to observe argv overwrite this exit-0 stub with a logging
+    # stub at the same path.
+    : > "$root/etc/airplanes/image-install"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/opt/airplanes/current/bin/feed-airplanes"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
     # Represents post-migration boot config: USER preserved for legacy
     # consumers, MLAT_USER + MLAT_ENABLED added by airplanes-webconfig's
     # migrate-config.sh so the new daemon sees the split schema.
@@ -60,12 +66,12 @@ MLAT_ENABLED=true
 MLAT_PRIVATE=false
 UAT_INPUT=""
 EOF
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
     [ "$status" -eq 0 ]
@@ -88,12 +94,12 @@ MLAT_ENABLED=true
 MLAT_PRIVATE=false
 UAT_INPUT="127.0.0.1:30978"
 EOF
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
     [ "$status" -eq 0 ]
@@ -104,12 +110,12 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/args.log"
     write_image_config "$root"
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
 
@@ -133,7 +139,7 @@ SH
     # --write-json feeds the stats uploader (airplanes-stats.sh). It must target
     # the forwarder's own RuntimeDirectory, never the image decoder's /run/readsb,
     # and must not pull in globe-index shards.
-    grep -q -- "--write-json $root/run/airplanes-feed" "$arg_log"
+    grep -q -- "--write-json $root/run/airplanes/feed" "$arg_log"
     if grep -q -- '/run/readsb' "$arg_log"; then
         return 1
     fi
@@ -154,7 +160,7 @@ SH
     # No image feed binary and no image-install marker → IMAGE_INSTALL=0, the
     # forwarder sources /etc/airplanes/feed.env and uses the built feed-airplanes
     # binary. The stats JSON contract must be identical to the image branch.
-    mkdir -p "$root/etc/airplanes" "$root/usr/local/share/airplanes"
+    mkdir -p "$root/etc/airplanes" "$root/opt/airplanes/current/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 LATITUDE="52.52"
 LONGITUDE="13.40"
@@ -163,16 +169,16 @@ MLAT_USER="manual-feeder"
 MLAT_ENABLED=true
 MLAT_PRIVATE=false
 EOF
-    cat > "$root/usr/local/share/airplanes/feed-airplanes" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/local/share/airplanes/feed-airplanes"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
     [ "$status" -eq 0 ]
-    grep -q -- "--write-json $root/run/airplanes-feed" "$arg_log"
+    grep -q -- "--write-json $root/run/airplanes/feed" "$arg_log"
     if grep -q -- '/run/readsb' "$arg_log"; then
         return 1
     fi
@@ -190,12 +196,12 @@ INPUT="127.0.0.1:30005"
 MLATSERVER="feed.airplanes.live:31090"
 JSON_OPTIONS="--write-json /run/readsb --write-json=/run/readsb --json-location-accuracy 2"
 EOF
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
     [ "$status" -eq 0 ]
@@ -203,7 +209,7 @@ SH
     # regardless of any earlier --write-json injected via JSON_OPTIONS.
     local args
     args="$(cat "$arg_log")"
-    [[ "$args" == *"--write-json $root/run/airplanes-feed" ]]
+    [[ "$args" == *"--write-json $root/run/airplanes/feed" ]]
 }
 
 @test "airplanes-mlat.sh: image-side MLAT_PRIVATE=true → mlat-client gets --privacy" {
@@ -211,7 +217,7 @@ SH
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
     write_image_config "$root"
-    mkdir -p "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$stub_bin/nc" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -220,12 +226,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -244,7 +250,7 @@ SH
     local stub_bin="$ROOT_DIR/bin"
     write_image_config "$root"
     sed -i -e 's/MLAT_PRIVATE=true/MLAT_PRIVATE=false/' "$root/boot/airplanes-config.txt"
-    mkdir -p "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$stub_bin/nc" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -253,12 +259,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -277,7 +283,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     install_legacy_mlat_translation_lib "$root"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
@@ -298,12 +304,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -315,7 +321,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -335,12 +341,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -357,7 +363,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -378,12 +384,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -402,7 +408,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     install_legacy_mlat_translation_lib "$root"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
@@ -423,12 +429,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -440,7 +446,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -460,12 +466,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -483,10 +489,11 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/boot" "$root/usr/bin" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/boot" "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     install_legacy_mlat_translation_lib "$root"
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    # Image install is signalled by the marker; with a boot config and no
+    # feed.env the daemon takes the BOOT_CONFIG source branch.
+    : > "$root/etc/airplanes/image-install"
     cat > "$root/boot/airplanes-config.txt" <<'EOF'
 LATITUDE="52"
 LONGITUDE="13"
@@ -508,12 +515,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -526,7 +533,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -547,12 +554,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -562,11 +569,11 @@ SH
     fi
 }
 
-@test "airplanes-feed.sh detects new-contract image via marker without /usr/bin/airplanes-feeder" {
+@test "airplanes-feed.sh detects new-contract image via the image-install marker" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/args.log"
-    local feed_bin="$root/usr/local/share/airplanes/feed-airplanes"
-    mkdir -p "$root/etc/airplanes" "$root/usr/local/share/airplanes"
+    local feed_bin="$root/opt/airplanes/current/bin/feed-airplanes"
+    mkdir -p "$root/etc/airplanes" "$root/opt/airplanes/current/bin"
     : > "$root/etc/airplanes/image-install"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
@@ -600,11 +607,11 @@ SH
     fi
 }
 
-@test "airplanes-feed.sh stays in manual-install branch when neither marker nor legacy binary present" {
+@test "airplanes-feed.sh stays in manual-install branch when the image-install marker is absent" {
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/args.log"
-    local feed_bin="$root/usr/local/share/airplanes/feed-airplanes"
-    mkdir -p "$root/etc/airplanes" "$root/usr/local/share/airplanes"
+    local feed_bin="$root/opt/airplanes/current/bin/feed-airplanes"
+    mkdir -p "$root/etc/airplanes" "$root/opt/airplanes/current/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -640,9 +647,9 @@ SH
 # file is written.
 install_state_writer_lib() {
     local root="$1"
-    install -d -m 0755 "$root/usr/local/share/airplanes/lib"
+    install -d -m 0755 "$root/opt/airplanes/current/share/airplanes/lib"
     install -m 0644 "$BATS_TEST_DIRNAME/../scripts/lib/state-writer.sh" \
-        "$root/usr/local/share/airplanes/lib/state-writer.sh"
+        "$root/opt/airplanes/current/share/airplanes/lib/state-writer.sh"
 }
 
 # Same as install_state_writer_lib but for the legacy-key translation
@@ -650,9 +657,9 @@ install_state_writer_lib() {
 # from PRIVACY / MLAT_MARKER.
 install_legacy_mlat_translation_lib() {
     local root="$1"
-    install -d -m 0755 "$root/usr/local/share/airplanes/lib"
+    install -d -m 0755 "$root/opt/airplanes/current/share/airplanes/lib"
     install -m 0644 "$BATS_TEST_DIRNAME/../scripts/lib/legacy-mlat-translation.sh" \
-        "$root/usr/local/share/airplanes/lib/legacy-mlat-translation.sh"
+        "$root/opt/airplanes/current/share/airplanes/lib/legacy-mlat-translation.sh"
 }
 
 # Set up an mlat run with stubbed nc/sleep/mlat-client so the daemon
@@ -662,7 +669,7 @@ install_legacy_mlat_translation_lib() {
 setup_mlat_runtime() {
     local root="$1"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$stub_bin/nc" <<'SH'
 #!/usr/bin/env bash
 exit 0
@@ -671,12 +678,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 }
 
 write_feed_env() {
@@ -708,20 +715,20 @@ write_feed_env() {
         PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    [ -f "$root/run/airplanes-mlat/state" ]
-    grep -qx 'schema_version=1' "$root/run/airplanes-mlat/state"
-    grep -qx 'service=airplanes-mlat' "$root/run/airplanes-mlat/state"
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=ok' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_enabled=true' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=alice' "$root/run/airplanes-mlat/state"
-    grep -qx 'latitude=52' "$root/run/airplanes-mlat/state"
-    grep -qx 'longitude=13' "$root/run/airplanes-mlat/state"
-    grep -qx 'altitude=35' "$root/run/airplanes-mlat/state"
-    grep -qE '^decided_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$root/run/airplanes-mlat/state"
+    [ -f "$root/run/airplanes/mlat/state" ]
+    grep -qx 'schema_version=1' "$root/run/airplanes/mlat/state"
+    grep -qx 'service=airplanes-mlat' "$root/run/airplanes/mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=ok' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_enabled=true' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_user=alice' "$root/run/airplanes/mlat/state"
+    grep -qx 'latitude=52' "$root/run/airplanes/mlat/state"
+    grep -qx 'longitude=13' "$root/run/airplanes/mlat/state"
+    grep -qx 'altitude=35' "$root/run/airplanes/mlat/state"
+    grep -qE '^decided_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$root/run/airplanes/mlat/state"
     # Default MLATSERVER → endpoint keys carry the default and flag it.
-    grep -qx 'mlat_server=feed.airplanes.live:31090' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_server_is_default=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_server=feed.airplanes.live:31090' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_server_is_default=true' "$root/run/airplanes/mlat/state"
     # mlat-client was invoked.
     [ -f "$arg_log" ]
 }
@@ -745,8 +752,8 @@ write_feed_env() {
         PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'mlat_server=feed.airplanes.test:31090' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_server_is_default=false' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_server=feed.airplanes.test:31090' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_server_is_default=false' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh publishes empty endpoint keys for a charset-invalid MLATSERVER" {
@@ -768,8 +775,8 @@ write_feed_env() {
         PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'mlat_server=' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_server_is_default=' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_server=' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_server_is_default=' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh writes state=disabled,reason=mlat_enabled_false when MLAT_ENABLED=false" {
@@ -791,8 +798,8 @@ write_feed_env() {
         PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=disabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes/mlat/state"
     [[ "$output" == *'MLAT DISABLED'* ]]
     # mlat-client was NOT invoked.
     [ ! -f "$arg_log" ]
@@ -815,7 +822,7 @@ write_feed_env() {
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=mlat_enabled_false' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh writes state=disabled,reason=geo_not_configured when GEO_CONFIGURED=false" {
@@ -836,9 +843,9 @@ write_feed_env() {
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
-    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=disabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes/mlat/state"
+    grep -qx 'geo_configured=false' "$root/run/airplanes/mlat/state"
 }
 
 # ---- disabled branch: config watch loop -----------------------------------
@@ -866,14 +873,13 @@ SH
     [[ "$output" == *'MLAT DISABLED'* ]]
 }
 
-# Write a legacy-image layout: no feed.env, the airplanes-feeder binary
-# marker present, and a post-migration-schema boot config that classifies
+# Write a legacy-image layout: no feed.env, the image-install marker
+# present, and a post-migration-schema boot config that classifies
 # as disabled. The wrapper then takes the BOOT_CONFIG source branch.
 write_legacy_disabled_boot_config() {
     local root="$1"
-    mkdir -p "$root/boot" "$root/usr/bin"
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    mkdir -p "$root/boot" "$root/etc/airplanes"
+    : > "$root/etc/airplanes/image-install"
     cat > "$root/boot/airplanes-config.txt" <<'EOF'
 MLAT_USER="legacy-feeder"
 MLAT_ENABLED=false
@@ -944,7 +950,7 @@ SH
         PATH="$ROOT_DIR/bin:$PATH" timeout 2 bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 124 ]
-    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=disabled' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh: disabled watch — invalid interval falls back to 60" {
@@ -989,8 +995,8 @@ SH
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
-    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes/mlat/state"
+    grep -qx 'geo_configured=false' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh fallback heals legacy equator user (LATITUDE=0, LONGITUDE!=0) → GEO_CONFIGURED=true" {
@@ -1012,8 +1018,8 @@ SH
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh fallback heals legacy prime-meridian user (LATITUDE!=0, LONGITUDE=0)" {
@@ -1032,8 +1038,8 @@ SH
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh derives GEO_CONFIGURED=true from non-zero coords (legacy feed.env)" {
@@ -1052,7 +1058,7 @@ SH
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh derives GEO_CONFIGURED=false from decimal-zero pair (0.00000/0.00000)" {
@@ -1074,7 +1080,7 @@ SH
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    grep -qx 'geo_configured=false' "$root/run/airplanes-mlat/state"
+    grep -qx 'geo_configured=false' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh: explicit GEO_CONFIGURED wins over legacy coord derivation" {
@@ -1097,8 +1103,8 @@ SH
 
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'geo_configured=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'geo_configured=true' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh: empty MLAT_USER + canonical feeder-id → state=enabled, MLAT_USER=Anonymous-<short>, mlat-client gets --user" {
@@ -1121,9 +1127,9 @@ SH
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=ok' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=Anonymous-0a1b2c3d' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=ok' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_user=Anonymous-0a1b2c3d' "$root/run/airplanes/mlat/state"
     # mlat-client must receive the substituted value, not an empty --user.
     grep -q -- '--user Anonymous-0a1b2c3d' "$arg_log"
 }
@@ -1148,9 +1154,9 @@ SH
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=ok' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=ok' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes/mlat/state"
     grep -q -- '--user Anonymous' "$arg_log"
 }
 
@@ -1166,8 +1172,8 @@ SH
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh: empty MLAT_USER + truncated feeder-id (not a UUID) → MLAT_USER=Anonymous" {
@@ -1184,8 +1190,8 @@ SH
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh: empty MLAT_USER + feeder-id is a symlink → MLAT_USER=Anonymous (refuses to follow)" {
@@ -1203,8 +1209,8 @@ SH
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=enabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_user=Anonymous' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh: empty MLAT_USER + feeder-id with CR/LF in canonical UUID → strips CR/LF, MLAT_USER=Anonymous-<short>" {
@@ -1221,7 +1227,7 @@ SH
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'mlat_user=Anonymous-0a1b2c3d' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_user=Anonymous-0a1b2c3d' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh exits 64 with schema-strict guard when boot config has legacy USER but no MLAT_USER" {
@@ -1232,9 +1238,10 @@ SH
     local root="$ROOT_DIR/root"
     install_state_writer_lib "$root"
     setup_mlat_runtime "$root"
-    mkdir -p "$root/boot" "$root/usr/bin"
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$root/usr/bin/airplanes-feeder"
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    mkdir -p "$root/boot" "$root/etc/airplanes"
+    # Marker routes the daemon into the boot-config branch so it sees the
+    # un-migrated legacy USER= without an accompanying MLAT_USER.
+    : > "$root/etc/airplanes/image-install"
     cat > "$root/boot/airplanes-config.txt" <<'EOF'
 LATITUDE="52.52000"
 LONGITUDE="13.40500"
@@ -1248,7 +1255,7 @@ EOF
     [[ "$output" == *"legacy USER= schema detected"* ]]
     [[ "$output" == *"Update Webconfig"* ]]
     # State file is not written: we exit before classifier runs.
-    [ ! -f "$root/run/airplanes-mlat/state" ]
+    [ ! -f "$root/run/airplanes/mlat/state" ]
 }
 
 @test "airplanes-mlat.sh exits 64 with state=misconfigured when ALTITUDE empty + MLAT_ENABLED=true" {
@@ -1272,9 +1279,9 @@ EOF
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 64 ]
-    grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=altitude_empty' "$root/run/airplanes-mlat/state"
-    grep -qx 'altitude=' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=misconfigured' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=altitude_empty' "$root/run/airplanes/mlat/state"
+    grep -qx 'altitude=' "$root/run/airplanes/mlat/state"
     [[ "$output" == *"ALTITUDE is empty"* ]]
 }
 
@@ -1300,8 +1307,8 @@ EOF
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'state=disabled' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=geo_not_configured' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=disabled' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=geo_not_configured' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh exits 64 with reason=mlat_private_invalid for hand-edited bad MLAT_PRIVATE" {
@@ -1322,9 +1329,9 @@ EOF
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 64 ]
-    grep -qx 'state=misconfigured' "$root/run/airplanes-mlat/state"
-    grep -qx 'reason=mlat_private_invalid' "$root/run/airplanes-mlat/state"
-    grep -qx 'mlat_private=yes' "$root/run/airplanes-mlat/state"
+    grep -qx 'state=misconfigured' "$root/run/airplanes/mlat/state"
+    grep -qx 'reason=mlat_private_invalid' "$root/run/airplanes/mlat/state"
+    grep -qx 'mlat_private=yes' "$root/run/airplanes/mlat/state"
     [[ "$output" == *"MLAT_PRIVATE must be 'true' or 'false'"* ]]
 }
 
@@ -1346,7 +1353,7 @@ EOF
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'mlat_private=true' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_private=true' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh state file publishes mlat_private=false when MLAT_PRIVATE absent (runtime default)" {
@@ -1366,7 +1373,7 @@ EOF
     run env AIRPLANES_ROOT="$root" PATH="$ROOT_DIR/bin:$PATH" bash "$MLAT_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'mlat_private=false' "$root/run/airplanes-mlat/state"
+    grep -qx 'mlat_private=false' "$root/run/airplanes/mlat/state"
 }
 
 @test "airplanes-mlat.sh runs without state-writer lib (defensive source falls through to stub)" {
@@ -1390,7 +1397,7 @@ EOF
     [ "$status" -eq 0 ]
     # Daemon still invoked mlat-client; no state file because lib was missing.
     [ -f "$arg_log" ]
-    [ ! -f "$root/run/airplanes-mlat/state" ]
+    [ ! -f "$root/run/airplanes/mlat/state" ]
 }
 
 @test "airplanes-feed.sh writes state=enabled,reason=ok with effective config" {
@@ -1398,29 +1405,29 @@ EOF
     local arg_log="$ROOT_DIR/feed-args.log"
     install_state_writer_lib "$root"
     write_image_config "$root"
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
 
     [ "$status" -eq 0 ]
-    [ -f "$root/run/airplanes-feed/state" ]
-    grep -qx 'schema_version=1' "$root/run/airplanes-feed/state"
-    grep -qx 'service=airplanes-feed' "$root/run/airplanes-feed/state"
-    grep -qx 'state=enabled' "$root/run/airplanes-feed/state"
-    grep -qx 'reason=ok' "$root/run/airplanes-feed/state"
-    grep -qx 'latitude=52.52000' "$root/run/airplanes-feed/state"
-    grep -qx 'longitude=13.40500' "$root/run/airplanes-feed/state"
-    grep -qx 'input=127.0.0.1:30005' "$root/run/airplanes-feed/state"
-    grep -q -- "feed_bin=$root/usr/bin/airplanes-feeder" "$root/run/airplanes-feed/state"
+    [ -f "$root/run/airplanes/feed/state" ]
+    grep -qx 'schema_version=1' "$root/run/airplanes/feed/state"
+    grep -qx 'service=airplanes-feed' "$root/run/airplanes/feed/state"
+    grep -qx 'state=enabled' "$root/run/airplanes/feed/state"
+    grep -qx 'reason=ok' "$root/run/airplanes/feed/state"
+    grep -qx 'latitude=52.52000' "$root/run/airplanes/feed/state"
+    grep -qx 'longitude=13.40500' "$root/run/airplanes/feed/state"
+    grep -qx 'input=127.0.0.1:30005' "$root/run/airplanes/feed/state"
+    grep -q -- "feed_bin=$root/opt/airplanes/current/bin/feed-airplanes" "$root/run/airplanes/feed/state"
     # Default TARGET → endpoint keys carry the default and flag it as such.
-    grep -qx 'target_host=feed.airplanes.live' "$root/run/airplanes-feed/state"
-    grep -qx 'target_port=30004' "$root/run/airplanes-feed/state"
-    grep -qx 'target_is_default=true' "$root/run/airplanes-feed/state"
+    grep -qx 'target_host=feed.airplanes.live' "$root/run/airplanes/feed/state"
+    grep -qx 'target_port=30004' "$root/run/airplanes/feed/state"
+    grep -qx 'target_is_default=true' "$root/run/airplanes/feed/state"
 }
 
 @test "airplanes-feed.sh publishes a non-default TARGET endpoint to the state file" {
@@ -1435,19 +1442,19 @@ SH
         'MLAT_USER="image-feeder"' \
         'MLAT_ENABLED=true' \
         'TARGET="--net-connector feed.airplanes.test,30004,beast_reduce_plus_out"'
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
 
     [ "$status" -eq 0 ]
-    grep -qx 'target_host=feed.airplanes.test' "$root/run/airplanes-feed/state"
-    grep -qx 'target_port=30004' "$root/run/airplanes-feed/state"
-    grep -qx 'target_is_default=false' "$root/run/airplanes-feed/state"
+    grep -qx 'target_host=feed.airplanes.test' "$root/run/airplanes/feed/state"
+    grep -qx 'target_port=30004' "$root/run/airplanes/feed/state"
+    grep -qx 'target_is_default=false' "$root/run/airplanes/feed/state"
 }
 
 @test "airplanes-feed.sh parses --net-connector=host TARGET form and flags a non-default port" {
@@ -1462,20 +1469,20 @@ SH
         'MLAT_USER="image-feeder"' \
         'MLAT_ENABLED=true' \
         'TARGET="--net-connector=feed.airplanes.live,9999,beast_reduce_plus_out"'
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
 
     [ "$status" -eq 0 ]
     # Default host on a non-default port is still a non-default endpoint.
-    grep -qx 'target_host=feed.airplanes.live' "$root/run/airplanes-feed/state"
-    grep -qx 'target_port=9999' "$root/run/airplanes-feed/state"
-    grep -qx 'target_is_default=false' "$root/run/airplanes-feed/state"
+    grep -qx 'target_host=feed.airplanes.live' "$root/run/airplanes/feed/state"
+    grep -qx 'target_port=9999' "$root/run/airplanes/feed/state"
+    grep -qx 'target_is_default=false' "$root/run/airplanes/feed/state"
 }
 
 @test "airplanes-feed.sh publishes empty endpoint keys for an unparseable TARGET" {
@@ -1490,21 +1497,21 @@ SH
         'MLAT_USER="image-feeder"' \
         'MLAT_ENABLED=true' \
         'TARGET="no connector flag here"'
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
 
     [ "$status" -eq 0 ]
     # Present-but-empty keys signal "configured but unparseable" to
     # consumers, distinct from key-absent (older daemon, no state).
-    grep -qx 'target_host=' "$root/run/airplanes-feed/state"
-    grep -qx 'target_port=' "$root/run/airplanes-feed/state"
-    grep -qx 'target_is_default=' "$root/run/airplanes-feed/state"
+    grep -qx 'target_host=' "$root/run/airplanes/feed/state"
+    grep -qx 'target_port=' "$root/run/airplanes/feed/state"
+    grep -qx 'target_is_default=' "$root/run/airplanes/feed/state"
 }
 
 @test "airplanes-mlat.sh: RESULTS bundle default routes to 30104 + 31015 + 30157" {
@@ -1517,7 +1524,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -1537,12 +1544,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -1566,7 +1573,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -1587,12 +1594,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -1617,7 +1624,7 @@ SH
     local root="$ROOT_DIR/root"
     local arg_log="$ROOT_DIR/mlat-args.log"
     local stub_bin="$ROOT_DIR/bin"
-    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/usr/local/share/airplanes/venv/bin"
+    mkdir -p "$root/etc/airplanes" "$stub_bin" "$root/opt/airplanes/current/share/airplanes/venv/bin"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
 INPUT="127.0.0.1:30005"
 INPUT_TYPE="dump1090"
@@ -1638,12 +1645,12 @@ SH
 #!/usr/bin/env bash
 exit 0
 SH
-    cat > "$root/usr/local/share/airplanes/venv/bin/mlat-client" <<'SH'
+    cat > "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/usr/local/share/airplanes/venv/bin/mlat-client"
+    chmod +x "$stub_bin/nc" "$stub_bin/sleep" "$root/opt/airplanes/current/share/airplanes/venv/bin/mlat-client"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" PATH="$stub_bin:$PATH" bash "$MLAT_SCRIPT"
 
@@ -1678,12 +1685,12 @@ USER="canonical-feed-env"
 MLATSERVER="feed.airplanes.live:31090"
 TARGET="--net-connector feed.airplanes.live,30004,beast_reduce_plus_out,feed2.airplanes.live,64004"
 EOF
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    cat > "$root/opt/airplanes/current/bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$ARG_LOG"
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$root/opt/airplanes/current/bin/feed-airplanes"
 
     run env AIRPLANES_ROOT="$root" ARG_LOG="$arg_log" bash "$FEED_SCRIPT"
 

--- a/test/test_install_script.bats
+++ b/test/test_install_script.bats
@@ -69,8 +69,8 @@ SH
 
     [ "$status" -eq 0 ]
     [ -f "$ROOT_DIR/root/setup-pwd" ]
-    [ "$(cat "$ROOT_DIR/root/setup-pwd")" = "$ROOT_DIR/root/usr/local/share/airplanes/git" ]
-    [ "$(git -C "$ROOT_DIR/root/usr/local/share/airplanes/git" remote get-url origin)" = "$repo" ]
+    [ "$(cat "$ROOT_DIR/root/setup-pwd")" = "$ROOT_DIR/root/var/lib/airplanes/runtime/git" ]
+    [ "$(git -C "$ROOT_DIR/root/var/lib/airplanes/runtime/git" remote get-url origin)" = "$repo" ]
 }
 
 @test "install.sh propagates build mode to setup.sh" {
@@ -131,7 +131,7 @@ SH
 
     [ "$status" -eq 0 ]
     [ -f "$ROOT_DIR/root/standalone-setup-pwd" ]
-    [ "$(cat "$ROOT_DIR/root/standalone-setup-pwd")" = "$ROOT_DIR/root/usr/local/share/airplanes/git" ]
+    [ "$(cat "$ROOT_DIR/root/standalone-setup-pwd")" = "$ROOT_DIR/root/var/lib/airplanes/runtime/git" ]
 }
 
 # __FEED_REF__ template behavior: the source-tree install.sh leaves the

--- a/test/test_install_uninstall_symmetry.bats
+++ b/test/test_install_uninstall_symmetry.bats
@@ -59,16 +59,18 @@ teardown() {
 
 # Stage a maximally-realistic post-install state at AIRPLANES_ROOT. The
 # optional first argument selects the systemd unit layout:
-#   - "manual" (default) — units in /lib/systemd/system, no marker.
+#   - "manual" (default) — units staged in /lib/systemd/system to model a
+#     pre-FHS install whose stale units uninstall must still sweep.
 #   - "image" — units in /etc/systemd/system, /etc/airplanes/image-install
-#     marker present. Mirrors what update.sh produces when IMAGE_SERVICE_LAYOUT
-#     is set (either IMAGE_INSTALL=1 or AIRPLANES_BUILD_MODE=1).
+#     marker present.
+# update.sh now installs all units to /etc/systemd/system (SYSTEMD_DIR);
+# uninstall.sh sweeps both dirs, which this symmetry test exercises.
 #
 # Path enumeration sourced from update.sh's install steps:
-#   - $IPATH contents: update.sh:474-497, 545, 569-589, 644-651, 716
-#   - systemd units: /lib/systemd/system (manual, update.sh:594-596) or
-#     /etc/systemd/system (image, update.sh:336 + 594-596)
-#   - /usr/local/bin/apl-feed: update.sh:545
+#   - $IPATH (payload) under /opt/airplanes/current/share/airplanes
+#   - $STATE (mutable) under /var/lib/airplanes/runtime
+#   - systemd units: /etc/systemd/system (uninstall also cleans /lib/systemd/system)
+#   - /usr/local/bin/apl-feed symlink shim
 #   - /etc/airplanes/ artifacts: update.sh:428,472,569,704; create-uuid.sh;
 #     claim-registration.sh:register_claim_secret
 #   - /etc/default/airplanes symlink: update-migrations.sh:finalize_legacy_feed_env_migration
@@ -83,8 +85,8 @@ stage_install_footprint() {
         *) echo "stage_install_footprint: invalid systemd_layout '$systemd_layout'" >&2; return 2 ;;
     esac
 
-    # $IPATH (= /usr/local/share/airplanes) — wiped wholesale by uninstall.
-    local ipath="$ROOT_DIR/usr/local/share/airplanes"
+    # $IPATH (= /opt/airplanes/current/share/airplanes) — wiped wholesale by uninstall.
+    local ipath="$ROOT_DIR/opt/airplanes/current/share/airplanes"
     mkdir -p "$ipath/git"
     mkdir -p "$ipath/apl-feed"
     mkdir -p "$ipath/lib"
@@ -134,17 +136,17 @@ stage_install_footprint() {
         : > "$ROOT_DIR/lib/systemd/system/airplanes-stats.timer"
     fi
 
-    # Diagnostics state directory — systemd's StateDirectory=airplanes-diagnostics
-    # creates /var/lib/airplanes-diagnostics owned by the diagnostics user on
+    # Diagnostics state directory — systemd's StateDirectory=airplanes/diagnostics
+    # creates /var/lib/airplanes/diagnostics owned by the diagnostics user on
     # first timer fire. uninstall.sh wipes the whole directory.
-    mkdir -p "$ROOT_DIR/var/lib/airplanes-diagnostics"
-    : > "$ROOT_DIR/var/lib/airplanes-diagnostics/diagnostics-last-success"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/diagnostics"
+    : > "$ROOT_DIR/var/lib/airplanes/diagnostics/diagnostics-last-success"
 
-    # Config-sync state directory — its own StateDirectory=airplanes-config-sync
+    # Config-sync state directory — its own StateDirectory=airplanes/config-sync
     # (separate from diagnostics so the two oneshots never re-chown a shared
     # dir). uninstall.sh wipes it too.
-    mkdir -p "$ROOT_DIR/var/lib/airplanes-config-sync"
-    : > "$ROOT_DIR/var/lib/airplanes-config-sync/config-sync-last-success"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/config-sync"
+    : > "$ROOT_DIR/var/lib/airplanes/config-sync/config-sync-last-success"
 
     # CLI wrapper at /usr/local/bin — installed by update.sh:545.
     mkdir -p "$ROOT_DIR/usr/local/bin"
@@ -180,35 +182,39 @@ run_uninstall() {
     [ ! -e "$ROOT_DIR/lib/systemd/system/airplanes-stats.timer" ]
 }
 
-@test "after install footprint, uninstall removes /var/lib/airplanes-diagnostics state dir" {
+@test "after install footprint, uninstall removes /var/lib/airplanes/diagnostics state dir" {
     stage_install_footprint
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ ! -e "$ROOT_DIR/var/lib/airplanes-diagnostics" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes/diagnostics" ]
 }
 
-@test "after install footprint, uninstall removes /var/lib/airplanes-config-sync state dir" {
+@test "after install footprint, uninstall removes /var/lib/airplanes/config-sync state dir" {
     stage_install_footprint
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ ! -e "$ROOT_DIR/var/lib/airplanes-config-sync" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes/config-sync" ]
 }
 
-@test "after install footprint, uninstall wipes IPATH and leaves only the legacy UUID symlink" {
+@test "after install footprint, uninstall wipes IPATH and re-materializes the legacy UUID symlink under STATE" {
     stage_install_footprint
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ -d "$ROOT_DIR/usr/local/share/airplanes" ]
-    # IPATH is recreated empty (uninstall.sh:59-60) then the legacy
-    # airplanes-uuid symlink is re-materialized when canonical feeder-id
-    # exists (uninstall.sh:70-72). Nothing else should remain.
+    # IPATH is recreated empty; the legacy airplanes-uuid symlink now lives
+    # under $STATE (/var/lib/airplanes/runtime), not inside IPATH.
+    [ -d "$ROOT_DIR/opt/airplanes/current/share/airplanes" ]
+    [ -z "$(ls -A "$ROOT_DIR/opt/airplanes/current/share/airplanes")" ]
+
+    # $STATE is recreated empty (uninstall.sh) then the legacy airplanes-uuid
+    # symlink is re-materialized when canonical feeder-id exists. Nothing else
+    # should remain there.
     local remaining
-    remaining="$(ls -A "$ROOT_DIR/usr/local/share/airplanes")"
+    remaining="$(ls -A "$ROOT_DIR/var/lib/airplanes/runtime")"
     [ "$remaining" = "airplanes-uuid" ]
-    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+    [ -L "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid" ]
 }
 
 @test "after install footprint, uninstall preserves /etc/airplanes/feeder-id" {

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -64,11 +64,27 @@ write_archive_fallback_stubs() {
     [ "$status" -eq 0 ]
 }
 
-@test "image install detection ignores the legacy feeder binary (signal dropped)" {
+@test "image install detection accepts the legacy feeder binary with config (legacy upgrade path)" {
+    # A legacy image predates the /etc/airplanes/image-install marker but ships
+    # the baked /usr/bin/airplanes-feeder binary. It must still be detected as
+    # an image install so a legacy ROM updating to feed/dev takes the image
+    # branch instead of dropping into interactive setup.
     mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/etc/airplanes"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
     chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
     printf 'USER="image"\n' > "$ROOT_DIR/etc/airplanes/feed.env"
+
+    run airplanes_is_image_install
+
+    [ "$status" -eq 0 ]
+}
+
+@test "image install detection rejects the legacy feeder binary without any config" {
+    # The binary alone (bare rootfs, no feed.env and no boot config) is not a
+    # configured image — the config guard must keep it out of the image branch.
+    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/etc/airplanes"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
 
     run airplanes_is_image_install
 

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -54,7 +54,17 @@ write_archive_fallback_stubs() {
     [ "$(airplanes_path /etc/airplanes/feed.env)" = "$ROOT_DIR/etc/airplanes/feed.env" ]
 }
 
-@test "image install detection supports canonical feed.env without boot config" {
+@test "image install detection accepts marker file with boot config (no feed.env)" {
+    mkdir -p "$ROOT_DIR/etc/airplanes" "$ROOT_DIR/boot"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
+    printf 'USER="image"\n' > "$ROOT_DIR/boot/airplanes-config.txt"
+
+    run airplanes_is_image_install
+
+    [ "$status" -eq 0 ]
+}
+
+@test "image install detection ignores the legacy feeder binary (signal dropped)" {
     mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/etc/airplanes"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
     chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
@@ -62,7 +72,7 @@ write_archive_fallback_stubs() {
 
     run airplanes_is_image_install
 
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
 }
 
 @test "image install detection accepts marker file with feed.env (new contract)" {
@@ -93,7 +103,14 @@ write_archive_fallback_stubs() {
     [ "$status" -ne 0 ]
 }
 
-@test "feed-bin resolver picks legacy /usr/bin/airplanes-feeder when present" {
+@test "feed-bin resolver returns the unified /opt prefix binary" {
+    run airplanes_image_feed_bin_default
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes" ]
+}
+
+@test "feed-bin resolver ignores the legacy feeder binary (unified path)" {
     mkdir -p "$ROOT_DIR/usr/bin"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
     chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
@@ -101,14 +118,7 @@ write_archive_fallback_stubs() {
     run airplanes_image_feed_bin_default
 
     [ "$status" -eq 0 ]
-    [ "$output" = "$ROOT_DIR/usr/bin/airplanes-feeder" ]
-}
-
-@test "feed-bin resolver falls back to /usr/local/share/airplanes/feed-airplanes when legacy missing" {
-    run airplanes_image_feed_bin_default
-
-    [ "$status" -eq 0 ]
-    [ "$output" = "$ROOT_DIR/usr/local/share/airplanes/feed-airplanes" ]
+    [ "$output" = "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes" ]
 }
 
 @test "getGIT clones the configured branch from a local repository" {

--- a/test/test_install_update_common.bats
+++ b/test/test_install_update_common.bats
@@ -119,18 +119,36 @@ write_archive_fallback_stubs() {
     [ "$status" -ne 0 ]
 }
 
-@test "feed-bin resolver returns the unified /opt prefix binary" {
+@test "feed-bin resolver prefers the /opt binary when present" {
+    mkdir -p "$ROOT_DIR/opt/airplanes/current/bin" "$ROOT_DIR/usr/bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes"
+    chmod +x "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes"
+    # A legacy binary present alongside /opt must not win.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
+    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+
     run airplanes_image_feed_bin_default
 
     [ "$status" -eq 0 ]
     [ "$output" = "$ROOT_DIR/opt/airplanes/current/bin/feed-airplanes" ]
 }
 
-@test "feed-bin resolver ignores the legacy feeder binary (unified path)" {
+@test "feed-bin resolver falls back to the legacy feeder binary (legacy image)" {
+    # No /opt binary (legacy ROM can't rebuild on an image); the baked
+    # /usr/bin/airplanes-feeder is the only feed binary available.
     mkdir -p "$ROOT_DIR/usr/bin"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ROOT_DIR/usr/bin/airplanes-feeder"
     chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
 
+    run airplanes_image_feed_bin_default
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$ROOT_DIR/usr/bin/airplanes-feeder" ]
+}
+
+@test "feed-bin resolver returns the canonical /opt path when no binary exists" {
+    # With neither binary present the resolver returns the /opt path so the
+    # caller's "missing binary" error points at the canonical location.
     run airplanes_image_feed_bin_default
 
     [ "$status" -eq 0 ]

--- a/test/test_remove_pre_fhs_layout.bats
+++ b/test/test_remove_pre_fhs_layout.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# remove_pre_fhs_layout — sweep the pre-FHS install layout
+# (/usr/local/share/airplanes payload + /lib/systemd/system units) on upgrade
+# to the /opt layout, while preserving feeder identity/config under
+# /etc/airplanes. /etc/airplanes is the firewall: it is never touched, so the
+# feeder keeps its identity (feeder-id) and config (feed.env) across the move.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    TMP="$(mktemp -d)"
+
+    AIRPLANES_ROOT="$TMP/root"
+    mkdir -p "$AIRPLANES_ROOT"
+    AIRPLANES_BUILD_MODE=
+    export AIRPLANES_ROOT AIRPLANES_BUILD_MODE
+
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/scripts/lib/install-update-common.sh"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/scripts/lib/update-migrations.sh"
+
+    LEGACY_IPATH="$AIRPLANES_ROOT/usr/local/share/airplanes"
+    LEGACY_SYSTEMD="$AIRPLANES_ROOT/lib/systemd/system"
+    ETC_AIRPLANES="$AIRPLANES_ROOT/etc/airplanes"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+seed_pre_fhs_install() {
+    mkdir -p "$LEGACY_IPATH/git" "$LEGACY_IPATH/lib" "$LEGACY_SYSTEMD" "$ETC_AIRPLANES"
+    : > "$LEGACY_IPATH/airplanes-feed.sh"
+    : > "$LEGACY_IPATH/feed-airplanes"
+    : > "$LEGACY_IPATH/airplanes-uuid"
+    local u
+    for u in airplanes-feed.service airplanes-mlat.service \
+             airplanes-diagnostics.service airplanes-diagnostics.timer \
+             airplanes-stats.service airplanes-stats.timer \
+             airplanes-config-sync.service airplanes-config-sync.timer; do
+        : > "$LEGACY_SYSTEMD/$u"
+    done
+    # Feeder identity + config that MUST survive the sweep.
+    printf '%s\n' '11111111-2222-3333-4444-555555555555' > "$ETC_AIRPLANES/feeder-id"
+    printf '%s\n' 'INPUT="127.0.0.1:30005"' > "$ETC_AIRPLANES/feed.env"
+}
+
+@test "remove_pre_fhs_layout: removes old payload tree and /lib units" {
+    seed_pre_fhs_install
+    remove_pre_fhs_layout "$LEGACY_IPATH" "$LEGACY_SYSTEMD" /dev/null
+    [ ! -e "$LEGACY_IPATH" ]
+    [ ! -e "$LEGACY_SYSTEMD/airplanes-feed.service" ]
+    [ ! -e "$LEGACY_SYSTEMD/airplanes-config-sync.timer" ]
+}
+
+@test "remove_pre_fhs_layout: preserves /etc/airplanes identity and config" {
+    seed_pre_fhs_install
+    remove_pre_fhs_layout "$LEGACY_IPATH" "$LEGACY_SYSTEMD" /dev/null
+    [ -f "$ETC_AIRPLANES/feeder-id" ]
+    [ -f "$ETC_AIRPLANES/feed.env" ]
+    grep -q '11111111-2222-3333-4444-555555555555' "$ETC_AIRPLANES/feeder-id"
+}
+
+@test "remove_pre_fhs_layout: no-op when no pre-FHS install present" {
+    mkdir -p "$LEGACY_SYSTEMD" "$ETC_AIRPLANES"
+    run remove_pre_fhs_layout "$LEGACY_IPATH" "$LEGACY_SYSTEMD" /dev/null
+    [ "$status" -eq 0 ]
+    [ ! -e "$LEGACY_IPATH" ]
+}
+
+@test "remove_pre_fhs_layout: defensive guard refuses a non-legacy rm -rf target" {
+    local bogus="$AIRPLANES_ROOT/var/lib/airplanes/runtime"
+    mkdir -p "$bogus" "$LEGACY_SYSTEMD"
+    : > "$LEGACY_SYSTEMD/airplanes-feed.service"   # trip the detection gate
+    remove_pre_fhs_layout "$bogus" "$LEGACY_SYSTEMD" /dev/null
+    # The wrong path must NOT be deleted (the guard only rm -rf's the legacy suffix)...
+    [ -d "$bogus" ]
+    # ...but the stale units are still swept.
+    [ ! -e "$LEGACY_SYSTEMD/airplanes-feed.service" ]
+}

--- a/test/test_setup_script.bats
+++ b/test/test_setup_script.bats
@@ -6,7 +6,7 @@ setup() {
     STUB_DIR="$ROOT_DIR/bin"
     EVENTS_LOG="$ROOT_DIR/events.log"
     ID_LOG="$ROOT_DIR/id.log"
-    GIT_DIR="$ROOT_DIR/usr/local/share/airplanes/git"
+    GIT_DIR="$ROOT_DIR/var/lib/airplanes/runtime/git"
     mkdir -p "$STUB_DIR" "$GIT_DIR"
     : > "$EVENTS_LOG"
     : > "$ID_LOG"
@@ -76,9 +76,8 @@ EOF
 }
 
 make_image_install_fixture() {
-    mkdir -p "$ROOT_DIR/usr/bin" "$ROOT_DIR/etc/airplanes"
-    : > "$ROOT_DIR/usr/bin/airplanes-feeder"
-    chmod +x "$ROOT_DIR/usr/bin/airplanes-feeder"
+    mkdir -p "$ROOT_DIR/etc/airplanes"
+    : > "$ROOT_DIR/etc/airplanes/image-install"
     : > "$ROOT_DIR/etc/airplanes/feed.env"
 }
 

--- a/test/test_uninstall_script.bats
+++ b/test/test_uninstall_script.bats
@@ -51,8 +51,8 @@ SH
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ -d "$ROOT_DIR/usr/local/share/airplanes" ]
-    [ -z "$(ls -A "$ROOT_DIR/usr/local/share/airplanes")" ]
+    [ -d "$ROOT_DIR/opt/airplanes/current/share/airplanes" ]
+    [ -z "$(ls -A "$ROOT_DIR/opt/airplanes/current/share/airplanes")" ]
     [ ! -e "$ROOT_DIR/etc/airplanes/feeder-id" ]
     [ -f "$SYSTEMCTL_LOG" ]
 }
@@ -127,36 +127,36 @@ SH
 }
 
 @test "uninstall.sh wipes IPATH contents and recreates the directory" {
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git/sub"
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/.cache"
-    : > "$ROOT_DIR/usr/local/share/airplanes/marker"
-    : > "$ROOT_DIR/usr/local/share/airplanes/git/sub/file"
+    mkdir -p "$ROOT_DIR/opt/airplanes/current/share/airplanes/sub"
+    mkdir -p "$ROOT_DIR/opt/airplanes/current/share/airplanes/.cache"
+    : > "$ROOT_DIR/opt/airplanes/current/share/airplanes/marker"
+    : > "$ROOT_DIR/opt/airplanes/current/share/airplanes/sub/file"
 
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ -d "$ROOT_DIR/usr/local/share/airplanes" ]
-    [ -z "$(ls -A "$ROOT_DIR/usr/local/share/airplanes")" ]
+    [ -d "$ROOT_DIR/opt/airplanes/current/share/airplanes" ]
+    [ -z "$(ls -A "$ROOT_DIR/opt/airplanes/current/share/airplanes")" ]
 }
 
 @test "canonical feeder-id is preserved across wipe and the legacy symlink is recreated" {
     mkdir -p "$ROOT_DIR/etc/airplanes"
     printf 'canonical-uuid-content\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git"
-    : > "$ROOT_DIR/usr/local/share/airplanes/git/marker"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime/git"
+    : > "$ROOT_DIR/var/lib/airplanes/runtime/git/marker"
 
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/git/marker" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes/runtime/git/marker" ]
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "canonical-uuid-content" ]
-    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
-    [ "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+    [ -L "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid" ]
+    [ "$(readlink "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
 }
 
 @test "legacy fallback is materialized to canonical when canonical is absent" {
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
-    printf 'legacy-uuid-content\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime"
+    printf 'legacy-uuid-content\n' > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
 
     run_uninstall
 
@@ -171,13 +171,13 @@ SH
     # Materialized canonical must be 0644.
     [ "$(stat -c '%a' "$ROOT_DIR/etc/airplanes/feeder-id")" = "644" ]
 
-    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
-    [ "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+    [ -L "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid" ]
+    [ "$(readlink "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
 }
 
 @test "legacy without a trailing newline is normalized to one trailing newline (UUID-format contract)" {
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
-    printf 'legacy-no-newline' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime"
+    printf 'legacy-no-newline' > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
 
     run_uninstall
 
@@ -190,8 +190,8 @@ SH
 }
 
 @test "empty legacy file still triggers materialization and symlink restoration" {
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
-    : > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime"
+    : > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
 
     run_uninstall
 
@@ -201,14 +201,14 @@ SH
     local expected="$ROOT_DIR/expected.bin"
     printf '\n' > "$expected"
     cmp "$expected" "$ROOT_DIR/etc/airplanes/feeder-id"
-    # Legacy symlink restored on top of the wiped IPATH.
-    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+    # Legacy symlink restored on top of the wiped state dir.
+    [ -L "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid" ]
 }
 
 @test "legacy UUID content is not leaked into trace output by set -x" {
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime"
     local secret_marker="LEGACY-LEAK-CANARY-9F3B7A"
-    printf '%s\n' "$secret_marker" > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    printf '%s\n' "$secret_marker" > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
 
     run_uninstall
 
@@ -224,16 +224,16 @@ SH
 
 @test "canonical wins over legacy when both exist with different values" {
     mkdir -p "$ROOT_DIR/etc/airplanes"
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime"
     printf 'CANONICAL-UUID\n' > "$ROOT_DIR/etc/airplanes/feeder-id"
-    printf 'legacy-different\n' > "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid"
+    printf 'legacy-different\n' > "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid"
 
     run_uninstall
 
     [ "$status" -eq 0 ]
     [ "$(cat "$ROOT_DIR/etc/airplanes/feeder-id")" = "CANONICAL-UUID" ]
-    [ -L "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
-    [ "$(readlink "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+    [ -L "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid" ]
+    [ "$(readlink "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
 }
 
 @test "no feeder-id is created when neither canonical nor legacy existed" {
@@ -241,7 +241,7 @@ SH
 
     [ "$status" -eq 0 ]
     [ ! -e "$ROOT_DIR/etc/airplanes/feeder-id" ]
-    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/airplanes-uuid" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes/runtime/airplanes-uuid" ]
 }
 
 @test "tar1090 uninstall hook fires when html-airplanes/ exists, with sandboxed gate AND invocation" {
@@ -270,13 +270,13 @@ SH
     # The script must keep going (it has no set -e) and still wipe IPATH +
     # daemon-reload + report success.
     mkdir -p "$ROOT_DIR/usr/local/share/tar1090/html-airplanes"
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git"
-    : > "$ROOT_DIR/usr/local/share/airplanes/git/marker"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime/git"
+    : > "$ROOT_DIR/var/lib/airplanes/runtime/git/marker"
 
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/git/marker" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes/runtime/git/marker" ]
     grep -q "daemon-reload" "$SYSTEMCTL_LOG"
 }
 
@@ -288,13 +288,13 @@ exit 7
 SH
     chmod +x "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh"
 
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes/git"
-    : > "$ROOT_DIR/usr/local/share/airplanes/git/marker"
+    mkdir -p "$ROOT_DIR/var/lib/airplanes/runtime/git"
+    : > "$ROOT_DIR/var/lib/airplanes/runtime/git/marker"
 
     run_uninstall
 
     [ "$status" -eq 0 ]
-    [ ! -e "$ROOT_DIR/usr/local/share/airplanes/git/marker" ]
+    [ ! -e "$ROOT_DIR/var/lib/airplanes/runtime/git/marker" ]
     grep -q "daemon-reload" "$SYSTEMCTL_LOG"
 }
 
@@ -302,7 +302,7 @@ SH
     mkdir -p "$ROOT_DIR/usr/local/share/tar1090/html-airplanes"
     cat > "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh" <<'SH'
 #!/usr/bin/env bash
-if [[ -f "$AIRPLANES_ROOT/usr/local/share/airplanes/marker-during-hook" ]]; then
+if [[ -f "$AIRPLANES_ROOT/opt/airplanes/current/share/airplanes/marker-during-hook" ]]; then
     printf 'IPATH-INTACT\n' >> "$TAR1090_LOG"
 else
     printf 'IPATH-WIPED\n' >> "$TAR1090_LOG"
@@ -311,8 +311,8 @@ exit 0
 SH
     chmod +x "$ROOT_DIR/usr/local/share/tar1090/uninstall.sh"
 
-    mkdir -p "$ROOT_DIR/usr/local/share/airplanes"
-    : > "$ROOT_DIR/usr/local/share/airplanes/marker-during-hook"
+    mkdir -p "$ROOT_DIR/opt/airplanes/current/share/airplanes"
+    : > "$ROOT_DIR/opt/airplanes/current/share/airplanes/marker-during-hook"
 
     run_uninstall
 

--- a/test/test_update_manifest.bats
+++ b/test/test_update_manifest.bats
@@ -78,8 +78,8 @@ extract_manifest() {
     local daemon_lib_names
     # Discover daemon-time libs by grepping the daemon scripts for source
     # statements that reference $IPATH/lib/<name>.sh (or its airplanes_path
-    # equivalent /usr/local/share/airplanes/lib/<name>.sh).
-    daemon_lib_names="$(grep -hoE '/usr/local/share/airplanes/lib/[A-Za-z0-9_-]+\.sh' \
+    # equivalent /opt/airplanes/current/share/airplanes/lib/<name>.sh).
+    daemon_lib_names="$(grep -hoE '/opt/airplanes/current/share/airplanes/lib/[A-Za-z0-9_-]+\.sh' \
         "$REPO_ROOT/scripts/airplanes-feed.sh" \
         "$REPO_ROOT/scripts/airplanes-mlat.sh" \
         2>/dev/null | sed 's|.*/||' | sort -u)"

--- a/test/test_update_script.bats
+++ b/test/test_update_script.bats
@@ -126,37 +126,42 @@ prepare_skip_build_state() {
     local feed_repo="$2"
     local mlat_repo="$3"
     local readsb_repo="$4"
-    local ipath="$root/usr/local/share/airplanes"
-    mkdir -p "$ipath/venv/bin"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
+    local bin="$root/opt/airplanes/current/bin"
+    local state="$root/var/lib/airplanes/runtime"
+    mkdir -p "$ipath/venv/bin" "$bin" "$state"
     cp "$feed_repo/update.sh" "$ipath/update.sh"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ipath/venv/bin/mlat-client"
     chmod +x "$ipath/venv/bin/mlat-client"
-    git -C "$mlat_repo" rev-parse HEAD > "$ipath/mlat_version"
-    git -C "$readsb_repo" rev-parse HEAD > "$ipath/readsb_version"
-    cat > "$ipath/feed-airplanes" <<'SH'
+    git -C "$mlat_repo" rev-parse HEAD > "$state/mlat_version"
+    git -C "$readsb_repo" rev-parse HEAD > "$state/readsb_version"
+    cat > "$bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 [[ "${1:-}" == "-V" ]] && exit 0
 exit 0
 SH
-    chmod +x "$ipath/feed-airplanes"
+    chmod +x "$bin/feed-airplanes"
 }
 
 prepare_image_skip_build_state() {
     local root="$1"
     local feed_repo="$2"
     local mlat_repo="$3"
-    local ipath="$root/usr/local/share/airplanes"
-    mkdir -p "$ipath/venv/bin" "$root/usr/bin"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
+    local bin="$root/opt/airplanes/current/bin"
+    local state="$root/var/lib/airplanes/runtime"
+    mkdir -p "$ipath/venv/bin" "$bin" "$state" "$root/etc/airplanes"
     cp "$feed_repo/update.sh" "$ipath/update.sh"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ipath/venv/bin/mlat-client"
     chmod +x "$ipath/venv/bin/mlat-client"
-    git -C "$mlat_repo" rev-parse HEAD > "$ipath/mlat_version"
-    cat > "$root/usr/bin/airplanes-feeder" <<'SH'
+    git -C "$mlat_repo" rev-parse HEAD > "$state/mlat_version"
+    : > "$root/etc/airplanes/image-install"
+    cat > "$bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 [[ "${1:-}" == "-V" ]] && exit 0
 exit 0
 SH
-    chmod +x "$root/usr/bin/airplanes-feeder"
+    chmod +x "$bin/feed-airplanes"
 }
 
 prepare_marker_image_skip_build_state() {
@@ -164,19 +169,21 @@ prepare_marker_image_skip_build_state() {
     local feed_repo="$2"
     local mlat_repo="$3"
     local readsb_repo="$4"
-    local ipath="$root/usr/local/share/airplanes"
-    mkdir -p "$ipath/venv/bin"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
+    local bin="$root/opt/airplanes/current/bin"
+    local state="$root/var/lib/airplanes/runtime"
+    mkdir -p "$ipath/venv/bin" "$bin" "$state"
     cp "$feed_repo/update.sh" "$ipath/update.sh"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$ipath/venv/bin/mlat-client"
     chmod +x "$ipath/venv/bin/mlat-client"
-    git -C "$mlat_repo" rev-parse HEAD > "$ipath/mlat_version"
-    git -C "$readsb_repo" rev-parse HEAD > "$ipath/readsb_version"
-    cat > "$ipath/feed-airplanes" <<'SH'
+    git -C "$mlat_repo" rev-parse HEAD > "$state/mlat_version"
+    git -C "$readsb_repo" rev-parse HEAD > "$state/readsb_version"
+    cat > "$bin/feed-airplanes" <<'SH'
 #!/usr/bin/env bash
 [[ "${1:-}" == "-V" ]] && exit 0
 exit 0
 SH
-    chmod +x "$ipath/feed-airplanes"
+    chmod +x "$bin/feed-airplanes"
     mkdir -p "$root/etc/airplanes"
     : > "$root/etc/airplanes/image-install"
 }
@@ -184,7 +191,7 @@ SH
 @test "update.sh replaces a missing or stale installed updater before continuing" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
     mkdir -p "$feed_repo" "$ipath" "$root/etc"
     echo 'VERSION_ID="13"' > "$root/etc/os-release"
     cat > "$feed_repo/update.sh" <<'SH'
@@ -214,7 +221,7 @@ SH
 @test "update.sh self-replace tolerates a 0644 destination from older feed" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
     mkdir -p "$feed_repo" "$ipath" "$root/etc"
     echo 'VERSION_ID="13"' > "$root/etc/os-release"
     cat > "$feed_repo/update.sh" <<'SH'
@@ -243,7 +250,7 @@ SH
 @test "update.sh runs setup when no feed env exists" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
     mkdir -p "$ipath" "$root/etc"
     echo 'VERSION_ID="13"' > "$root/etc/os-release"
     copy_feed_fixture_repo "$feed_repo"
@@ -275,7 +282,7 @@ SH
     # Anonymous fallback this state is valid and setup.sh must NOT run.
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
     mkdir -p "$ipath" "$root/etc/airplanes"
     echo 'VERSION_ID="13"' > "$root/etc/os-release"
     cat > "$root/etc/airplanes/feed.env" <<'EOF'
@@ -322,7 +329,7 @@ SH
     local mlat_repo="$ROOT_DIR/mlat-source"
     local readsb_repo="$ROOT_DIR/readsb-source"
     local claim_bin="$ROOT_DIR/apl-feed-stub"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
 
     copy_feed_fixture_repo "$feed_repo"
     make_component_repo "$mlat_repo" master
@@ -357,11 +364,11 @@ SH
     [ "$status" -eq 0 ]
     [ -x "$root/usr/local/bin/apl-feed" ]
     [ -f "$ipath/apl-feed/common.sh" ]
-    [ -f "$root/lib/systemd/system/airplanes-feed.service" ]
-    [ -f "$root/lib/systemd/system/airplanes-mlat.service" ]
+    [ -f "$root/etc/systemd/system/airplanes-feed.service" ]
+    [ -f "$root/etc/systemd/system/airplanes-mlat.service" ]
     [ -f "$root/etc/airplanes/feeder-id" ]
-    [ -L "$ipath/airplanes-uuid" ]
-    [ "$(readlink "$ipath/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
+    [ -L "$root/var/lib/airplanes/runtime/airplanes-uuid" ]
+    [ "$(readlink "$root/var/lib/airplanes/runtime/airplanes-uuid")" = "../../../../etc/airplanes/feeder-id" ]
     # Canonicalisers rewrote the legacy fixture: TARGET bumped to feed2
     # failover, NET_OPTIONS lost its --uuid-file arg. Brand endpoints are
     # also available as daemon defaults in the installed wrappers — `[ ...
@@ -507,7 +514,7 @@ SH
     [ ! -e "$root/lib/systemd/system/airplanes-feed.service" ]
     grep -qE '^After=.*airplanes-first-run.service' "$root/etc/systemd/system/airplanes-feed.service"
     grep -qE '^After=.*airplanes-first-run.service' "$root/etc/systemd/system/airplanes-mlat.service"
-    [ -x "$root/usr/local/share/airplanes/feed-airplanes" ]
+    [ -x "$root/opt/airplanes/current/bin/feed-airplanes" ]
     [ ! -x "$root/usr/bin/airplanes-feeder" ]
     [ -f "$root/etc/airplanes/image-install" ]
     grep -q 'systemctl enable airplanes-feed' "$ROOT_DIR/commands.log"
@@ -522,7 +529,7 @@ SH
     ! grep -q 'systemctl daemon-reload' "$ROOT_DIR/commands.log"
     ! grep -q '^pgrep ' "$ROOT_DIR/commands.log"
     [ ! -e "$root/etc/airplanes/feeder-id" ]
-    [ ! -e "$root/usr/local/share/airplanes/airplanes-uuid" ]
+    [ ! -e "$root/var/lib/airplanes/runtime/airplanes-uuid" ]
     [ ! -e "$ROOT_DIR/claim.log" ]
     [[ "$output" =~ "Build mode setup complete" ]]
 }
@@ -533,7 +540,7 @@ SH
     local mlat_repo="$ROOT_DIR/mlat-source"
     local readsb_repo="$ROOT_DIR/readsb-source"
     local claim_bin="$ROOT_DIR/apl-feed-stub"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
 
     copy_feed_fixture_repo "$feed_repo"
     make_component_repo "$mlat_repo" master
@@ -566,10 +573,10 @@ SH
         bash "$UPDATE"
 
     [ "$status" -eq 0 ]
-    [ -x "$ipath/feed-airplanes" ]
+    [ -x "$root/opt/airplanes/current/bin/feed-airplanes" ]
     [ -L "$root/etc/default/airplanes" ]
-    [ -f "$root/lib/systemd/system/airplanes-feed.service" ]
-    [ ! -e "$root/etc/systemd/system/airplanes-feed.service" ]
+    [ -f "$root/etc/systemd/system/airplanes-feed.service" ]
+    [ ! -e "$root/lib/systemd/system/airplanes-feed.service" ]
     [ ! -x "$root/usr/bin/airplanes-feeder" ]
     grep -q 'systemctl restart airplanes-feed' "$ROOT_DIR/commands.log"
     [ "$(grep -c 'systemctl daemon-reload' "$ROOT_DIR/commands.log")" = "1" ]
@@ -581,7 +588,7 @@ SH
     local mlat_repo="$ROOT_DIR/mlat-source"
     local readsb_repo="$ROOT_DIR/readsb-source"
     local claim_bin="$ROOT_DIR/apl-feed-stub"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
 
     copy_feed_fixture_repo "$feed_repo"
     make_component_repo "$mlat_repo" master
@@ -614,8 +621,8 @@ SH
     [ "$status" -eq 0 ]
     # Marker-only path must not exit with "Image feed binary missing".
     ! [[ "$output" =~ "Image feed binary missing" ]]
-    grep -q "Using image-provided feed client: $ipath/feed-airplanes" <<< "$output"
-    [ -x "$ipath/feed-airplanes" ]
+    grep -q "Using image-provided feed client: $root/opt/airplanes/current/bin/feed-airplanes" <<< "$output"
+    [ -x "$root/opt/airplanes/current/bin/feed-airplanes" ]
     [ ! -e "$root/usr/bin/airplanes-feeder" ]
     [ -f "$root/etc/airplanes/image-install" ]
     [ -f "$root/etc/systemd/system/airplanes-feed.service" ]
@@ -627,7 +634,7 @@ SH
     local feed_repo="$ROOT_DIR/feed-source"
     local mlat_repo="$ROOT_DIR/mlat-source"
     local claim_bin="$ROOT_DIR/apl-feed-stub"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
 
     copy_feed_fixture_repo "$feed_repo"
     make_component_repo "$mlat_repo" master
@@ -659,15 +666,15 @@ SH
     [ -f "$ipath/apl-feed/common.sh" ]
     [ -f "$root/etc/systemd/system/airplanes-feed.service" ]
     [ -f "$root/etc/systemd/system/airplanes-mlat.service" ]
-    grep -q 'ExecStart=/usr/local/share/airplanes/airplanes-feed.sh' "$root/etc/systemd/system/airplanes-feed.service"
-    grep -q 'ExecStart=/usr/local/share/airplanes/airplanes-mlat.sh' "$root/etc/systemd/system/airplanes-mlat.service"
+    grep -q 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-feed.sh' "$root/etc/systemd/system/airplanes-feed.service"
+    grep -q 'ExecStart=/opt/airplanes/current/share/airplanes/airplanes-mlat.sh' "$root/etc/systemd/system/airplanes-mlat.service"
     grep -qE '^After=.*airplanes-first-run.service' "$root/etc/systemd/system/airplanes-feed.service"
     grep -qE '^After=.*airplanes-first-run.service' "$root/etc/systemd/system/airplanes-mlat.service"
     [ ! -e "$root/lib/systemd/system/airplanes-feed.service" ]
     [ ! -e "$root/lib/systemd/system/airplanes-mlat.service" ]
     [ "$(cat "$root/etc/airplanes/feeder-id")" = "22222222-3333-4444-5555-666666666666" ]
-    [ -L "$ipath/airplanes-uuid" ]
-    [ -x "$root/usr/bin/airplanes-feeder" ]
+    [ -L "$root/var/lib/airplanes/runtime/airplanes-uuid" ]
+    [ -x "$root/opt/airplanes/current/bin/feed-airplanes" ]
     [ ! -e "$ipath/feed-airplanes" ]
     [ ! -e "$root/etc/airplanes/feed.env" ]
     [ -L "$root/etc/default/airplanes" ]
@@ -684,7 +691,7 @@ SH
 @test "update.sh sweeps orphan airplanes-mlat2 unit before falling back to setup" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
     mkdir -p "$ipath" "$root/etc" \
         "$root/lib/systemd/system" \
         "$root/etc/systemd/system/default.target.wants" \
@@ -741,7 +748,7 @@ SH
 @test "update.sh sweep is no-op when no orphan airplanes-mlat2 unit exists" {
     local root="$ROOT_DIR/root"
     local feed_repo="$ROOT_DIR/feed-source"
-    local ipath="$root/usr/local/share/airplanes"
+    local ipath="$root/opt/airplanes/current/share/airplanes"
     mkdir -p "$ipath" "$root/etc"
     echo 'VERSION_ID="13"' > "$root/etc/os-release"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,13 +12,18 @@ airplanes_path() {
     fi
 }
 
-IPATH="$(airplanes_path /usr/local/share/airplanes)"
+PREFIX="$(airplanes_path /opt/airplanes/current)"
+IPATH="$PREFIX/share/airplanes"
+STATE="$(airplanes_path /var/lib/airplanes/runtime)"
+# Payload directory the previous (pre-FHS) layout installed to; removed so an
+# upgrade-then-uninstall doesn't leak the stale tree.
+LEGACY_IPATH="$(airplanes_path /usr/local/share/airplanes)"
 FEEDER_ID="$(airplanes_path /etc/airplanes/feeder-id)"
-LEGACY_UUID="$IPATH/airplanes-uuid"
-# Unit-file directories: manual install (/lib/systemd/system, update.sh
-# default) and image-install / build-mode (/etc/systemd/system, set by
-# update.sh when IMAGE_SERVICE_LAYOUT=1). Iterate both unconditionally; unit
-# names are airplanes-specific and rm -f is a no-op when absent.
+LEGACY_UUID="$STATE/airplanes-uuid"
+# Unit-file directories: units now install to /etc/systemd/system, but
+# pre-FHS manual installs wrote to /lib/systemd/system. Iterate both
+# unconditionally; unit names are airplanes-specific and rm -f is a no-op
+# when absent.
 SYSTEMD_UNIT_DIRS=(
     "$(airplanes_path /lib/systemd/system)"
     "$(airplanes_path /etc/systemd/system)"
@@ -79,7 +84,10 @@ rm -f "$LOCAL_BIN_APL_FEED"
 rm -f "$IMAGE_INSTALL_MARKER"
 # State directories for the diagnostics and config-sync oneshots (last-success
 # timestamp files). Created by systemd's StateDirectory= on first fire of each
-# unit; nothing in them is user-supplied, so remove wholesale.
+# unit; nothing in them is user-supplied, so remove wholesale. Both the new
+# nested layout and the pre-FHS flat dirs are removed.
+rm -rf "$(airplanes_path /var/lib/airplanes/diagnostics)"
+rm -rf "$(airplanes_path /var/lib/airplanes/config-sync)"
 rm -rf "$(airplanes_path /var/lib/airplanes-diagnostics)"
 rm -rf "$(airplanes_path /var/lib/airplanes-config-sync)"
 
@@ -107,6 +115,11 @@ fi
 
 rm -rf "$IPATH"
 mkdir -p "$IPATH"
+# Mutable runtime state (git checkout, build trees, version stamps, legacy
+# uuid symlink) and the pre-FHS payload dir.
+rm -rf "$STATE"
+mkdir -p "$STATE"
+rm -rf "$LEGACY_IPATH"
 
 if [[ ! -f "$FEEDER_ID" && "$LEGACY_FALLBACK_VALID" -eq 1 ]]; then
     mkdir -p "$(dirname "$FEEDER_ID")"

--- a/update.sh
+++ b/update.sh
@@ -147,7 +147,8 @@ else
     }
 
     airplanes_is_image_install() {
-        [[ -f "$(airplanes_path /etc/airplanes/image-install)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
+        [[ -f "$(airplanes_path /etc/airplanes/image-install)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]] \
+            || [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
     }
 
     airplanes_image_feed_bin_default() {

--- a/update.sh
+++ b/update.sh
@@ -128,34 +128,30 @@ else
     }
 
     airplanes_init_paths() {
-        IPATH="$(airplanes_path /usr/local/share/airplanes)"
-        GIT="$IPATH/git"
-        LOGFILE="$IPATH/lastlog"
+        PREFIX="$(airplanes_path /opt/airplanes/current)"
+        IPATH="$PREFIX/share/airplanes"
+        BIN="$PREFIX/bin"
+        STATE="$(airplanes_path /var/lib/airplanes/runtime)"
+        GIT="$STATE/git"
+        LOGFILE="$STATE/lastlog"
         BOOT_CONFIG="$(airplanes_path /boot/airplanes-config.txt)"
         BOOT_ENV="$(airplanes_path /boot/airplanes-env)"
         ETC_AIRPLANES="$(airplanes_path /etc/airplanes)"
         FEED_ENV="$ETC_AIRPLANES/feed.env"
         FEEDER_ID_FILE="$ETC_AIRPLANES/feeder-id"
-        LEGACY_UUID_FILE="$IPATH/airplanes-uuid"
+        LEGACY_UUID_FILE="$STATE/airplanes-uuid"
         BOOT_UUID_FILE="$(airplanes_path /boot/airplanes-uuid)"
         LEGACY_FEED_ENV="$(airplanes_path /etc/default/airplanes)"
         LOCAL_BIN="$(airplanes_path /usr/local/bin)"
-        SYSTEMD_DIR="$(airplanes_path /lib/systemd/system)"
+        SYSTEMD_DIR="$(airplanes_path /etc/systemd/system)"
     }
 
     airplanes_is_image_install() {
-        [[ -x "$(airplanes_path /usr/bin/airplanes-feeder)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]] \
-            || [[ -f "$(airplanes_path /etc/airplanes/image-install)" && -f "$FEED_ENV" ]]
+        [[ -f "$(airplanes_path /etc/airplanes/image-install)" && ( -f "$FEED_ENV" || -f "$BOOT_CONFIG" ) ]]
     }
 
     airplanes_image_feed_bin_default() {
-        local legacy
-        legacy="$(airplanes_path /usr/bin/airplanes-feeder)"
-        if [[ -x "$legacy" ]]; then
-            printf '%s' "$legacy"
-        else
-            printf '%s' "$(airplanes_path /usr/local/share/airplanes/feed-airplanes)"
-        fi
+        printf '%s' "$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
     }
 
     airplanes_image_target_default() {
@@ -339,12 +335,12 @@ IMAGE_INSTALL=0
 if airplanes_is_image_install; then
     IMAGE_INSTALL=1
 fi
-IMAGE_SERVICE_LAYOUT=0
-if [[ "$IMAGE_INSTALL" == "1" ]] || airplanes_is_build_mode; then
-    IMAGE_SERVICE_LAYOUT=1
-fi
-
 mkdir -p "$IPATH"
+# Mutable runtime state (git checkout, lastlog, readsb/mlat build trees,
+# version stamps) lives under $STATE=/var/lib/airplanes/runtime, separate
+# from the read-only payload under $IPATH. getGIT clones into $GIT=$STATE/git
+# and $LOGFILE=$STATE/lastlog, so the parent must exist first.
+mkdir -p "$STATE"
 rm -f "$LOGFILE"
 touch "$LOGFILE"
 
@@ -381,11 +377,6 @@ if [[ "$1" != "test" ]] && { [[ ! -f "$IPATH/update.sh" ]] || ! diff "$GIT/updat
     bash "$IPATH/update.sh" "$@"
     exit $?
 fi
-if [[ "$IMAGE_SERVICE_LAYOUT" == "1" ]]; then
-    # Images ship these units in /etc/systemd/system, which overrides /lib.
-    SYSTEMD_DIR="$(airplanes_path /etc/systemd/system)"
-fi
-
 # Migration helpers: legacy retirements, env-file rewrites, manifest-based
 # pruning, finalize symlinks. See scripts/lib/update-migrations.sh for the
 # function definitions and the migration ordering contract.
@@ -598,8 +589,16 @@ fi
 if [[ -d "$IPATH/lib" ]]; then
     prune_installed_script_artifacts "$IPATH/lib" "$GIT/scripts/lib" historical_daemon_libs
 fi
+# apl-feed dispatcher: the real CLI lands under $BIN (the consolidated
+# FHS prefix, alongside the feed binary), matching where the runtime
+# overlay installs it. $LOCAL_BIN/apl-feed is a stable symlink shim into
+# it so the webconfig-pinned /usr/local/bin/apl-feed argv path keeps
+# working. apl-feed.sh resolves its modules via an absolute fallback, so
+# the symlink shim is safe.
+mkdir -p "$BIN"
+install -m 0755 "$GIT/scripts/apl-feed.sh" "$BIN/apl-feed"
 mkdir -p "$LOCAL_BIN"
-install -m 0755 "$GIT/scripts/apl-feed.sh" "$LOCAL_BIN/apl-feed"
+ln -sfn "$BIN/apl-feed" "$LOCAL_BIN/apl-feed"
 
 # Daemon user/group. Renamed from "airplanes" to avoid collision with what
 # users typically pick as their console/SSH login on a fresh image flash.
@@ -633,13 +632,16 @@ fi
 
 MLAT_REPO="${AIRPLANES_MLAT_REPO:-https://github.com/airplanes-live/mlat-client}"
 MLAT_BRANCH="${AIRPLANES_MLAT_BRANCH:-master}"
-MLAT_GIT="$IPATH/mlat-client-git"
+MLAT_GIT="$STATE/mlat-client-git"
 
+# The mlat_version stamp is mutable build state, so it lives under $STATE
+# (passed as the ipath arg) rather than alongside the read-only payload in
+# $IPATH. The venv itself stays at $VENV=$IPATH/venv.
 install_mlat_client \
     "$MLAT_REPO" \
     "$MLAT_BRANCH" \
     "$VENV" \
-    "$IPATH" \
+    "$STATE" \
     "$MLAT_GIT" \
     "$LOGFILE" \
     "$REINSTALL" \
@@ -676,7 +678,7 @@ else
     # The daemon classifies disabled-by-config and self-disables via
     # sleep+exit; systemd Restart=always re-runs it. This keeps the
     # daemon-owned state-file pattern coherent: apl-feed status and the
-    # dashboards trust the daemon's published /run/airplanes-mlat/state
+    # dashboards trust the daemon's published /run/airplanes/mlat/state
     # rather than re-deriving the predicate from feed.env.
     systemctl enable airplanes-mlat >> "$LOGFILE" || true
     systemctl restart airplanes-mlat || true
@@ -701,15 +703,19 @@ else
     if airplanes_is_legacy_os; then
         READSB_BRANCH="jessie"
     fi
-    READSB_GIT="$IPATH/readsb-git"
-    READSB_BIN="$IPATH/feed-airplanes"
+    READSB_GIT="$STATE/readsb-git"
+    READSB_BIN="$BIN/feed-airplanes"
 
+    # The feed binary lands in $BIN (the consolidated prefix bin/), matching
+    # the overlay's /opt/airplanes/current/bin/feed-airplanes. The build tree
+    # and the readsb_version stamp are mutable state under $STATE.
+    mkdir -p "$BIN"
     build_readsb_feed_client \
         "$READSB_REPO" \
         "$READSB_BRANCH" \
         "$READSB_GIT" \
         "$READSB_BIN" \
-        "$IPATH" \
+        "$STATE" \
         "$LOGFILE" \
         "$REINSTALL"
 fi
@@ -739,7 +745,7 @@ echo 94
 
 if ! airplanes_is_build_mode; then
     systemctl is-active airplanes-feed &>/dev/null || {
-        rm -f "$IPATH/readsb_version"
+        rm -f "$STATE/readsb_version"
         echo "---------------------------------"
         journalctl -u airplanes-feed | tail -n10
         echo "---------------------------------"
@@ -754,7 +760,7 @@ echo 96
 
 if ! airplanes_is_build_mode; then
     [[ "${MLAT_DISABLED}" == "1" ]] || systemctl is-active airplanes-mlat &>/dev/null || {
-        rm -f "$IPATH/mlat_version"
+        rm -f "$STATE/mlat_version"
         echo "---------------------------------"
         journalctl -u airplanes-mlat | tail -n10
         echo "---------------------------------"
@@ -815,6 +821,12 @@ fi
 RC_LOCAL="$(airplanes_path /etc/rc.local)"
 MLAT_CLIENT_DEFAULT="$(airplanes_path /etc/default/mlat-client)"
 run_post_update_legacy_cleanup "$RC_LOCAL" "$MLAT_CLIENT_DEFAULT" "$LOGFILE"
+
+# Sweep the pre-FHS install layout (old /usr/local/share/airplanes payload +
+# /lib/systemd/system units) now that the new /opt layout is fully installed
+# and the feeder UUID has been migrated into /etc/airplanes/feeder-id. No-op
+# unless a pre-FHS install is actually present; /etc/airplanes is preserved.
+remove_pre_fhs_layout "$(airplanes_path /usr/local/share/airplanes)" "$(airplanes_path /lib/systemd/system)" "$LOGFILE"
 
 if [[ "$IMAGE_INSTALL" != "1" ]]; then
     finalize_legacy_feed_env_migration "$LEGACY_FEED_ENV" "$FEED_ENV"

--- a/update.sh
+++ b/update.sh
@@ -152,7 +152,16 @@ else
     }
 
     airplanes_image_feed_bin_default() {
-        printf '%s' "$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
+        local opt_bin legacy_bin
+        opt_bin="$(airplanes_path /opt/airplanes/current/bin/feed-airplanes)"
+        legacy_bin="$(airplanes_path /usr/bin/airplanes-feeder)"
+        if [[ -x "$opt_bin" ]]; then
+            printf '%s' "$opt_bin"
+        elif [[ -x "$legacy_bin" ]]; then
+            printf '%s' "$legacy_bin"
+        else
+            printf '%s' "$opt_bin"
+        fi
     }
 
     airplanes_image_target_default() {
@@ -599,7 +608,11 @@ fi
 mkdir -p "$BIN"
 install -m 0755 "$GIT/scripts/apl-feed.sh" "$BIN/apl-feed"
 mkdir -p "$LOCAL_BIN"
-ln -sfn "$BIN/apl-feed" "$LOCAL_BIN/apl-feed"
+# Relative symlink target (mirrors create-uuid.sh's compat symlink) so it
+# resolves both on-device (ROOT=/) and under AIRPLANES_ROOT (image build /
+# chroot). An absolute "$BIN/apl-feed" would bake the root-prefixed build path;
+# an absolute "/opt/..." would escape the rootfs during build.
+ln -sfn ../../../opt/airplanes/current/bin/apl-feed "$LOCAL_BIN/apl-feed"
 
 # Daemon user/group. Renamed from "airplanes" to avoid collision with what
 # users typically pick as their console/SSH login on a fresh image flash.


### PR DESCRIPTION
Moves the feeder's standalone install onto the FHS layout the image already uses: payload under `/opt/airplanes/current`, mutable state under `/var/lib/airplanes/runtime`, and systemd units under `/etc/systemd/system`, instead of the old `/usr/local/share/airplanes` tree, `/lib` units, and `/usr/bin` binary. The result is one install layout whether the feeder came from the image or a manual install.

Feeders on the previous layout are migrated automatically on their next update: the new layout is installed, the feeder UUID is carried into `/etc/airplanes/feeder-id`, and the old tree and units are removed. `/etc/airplanes` is never touched, so identity and configuration are preserved.
