### PR TITLE
Clarify the MLAT name-privacy label in status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OK    Feeder ID            11111111-2222-3333-4444-555555555555
 OK    Claim secret         present
 OK    Website claim        registered, not yet claimed
 OK    Server reception     currently receiving (last data seen 1m ago)
-OK    MLAT service         running (name: public)
+OK    MLAT service         running (public name)
 OK    Diagnostics push     enabled (default), last push 4m ago
 
 Result: feeding looks healthy

--- a/scripts/apl-feed/status.sh
+++ b/scripts/apl-feed/status.sh
@@ -422,8 +422,8 @@ _mlat_privacy_suffix() {
         return 0
     fi
     case "$mlat_private" in
-        true)  printf ' (name: private)' ;;
-        false) printf ' (name: public)' ;;
+        true)  printf ' (private name)' ;;
+        false) printf ' (public name)' ;;
     esac
 }
 

--- a/test/test_apl_feed_status.bats
+++ b/test/test_apl_feed_status.bats
@@ -462,24 +462,24 @@ STUB
 # mlat_status_line when decision=enabled and active_state=active, so the
 # data-flow output stays compact (one line per concern).
 
-@test "mlat_status_line: enabled + active + mlat_private=true → 'running (name: private)'" {
+@test "mlat_status_line: enabled + active + mlat_private=true → 'running (private name)'" {
     write_mlat_state enabled ok true
     stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
     run mlat_status_line
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'running (name: private)'* ]]
+    [[ "$output" == *'running (private name)'* ]]
 }
 
-@test "mlat_status_line: enabled + active + mlat_private=false → 'running (name: public)'" {
+@test "mlat_status_line: enabled + active + mlat_private=false → 'running (public name)'" {
     write_mlat_state enabled ok false
     stub_systemctl_active_state active
     status_init
     STATUS_OUTPUT_JSON=0
     run mlat_status_line
     [[ "$output" == *'OK'* ]]
-    [[ "$output" == *'running (name: public)'* ]]
+    [[ "$output" == *'running (public name)'* ]]
 }
 
 @test "mlat_status_line: enabled + active + mlat_private missing → bare 'running' (no suffix)" {
@@ -490,7 +490,8 @@ STUB
     run mlat_status_line
     [[ "$output" == *'OK'* ]]
     [[ "$output" == *'running'* ]]
-    [[ "$output" != *'(name:'* ]]
+    [[ "$output" != *'(public name)'* ]]
+    [[ "$output" != *'(private name)'* ]]
 }
 
 @test "mlat_status_line: disabled + mlat_private=true → 'disabled by config' (no privacy suffix when disabled)" {
@@ -503,7 +504,8 @@ STUB
     run mlat_status_line
     [[ "$output" == *'OK'* ]]
     [[ "$output" == *'disabled by config (MLAT_ENABLED=false)'* ]]
-    [[ "$output" != *'(name:'* ]]
+    [[ "$output" != *'(public name)'* ]]
+    [[ "$output" != *'(private name)'* ]]
 }
 
 @test "mlat_status_line: enabled + activating + mlat_private=true → 'starting up' (no suffix mid-transition)" {
@@ -516,7 +518,8 @@ STUB
     run mlat_status_line
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'starting up (activating)'* ]]
-    [[ "$output" != *'(name:'* ]]
+    [[ "$output" != *'(public name)'* ]]
+    [[ "$output" != *'(private name)'* ]]
 }
 
 @test "mlat_status_line: enabled + active + unknown mlat_private value → 'running' + warn 'unknown value' (forward-compat)" {
@@ -531,7 +534,8 @@ STUB
     run mlat_status_line
     [[ "$output" == *'OK'* ]]
     [[ "$output" == *'running'* ]]
-    [[ "$output" != *'running (name:'* ]]
+    [[ "$output" != *'(public name)'* ]]
+    [[ "$output" != *'(private name)'* ]]
     [[ "$output" == *'CHECK'* ]]
     [[ "$output" == *'MLAT name privacy'* ]]
     [[ "$output" == *'unknown value: futureschema'* ]]


### PR DESCRIPTION
The MLAT service line in `apl-feed status` appended `(name: public)` / `(name: private)`, which reads as if the feeder's MLAT name were literally "public" or "private". The suffix actually reflects whether the name is shown publicly on the MLAT map. Reword it to `(public name)` / `(private name)` so the line reads naturally.