### PR TITLE
Document why --max-range appears twice on image installs

### DIFF
--- a/scripts/airplanes-feed.sh
+++ b/scripts/airplanes-feed.sh
@@ -82,6 +82,12 @@ NET_OPTIONS="${NET_OPTIONS:-"--net-heartbeat 60 --net-ro-size 1280 --net-ro-inte
 
 if [[ "$IMAGE_INSTALL" == "1" ]]; then
     FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-"--net-ro-interval 0.2"}"
+    # --max-range 450 appears in BOTH this default and JSON_OPTIONS' default,
+    # so a new-image cmdline carries it twice (same value; readsb takes the
+    # last). The overlap is deliberate, not a dedupe target: legacy images
+    # ship their own JSON_OPTIONS via /boot/airplanes-env WITHOUT --max-range,
+    # so this copy is the only range cap there; standalone installs take the
+    # JSON_OPTIONS default instead (FEED_IMAGE_OPTIONS is empty for them).
     FEED_IMAGE_OPTIONS="${FEED_IMAGE_OPTIONS:-"--db-file=none --max-range 450"}"
 else
     FEED_NET_OPTIONS="${FEED_NET_OPTIONS:-$NET_OPTIONS}"


### PR DESCRIPTION
On a new-image feeder the daemon cmdline carries `--max-range 450` twice — once from `JSON_OPTIONS` and once from `FEED_IMAGE_OPTIONS` — which reads like a copy-paste bug. It is not: legacy images ship their own `JSON_OPTIONS` via `/boot/airplanes-env` without a range cap (so the `FEED_IMAGE_OPTIONS` copy is the only cap there), while standalone installs get it only from `JSON_OPTIONS`. readsb takes the last occurrence and both are the same value. Add a comment so the overlap does not get "cleaned up" and silently drop the cap for one population.